### PR TITLE
Raising the bar on code compliance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,12 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-typing-imports==1.6.0]
-        entry: flake8 --ignore=E24,E121,E122,E123,E124,E126,E226,E265,E305,E402,F401,F405,E501,E704,F403,F841,W503
-        # TODO(cloudnull): These codes were added to pass the lint check.
-        #                  All of these ignore codes should be resolved in
-        #                  future PRs.
+        # List of ignored checks overrides the flake8 defaults.
+        # Changes to the list, especially extensions should be
+        # justified with relation to defaults.
+        # E501 - line is too long, would require local ignore or obfuscating changes
+        # W503 - line break before binary operator, ignored by default
+        entry: flake8 --ignore=E501,W503
   - repo: https://github.com/ansible-community/ansible-lint
     rev: v5.3.2
     hooks:

--- a/edpm_ansible/ansible_plugins/filter/helpers.py
+++ b/edpm_ansible/ansible_plugins/filter/helpers.py
@@ -16,10 +16,7 @@
 
 import ast
 import json
-import os
 import re
-
-from ansible import errors
 
 
 # cmp() doesn't exist on python3
@@ -68,7 +65,7 @@ class FilterModule(object):
                 continue
 
             # Don't delete containers NOT managed by edpm* or paunch*
-            elif not re.findall(r"(?=("+'|'.join(['edpm', 'paunch'])+r"))",
+            elif not re.findall(r"(?=(" + '|'.join(['edpm', 'paunch']) + r"))",
                                 managed_by):
                 to_skip += [c_name]
                 continue

--- a/edpm_ansible/ansible_plugins/modules/container_config_data.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_data.py
@@ -17,7 +17,6 @@
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.parsing.convert_bool import boolean
 
 import glob
 import json
@@ -129,7 +128,7 @@ class ContainerConfigDataManager(object):
 
             # Merge the config dict with given overrides
             self.results['configs'] = self._merge_with_overrides(
-                    config_dict, config_overrides)
+                config_dict, config_overrides)
         else:
             self.module.debug(
                 msg='{} does not exists, skipping step'.format(config_path))

--- a/edpm_ansible/ansible_plugins/modules/container_puppet_config.py
+++ b/edpm_ansible/ansible_plugins/modules/container_puppet_config.py
@@ -17,16 +17,12 @@
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.parsing.convert_bool import boolean
-from datetime import datetime
 
-import base64
 import copy
 import fnmatch
 import json
 import os
 import shutil
-import tempfile
 import yaml
 
 
@@ -444,7 +440,6 @@ class ContainerPuppetManager:
         :returns: string
         """
         hashfile = "%s.md5sum" % config_volume
-        hash_data = ''
         if self._exists(hashfile):
             return self._slurp(hashfile).strip('\n')
 

--- a/edpm_ansible/ansible_plugins/modules/edpm_container_image_prepare.py
+++ b/edpm_ansible/ansible_plugins/modules/edpm_container_image_prepare.py
@@ -18,13 +18,11 @@
 import copy
 import yaml
 import logging
-import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.openstack.cloud.plugins.module_utils.openstack import openstack_full_argument_spec
 from ansible_collections.openstack.cloud.plugins.module_utils.openstack import openstack_module_kwargs
 
-from edpm_common import constants
 from edpm_common.image import image_uploader
 from edpm_common.image import kolla_builder
 from edpm_common.utils.locks import processlock

--- a/edpm_ansible/ansible_plugins/modules/edpm_container_manage.py
+++ b/edpm_ansible/ansible_plugins/modules/edpm_container_manage.py
@@ -26,6 +26,8 @@ import json
 
 from concurrent.futures import ThreadPoolExecutor
 
+from ansible_collections.containers.podman.plugins.module_utils.podman.podman_container_lib import PodmanManager, ARGUMENTS_SPEC_CONTAINER  # noqa: F402
+
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
     'status': ['preview'],
@@ -90,9 +92,6 @@ EXAMPLES = """
     config_id: edpm_step1
     config_dir: /var/lib/edpm-config/container-startup-config/step_1
 """
-
-
-from ansible_collections.containers.podman.plugins.module_utils.podman.podman_container_lib import PodmanManager, ARGUMENTS_SPEC_CONTAINER  # noqa: F402
 
 
 class ExecFailure(Exception):

--- a/edpm_ansible/ansible_plugins/modules/edpm_os_net_config_mappings.py
+++ b/edpm_ansible/ansible_plugins/modules/edpm_os_net_config_mappings.py
@@ -166,5 +166,6 @@ def main():
     )
     run(module)
 
+
 if __name__ == '__main__':
     main()

--- a/edpm_ansible/ansible_plugins/strategy/edpm_base.py
+++ b/edpm_ansible/ansible_plugins/strategy/edpm_base.py
@@ -153,11 +153,10 @@ class EdpmBase(StrategyBase):
         """
         self._debug('process_includes...')
         include_files = IncludedFile.process_include_results(
-                host_results,
-                iterator=self._iterator,
-                loader=self._loader,
-                variable_manager=self._variable_manager
-        )
+            host_results,
+            iterator=self._iterator,
+            loader=self._loader,
+            variable_manager=self._variable_manager)
 
         include_success = True
         if len(include_files) == 0:

