### PR TITLE
Include EDPM Ceph client files to the list of roles

### DIFF
--- a/edpm_ansible/roles/edpm_ceph_client_files/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_ceph_client_files/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of "edpm_ceph_client_files"
+edpm_ceph_client_files_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
+edpm_ceph_client_files_hide_sensitive_logs: true
+edpm_ceph_client_files_source: ""
+edpm_ceph_client_files_config_home: "{{ edpm_ceph_client_config_home | default('/var/lib/edpm-config/ceph/') }}"

--- a/edpm_ansible/roles/edpm_ceph_client_files/handlers/main.yml
+++ b/edpm_ansible/roles/edpm_ceph_client_files/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/edpm_ansible/roles/edpm_ceph_client_files/meta/main.yml
+++ b/edpm_ansible/roles/edpm_ceph_client_files/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_ceph_client_files
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.7
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 8
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/edpm_ansible/roles/edpm_ceph_client_files/molecule/default/converge.yml
+++ b/edpm_ansible/roles/edpm_ceph_client_files/molecule/default/converge.yml
@@ -1,0 +1,23 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "edpm_ceph_client_files"
+  vars:
+    edpm_ceph_client_files_source: "/home/stack/ceph_files/"

--- a/edpm_ansible/roles/edpm_ceph_client_files/molecule/default/molecule.yml
+++ b/edpm_ansible/roles/edpm_ceph_client_files/molecule/default/molecule.yml
@@ -1,0 +1,28 @@
+---
+driver:
+  name: podman
+
+provisioner:
+  inventory:
+    hosts:
+      all:
+        hosts:
+          centos:
+            ansible_python_interpreter: /usr/bin/python3
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml
+
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - verify
+    - destroy
+
+verifier:
+  name: testinfra

--- a/edpm_ansible/roles/edpm_ceph_client_files/molecule/default/prepare.yml
+++ b/edpm_ansible/roles/edpm_ceph_client_files/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+    - role: env_data

--- a/edpm_ansible/roles/edpm_ceph_client_files/tasks/main.yml
+++ b/edpm_ansible/roles/edpm_ceph_client_files/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Fail if edpm_ceph_client_files_source is missing
+  fail:
+    msg: >-
+      edpm_ceph_client_files_source must be set to a path that
+      already exists on the Ansible host which contains Ceph
+      configuration and Cephx key files.
+  when:
+    - edpm_ceph_client_files_source is not defined or
+      (edpm_ceph_client_files_source is defined and
+       edpm_ceph_client_files_source | length < 1)
+
+- name: Get list ceph files to copy from localhost edpm_ceph_client_files_source
+  delegate_to: localhost
+  become: true
+  set_fact:
+    edpm_ceph_client_dist: "{{ lookup('fileglob',
+                                  edpm_ceph_client_files_source ~ '/*',
+                                  wantlist=True) | list }}"
+
+- name: Ensure edpm_ceph_client_config_home exists on all hosts
+  file:
+    path: "{{ edpm_ceph_client_files_config_home }}"
+    state: directory
+  become: true
+
+- name: Push files from edpm_ceph_client_files_source to all hosts
+  become: true
+  copy:
+    src: "{{ item }}"
+    dest: "{{ edpm_ceph_client_files_config_home }}/{{ item | basename }}"
+    mode: "{{ '600' if item | regex_search('.*.keyring$') else '644' }}"
+  loop: "{{ edpm_ceph_client_dist }}"

--- a/edpm_ansible/roles/edpm_ceph_client_files/vars/main.yml
+++ b/edpm_ansible/roles/edpm_ceph_client_files/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "edpm_ceph_client_files"


### PR DESCRIPTION
This patch includes the `edpm_ceph_client_files` role to the list of the `edpm` roles.
It will be used to copy on the `external compute nodes` both `ceph.conf` and the
related `keyring`.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>