### PR TITLE
Adding stub github actions

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -1,0 +1,14 @@
+name: Check pull request
+on:
+   pull_request:
+      types: [opened]
+jobs:
+   run_linters:
+      runs-on: ubuntu-22.04
+      steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install tox
+        run: pip install tox>=4.0
+      - name: Run tox linters
+        run: tox -e linters

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: "CodeQL"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '37 1 * * 6'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Some basic github actions for the repo. The CodeQL is derived from [openstack-ansibleee-operator](https://github.com/openstack-k8s-operators/openstack-ansibleee-operator/blob/main/.github/workflows/codeql.yml), while the check-pr relies on tox and pre-commit combination. 

Both are using ubuntu-22.04 nodes. 

Signed-off-by: Jiri Podivin <jpodivin@redhat.com>