### PR TITLE
edpm_kernel: Remove HEAT_TEMPLATE from variable name

### DIFF
--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-adding/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-adding/test_vars.yml
@@ -1,4 +1,4 @@
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 "'
 _mocked_cmdline: ""
 edpm_kernel_args: "test=1"
 edpm_kernel_hugepages:

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-existing-kernelargs/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-existing-kernelargs/test_vars.yml
@@ -1,4 +1,4 @@
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 test3=4 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 hugepagesz=1048576 hugepages=12 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 test3=4 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 hugepagesz=1048576 hugepages=12 "'
 _mocked_cmdline: test=1 default_hugepagesz=1GB hugepagesz=1G hugepages=12 hugepagesz=4096 hugepages=5
 edpm_kernel_args: "test=1 default_hugepagesz=1GB hugepagesz=1G hugepages=12 hugepagesz=4096 hugepages=5 test3=4"
 edpm_kernel_hugepages:

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-idempotency-change/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-idempotency-change/test_vars.yml
@@ -1,4 +1,4 @@
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 default_hugepagesz=4096 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=12 hugepagesz=1048576 hugepages=12 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 default_hugepagesz=4096 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=12 hugepagesz=1048576 hugepages=12 "'
 _mocked_cmdline_original: test=1 default_hugepagesz=1GB hugepagesz=1G hugepages=12 hugepagesz=4096 hugepages=5
 _mocked_cmdline_updated: test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10
 edpm_kernel_args: "test=1"

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-idempotency-nochange/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-idempotency-nochange/test_vars.yml
@@ -1,4 +1,4 @@
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 hugepagesz=1048576 hugepages=12 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 hugepagesz=1048576 hugepages=12 "'
 _mocked_cmdline_original: test=1 default_hugepagesz=1GB hugepagesz=1G hugepages=12 hugepagesz=4096 hugepages=5
 _mocked_cmdline_updated: test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10
 edpm_kernel_args: "test=1"

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-integer/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-integer/test_vars.yml
@@ -1,4 +1,4 @@
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 hugepagesz=1048576 hugepages=12 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 hugepagesz=1048576 hugepages=12 "'
 _mocked_cmdline: test=1 default_hugepagesz=1GB hugepagesz=1G hugepages=12 hugepagesz=4096 hugepages=5
 edpm_kernel_args: "test=1"
 edpm_kernel_hugepages:

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-remove/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify-remove/test_vars.yml
@@ -1,5 +1,5 @@
 _mocked_cmdline: test=1 default_hugepagesz=1GB hugepagesz=1G hugepages=12 hugepagesz=4096 hugepages=5
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 "'
 edpm_kernel_args: "test=1"
 edpm_kernel_hugepages_remove: true
 edpm_kernel_hugepages:

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-modify/test_vars.yml
@@ -1,4 +1,4 @@
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 hugepagesz=1048576 hugepages=12 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 hugepagesz=1048576 hugepages=12 "'
 _mocked_cmdline: test=1 default_hugepagesz=1GB hugepagesz=1G hugepages=12 hugepagesz=4096 hugepages=5
 edpm_kernel_args: "test=1"
 edpm_kernel_hugepages:

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-nochange-remove/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-nochange-remove/test_vars.yml
@@ -1,4 +1,4 @@
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS="  default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS="  default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 "'
 _mocked_cmdline: default_hugepagesz=2M hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 hugepagesz=10240 hugepages=10
 edpm_kernel_hugepages_remove: true
 edpm_kernel_hugepages:

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-nochange/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-hugepages-nochange/test_vars.yml
@@ -1,5 +1,5 @@
 _mocked_cmdline: default_hugepagesz=2M hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 default_hugepagesz=2M hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 default_hugepagesz=2M hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 "'
 edpm_kernel_args: test=1 default_hugepagesz=2M hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10
 edpm_kernel_hugepages:
   "2048":

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-update/converge.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-update/converge.yml
@@ -26,14 +26,14 @@
     - name: create kernelargs entry with the older name
       lineinfile:
         dest: /etc/default/grub
-        regexp: '^EDPM_HEAT_TEMPLATE_KERNEL_ARGS.*'
+        regexp: '^EDPM_KERNEL_ARGS.*'
         insertafter: '^GRUB_CMDLINE_LINUX.*'
-        line: 'EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" {{ edpm_kernel_args }} "'
+        line: 'EDPM_KERNEL_ARGS=" {{ edpm_kernel_args }} "'
     - name: create append entry with older name
       lineinfile:
         dest: /etc/default/grub
-        line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${EDPM_HEAT_TEMPLATE_KERNEL_ARGS}"'
-        insertafter: '^EDPM_HEAT_TEMPLATE_KERNEL_ARGS.*'
+        line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${EDPM_KERNEL_ARGS}"'
+        insertafter: '^EDPM_KERNEL_ARGS.*'
     - include_role:
         name: "edpm_kernel"
         tasks_from: kernelargs.yml

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-update/verify.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs-update/verify.yml
@@ -23,7 +23,7 @@
     - name: Check if the kernel args is applied to the grub file
       lineinfile:
         path: /etc/default/grub
