### PR TITLE
Stop creating /var/lib/heat-config

### DIFF
--- a/edpm_ansible/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/edpm_ansible/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -64,13 +64,6 @@
     - not 'Could not find the requested service' in openvswitch_service_start.msg|default('')
     - openvswitch_service_start is failed
 
-- name: Create /var/lib/heat-config/edpm-config-download directory for deployment data
-  become: true
-  ansible.builtin.file:
-    path: /var/lib/heat-config/edpm-config-download
-    state: directory
-    mode: 0755
-
 - name: Deploy and enable network service
   become: true
   when:


### PR DESCRIPTION
This directory was used in TripleO but should no longer be used in EDPM which does not use heat.