### PR TITLE
Expanding number of activities that trigger check,w harmonizing workf…

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -1,14 +1,17 @@
 name: Check pull request
 on:
-   pull_request:
-      types: [opened]
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
 jobs:
-   run_linters:
-      runs-on: ubuntu-22.04
-      steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Install tox
-        run: pip install tox>=4.0
-      - name: Run tox linters
-        run: tox -e linters
+  run_linters:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Install tox
+      run: pip install tox>=4.0
+    - name: Run tox linters
+      run: tox -e linters


### PR DESCRIPTION
…low file indentation

Opening, reopening or any change to commit included at the head of PR will now trigger a check job.
Technically this makes explicit the implicit defaults of the the pull request trigger [0].

Indentation of the workflow file was normalized to comply with best practices.

[0] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

Signed-off-by: Jiri Podivin <jpodivin@redhat.com>