### PR TITLE
Adding minimal tox setup to keep style parity with tripleo-ansible

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,16 +14,5 @@ mock_roles:
     - ceph-facts
 mock_modules:
     - baremetal_nodes_validate
-    - ceph_crush_rule
-    - ceph_dashboard_user
-    - ceph_key
-    - ceph_fs
-    - ceph_pool
-    - ceph_mkspec
-    - ceph_spec_bootstrap
     - config_template
     - container_startup_config
-    - lvm2_physical_devices_facts
-    - metalsmith_instances
-    - os_baremetal_clean_node
-    - os_baremetal_provide_node

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -9,9 +9,7 @@ verbosity: 1
 # Mocking modules is not recommended as it prevents testing of invalid
 # arguments or lack of their presence at runtime. It is preffered to
 # make use of requirements.yml to declare them.
-mock_roles:
-    - ceph-defaults
-    - ceph-facts
+# mock_roles:
 mock_modules:
     - baremetal_nodes_validate
     - config_template

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -11,6 +11,5 @@ verbosity: 1
 # make use of requirements.yml to declare them.
 # mock_roles:
 mock_modules:
-    - baremetal_nodes_validate
     - config_template
     - container_startup_config

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,29 @@
+exclude_paths:
+    - releasenotes/
+    - ../
+parseable: true
+quiet: false
+rulesdir:
+    - .ansible-lint_rules/
+verbosity: 1
+# Mocking modules is not recommended as it prevents testing of invalid
+# arguments or lack of their presence at runtime. It is preffered to
+# make use of requirements.yml to declare them.
+mock_roles:
+    - ceph-defaults
+    - ceph-facts
+mock_modules:
+    - baremetal_nodes_validate
+    - ceph_crush_rule
+    - ceph_dashboard_user
+    - ceph_key
+    - ceph_fs
+    - ceph_pool
+    - ceph_mkspec
+    - ceph_spec_bootstrap
+    - config_template
+    - container_startup_config
+    - lvm2_physical_devices_facts
+    - metalsmith_instances
+    - os_baremetal_clean_node
+    - os_baremetal_provide_node

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+---
+extends: default
+
+rules:
+  line-length:
+    # matches hardcoded 160 value from ansible-lint
+    max: 160
+
+ignore: |
+  zuul.d/*.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pbr>=1.6
-tenacity>=8
+tenacity>=6.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,57 @@
+[tox]
+minversion = 4.0.0
+envlist = linters
+ignore_base_python_conflict = True
+
+[testenv]
+basepython = python3
+usedevelop = True
+passenv = *
+setenv =
+   ANSIBLE_SKIP_CONFLICT_CHECK=1
+   ANSIBLE_ACTION_PLUGINS={toxinidir}/edpm_ansible/roles.galaxy/config_template/action:{toxinidir}/edpm_ansible/ansible_plugins/action
+   ANSIBLE_CALLBACK_PLUGINS={toxinidir}/edpm_ansible/ansible_plugins/callback
+   ANSIBLE_FILTER_PLUGINS={toxinidir}/edpm_ansible/ansible_plugins/filter
+   ANSIBLE_LIBRARY={toxinidir}/edpm_ansible/roles.galaxy/config_template/library:{toxinidir}/edpm_ansible/ansible_plugins/modules
+   ANSIBLE_MODULE_UTILS={toxinidir}/edpm_ansible/ansible_plugins/module_utils
+   ANSIBLE_ROLES_PATH={toxinidir}/edpm_ansible/roles.galaxy:{toxinidir}/edpm_ansible/roles
+   ANSIBLE_INVENTORY={toxinidir}/tests/hosts.ini
+   ANSIBLE_NOCOWS=1
+   ANSIBLE_RETRY_FILES_ENABLED=0
+   ANSIBLE_STDOUT_CALLBACK=debug
+   ANSIBLE_LOG_PATH={envlogdir}/ansible-execution.log
+   VIRTUAL_ENV={envdir}
+   LC_ALL=en_US.UTF-8
+   # pip: Avoid 2020-01-01 warnings: https://github.com/pypa/pip/issues/6207
+   # paramiko CryptographyDeprecationWarning: https://github.com/ansible/ansible/issues/52598
+   PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command,ignore::UserWarning
+   PIP_DISABLE_PIP_VERSION_CHECK=1
+   TRIPLEO_ANSIBLE_COMPUTE_NODE_MOLECULE_CACHE={homedir}/.cache/edpm-ansible/containers
+   TRIPLEO_ANSIBLE_COMPUTE_NODE_MOLECULE_VOLUMES=['{homedir}/.cache/edpm-ansible/containers:/var/lib/containers:rw','/sys/fs/cgroup:/sys/fs/cgroup:rw']
+sitepackages = True
+deps =
+   -r {toxinidir}/requirements.txt
+   -r {toxinidir}/test-requirements.txt
+   -c {env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+commands =
+# ansible-core 2.13.6 installed with py38 does not provide a way to set
+# timeout with ansible-galaxy command.
+   ansible-galaxy install -fr {toxinidir}/edpm_ansible/requirements.yml
+   stestr run {posargs}
+allowlist_externals =
+   bash
+   tox
+   true
+   ansible-galaxy
+
+[testenv:linters]
+skip_install = True
+sitepackages = False
+deps =
+   pre-commit
+   virtualenv
+commands =
+   bash -c "ANSIBLE_ROLES_PATH='{toxinidir}/edpm_ansible/roles.galaxy' \
+          ansible-galaxy install -fr {toxinidir}/edpm_ansible/requirements.yml"
+   ansible-galaxy install -fr {toxinidir}/edpm_ansible/requirements.yml
+   python -m pre_commit run -a

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ sitepackages = True
 deps =
    -r {toxinidir}/requirements.txt
    -r {toxinidir}/test-requirements.txt
-   -c {env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+   -c {env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/zed}
 commands =
 # ansible-core 2.13.6 installed with py38 does not provide a way to set
 # timeout with ansible-galaxy command.


### PR DESCRIPTION
I've removed bulk of the tox configuration that wasn't directly involved in the style checking, while porting over files we need for linting ansible and yaml files.

I didn't include the documentation and release notes environments because it may be better to start from scratch there.

Openstack constraints file isn't compatible with required version of tenacity, so it's not being considered for now. 

Signed-off-by: Jiri Podivin <jpodivin@redhat.com>