### PR TITLE
Get rid of reference to /var/lib/config/puppet-generated

### DIFF
--- a/edpm_ansible/roles/edpm_kernel/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_kernel/defaults/main.yml
@@ -59,3 +59,6 @@ edpm_kernel_sysctl_extra_settings:
     value: 1
   fs.inotify.max_user_instances:
     value: 1024
+
+# This should be synced with edpm_nova_compute role
+edpm_nova_compute_config_dir: /var/lib/config-data/ansible-generated/nova_libvirt

--- a/edpm_ansible/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/edpm_ansible/roles/edpm_kernel/tasks/kernelargs.yml
@@ -24,7 +24,7 @@
   block:
     - name: Check if node has a nova.conf
       ansible.builtin.stat:
-        path: /var/lib/config-data/puppet-generated/nova_libvirt/etc/nova/nova.conf
+        path: "{{ edpm_nova_compute_config_dir }}/etc/nova/nova.conf"
       register: nova_conf_check
 
     - name: Enabling defer_reboot when TSX was added or appended

--- a/edpm_ansible/roles/edpm_ovn/files/neutron-cleanup
+++ b/edpm_ansible/roles/edpm_ovn/files/neutron-cleanup
@@ -2,14 +2,17 @@
 # Cleanup neutron OVS bridges. To be called on startup to avoid
 # "difficult-to-debug" issues with partially configured resources.
 
-for port in `ovs-vsctl list-ports ${INT_BRIDGE:-"br-int"}`; do
+$INT_BRIDGE=${INT_BRIDGE:-"br-int"}
+$TUN_BRIDGE=${TUN_BRIDGE:-"br-tun"}
+
+for port in `ovs-vsctl list-ports ${INT_BRIDGE}`; do
     skip_cleanup=`ovs-vsctl --if-exists get Interface $port external_ids:skip_cleanup`
     if ! [[ "x$skip_cleanup" == "x\"true\"" ]]; then
-        ovs-vsctl del-port ${INT_BRIDGE:-"br-int"} $port
+        ovs-vsctl del-port ${INT_BRIDGE} $port
     fi
 done
 
-ovs-vsctl --if-exists del-br ${TUN_BRIDGE:-"br-tun"}
+ovs-vsctl --if-exists del-br ${TUN_BRIDGE}
 
 # Clean up trunk port bridges
 for br in $(ovs-vsctl list-br | egrep 'tbr-[0-9a-f\-]+'); do

--- a/edpm_ansible/roles/edpm_ovn/files/neutron-cleanup
+++ b/edpm_ansible/roles/edpm_ovn/files/neutron-cleanup
@@ -2,13 +2,6 @@
 # Cleanup neutron OVS bridges. To be called on startup to avoid
 # "difficult-to-debug" issues with partially configured resources.
 
-NEUTRON_OVS_CONF=/var/lib/config-data/puppet-generated/neutron/etc/neutron/plugins/ml2/openvswitch_agent.ini
-
-if [ -e ${NEUTRON_OVS_CONF} ]; then
-    INT_BRIDGE=`crudini --get ${NEUTRON_OVS_CONF} ovs integration_bridge`
-    TUN_BRIDGE=`crudini --get ${NEUTRON_OVS_CONF} ovs tunnel_bridge`
-fi
-
 for port in `ovs-vsctl list-ports ${INT_BRIDGE:-"br-int"}`; do
     skip_cleanup=`ovs-vsctl --if-exists get Interface $port external_ids:skip_cleanup`
     if ! [[ "x$skip_cleanup" == "x\"true\"" ]]; then


### PR DESCRIPTION
The path was used in TripleO but it no longer makes sense because we'll not use puppet to generate config files.