### PR TITLE
Remove remaining reference to puppet package

### DIFF
--- a/edpm_ansible/roles/edpm_bootstrap/molecule/default/tests/test_default.py
+++ b/edpm_ansible/roles/edpm_bootstrap/molecule/default/tests/test_default.py
@@ -23,10 +23,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_package_installed(host):
-    assert host.package("puppet-edpm").is_installed
-
-
 def test_iptables_exists(host):
     assert host.file("/etc/sysconfig/iptables").exists
     assert host.file("/etc/sysconfig/ip6tables").exists


### PR DESCRIPTION
This removes the leftover of the puppet package, which was missed in e5f38797e18ff5639692027e62549870921773f4 .