### PR TITLE
tox: Remove unused environment variables for moulecule tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,6 @@ setenv =
    # paramiko CryptographyDeprecationWarning: https://github.com/ansible/ansible/issues/52598
    PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command,ignore::UserWarning
    PIP_DISABLE_PIP_VERSION_CHECK=1
-   TRIPLEO_ANSIBLE_COMPUTE_NODE_MOLECULE_CACHE={homedir}/.cache/edpm-ansible/containers
-   TRIPLEO_ANSIBLE_COMPUTE_NODE_MOLECULE_VOLUMES=['{homedir}/.cache/edpm-ansible/containers:/var/lib/containers:rw','/sys/fs/cgroup:/sys/fs/cgroup:rw']
 sitepackages = True
 deps =
    -r {toxinidir}/requirements.txt


### PR DESCRIPTION
These environment variables are not used because we have not yet imported the molecule tests. These should be added when we import the molecule tests with the modified name (not current one prefixed with TRIPLEO_).

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>