-        line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 "'
+        line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 "'
         state: present
       check_mode: true
       register: grub
@@ -31,7 +31,7 @@
     - name: Check if the older name entries are removed
       lineinfile:
         path: /etc/default/grub
-        regexp: '^EDPM_HEAT_TEMPLATE_KERNEL_ARGS.*'
+        regexp: '^EDPM_KERNEL_ARGS.*'
         state: absent
       check_mode: true
       register: grub
@@ -39,7 +39,7 @@
     - name: Check if the older name entries are removed for append
       lineinfile:
         path: /etc/default/grub
-        regexp: '.*{EDPM_HEAT_TEMPLATE_KERNEL_ARGS}.*'
+        regexp: '.*{EDPM_KERNEL_ARGS}.*'
         state: absent
       check_mode: true
       register: grub

--- a/edpm_ansible/roles/edpm_kernel/molecule/kernelargs/test_vars.yml
+++ b/edpm_ansible/roles/edpm_kernel/molecule/kernelargs/test_vars.yml
@@ -1,3 +1,3 @@
-expected_line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" test=1 "'
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 "'
 edpm_kernel_args: test=1
 _mocked_cmdline: ""

--- a/edpm_ansible/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/edpm_ansible/roles/edpm_kernel/tasks/kernelargs.yml
@@ -116,7 +116,7 @@
 
 - name: Check if the kernelargs entry is already present in the file
   replace:
-    regexp: EDPM_HEAT_TEMPLATE_KERNEL_ARGS
+    regexp: EDPM_KERNEL_ARGS
     dest: /etc/default/grub
     replace: ''
   check_mode: true
@@ -126,24 +126,24 @@
 - block:
     # Leapp does not recognise grun entries starting other than GRUB
     # It results wrong formatting of entries in file /etc/default/grub
-    # In order to fix it for FFU (queens to train), EDPM_HEAT_TEMPLATE_KERNEL_ARGS has been renamed
+    # In order to fix it for FFU (queens to train), EDPM_KERNEL_ARGS has been renamed
     # Ensure the fresh deployment is also alinged with the same name
-    - name: Delete older name EDPM_HEAT_TEMPLATE_KERNEL_ARGS entries if present
+    - name: Delete older name EDPM_KERNEL_ARGS entries if present
       lineinfile:
         dest: /etc/default/grub
-        regexp: 'EDPM_HEAT_TEMPLATE_KERNEL_ARGS'
+        regexp: 'EDPM_KERNEL_ARGS'
         state: absent
-    - name: Ensure the kernel args ( {{ edpm_kernel_args }} ) is present as GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS
+    - name: Ensure the kernel args ( {{ edpm_kernel_args }} ) is present as GRUB_EDPM_KERNEL_ARGS
       lineinfile:
         dest: /etc/default/grub
-        regexp: '^GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS.*'
+        regexp: '^GRUB_EDPM_KERNEL_ARGS.*'
         insertafter: '^GRUB_CMDLINE_LINUX.*'
-        line: 'GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS=" {{ edpm_kernel_args }} "'
-    - name: Add GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS to the GRUB_CMDLINE_LINUX parameter
+        line: 'GRUB_EDPM_KERNEL_ARGS=" {{ edpm_kernel_args }} "'
+    - name: Add GRUB_EDPM_KERNEL_ARGS to the GRUB_CMDLINE_LINUX parameter
       lineinfile:
         dest: /etc/default/grub
-        line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS}"'
-        insertafter: '^GRUB_EDPM_HEAT_TEMPLATE_KERNEL_ARGS.*'
+        line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${GRUB_EDPM_KERNEL_ARGS}"'
+        insertafter: '^GRUB_EDPM_KERNEL_ARGS.*'
     - name: Check grub config paths
       stat:
         path: "{{ item }}"

--- a/edpm_ansible/roles/edpm_kernel/tasks/upgrade_tasks.yml
+++ b/edpm_ansible/roles/edpm_kernel/tasks/upgrade_tasks.yml
@@ -17,10 +17,10 @@
 - name: fix grub entries to have name start with GRUB_
   replace:
     path: '/etc/default/grub'
-    regexp: '^(EDPM_HEAT_TEMPLATE_KERNEL_ARGS)(.*)'
+    regexp: '^(EDPM_KERNEL_ARGS)(.*)'
     replace: 'GRUB_\1\2'
 - name: fix grub entries in append statement
   replace:
     path: '/etc/default/grub'
-    regexp: '(.*){(EDPM_HEAT_TEMPLATE_KERNEL_ARGS)}(.*)'
+    regexp: '(.*){(EDPM_KERNEL_ARGS)}(.*)'
     replace: '\1{GRUB_\2}\3'


### PR DESCRIPTION
Because we no longer use heat, the current variable name no longer makes sense.