--- a/edpm_ansible/roles/edpm_nova_compute/files/tests/test_nova_statedir_ownership.py
+++ b/edpm_ansible/roles/edpm_nova_compute/files/tests/test_nova_statedir_ownership.py
@@ -257,17 +257,14 @@ def fake_testtree(testtree):
                                     side_effect=fake_stat) as fake_stat:
                         with mock.patch(
                                 'os.unlink',
-                                side_effect=fake_unlink
-                                ) as fake_unlink:
+                                side_effect=fake_unlink) as fake_unlink:
                             with mock.patch(
                                     'selinux.lgetfilecon',
                                     side_effect=fake_lgetfilecon,
-                                    return_value=[10, 'newcontext']
-                                    ) as fake_lgetfilecon:
+                                    return_value=[10, 'newcontext']) as fake_lgetfilecon:
                                 with mock.patch(
                                         'selinux.lsetfilecon',
-                                        side_effect=fake_lsetfilecon,
-                                        ) as fake_lsetfilecon:
+                                        side_effect=fake_lsetfilecon) as fake_lsetfilecon:
                                     yield (fake_chown,
                                            fake_exists,
                                            fake_listdir,
@@ -281,8 +278,7 @@ def assert_ids(testtree, path, uid, gid):
     statinfo = testtree[path]['stat']
     assert (uid, gid) == (statinfo.st_uid, statinfo.st_gid), \
         "{}: expected ownership {}:{} actual {}:{}".format(
-            path, uid, gid, statinfo.st_uid, statinfo.st_gid
-        )
+            path, uid, gid, statinfo.st_uid, statinfo.st_gid)
 
 
 class PathManagerCase(base.BaseTestCase):

--- a/edpm_ansible/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
+++ b/edpm_ansible/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
@@ -27,6 +27,6 @@ def test_ssh_host_keys(host):
     expected = [
         '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[centos]* ssh-rsa AAAATEST',
     ]
-    known_hosts = host.file("/etc/ssh/ssh_known_hosts").content_string
+
     for line in expected:
         assert line in host.file("/etc/ssh/ssh_known_hosts").content_string

--- a/edpm_ansible/roles/edpm_ssh_known_hosts/molecule/no_networks/tests/test_no_networks.py
+++ b/edpm_ansible/roles/edpm_ssh_known_hosts/molecule/no_networks/tests/test_no_networks.py
@@ -27,6 +27,6 @@ def test_ssh_host_keys(host):
     expected = [
         '[centos]* ssh-rsa AAAATEST',
     ]
-    known_hosts = host.file("/etc/ssh/ssh_known_hosts").content_string
+
     for line in expected:
         assert line in host.file("/etc/ssh/ssh_known_hosts").content_string

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 
 
-import os
-
-
 def pytest_addoption(parser):
     parser.addoption('--scenario', help='scenario setting')
     parser.addoption('--ansible-args', help='ansible args passed into test runner.')

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -14,7 +14,6 @@
 import os
 import subprocess
 
-import pytest
 import yaml
 
 


### PR DESCRIPTION
Most of the previously ignored style violations have been resolved. This includes unused imports and variables, as well as less intrusive style deficiencies.

Since we are starting essentially from scratch here I believe we should avoid perpetuating some of the issues that plagued our codebase before. Appropriate baseline is essential for this, as it prevents reintroduction of previously resolved problems. 

Any further code ported from tripleo-ansible will possibly require some changes to comply. But since it isn't going to be done in one go it should be manageable, while also offering an opportunity to look over some other cases inviting possible refactor. 

Signed-off-by: Jiri Podivin <jpodivin@redhat.com>