### PR TITLE
Trigger the container restart when configuration change

### DIFF
--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -169,8 +169,7 @@ class ContainerConfigHashManager:
             if os.path.isfile(file) and file_relpath not in exclusions:
                 total_hash.update(self._read_file(file))
 
-        h = total_hash.hexdigest()
-        return h
+        return total_hash.hexdigest()
 
     def _set_config_hash(self, config_volume, exclusions=[]):
         """Create a config hash for a config_volume.
@@ -178,8 +177,7 @@ class ContainerConfigHashManager:
         :param exclusions: list
         :returns: string
         """
-        hash = self._create_checksum(config_volume, exclusions)
-        return hash
+        return self._create_checksum(config_volume, exclusions)
 
     def _get_config_base(self, prefix, volume):
         """Returns a config base path for a specific volume.

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -241,7 +241,7 @@ class ContainerConfigHashManager:
                     exclude_from_hash = startup_config_json['environment'].get(
                         'EDPM_EXCLUDE_FROM_HASH', '').split(':')
                 new_hashes = [
-                    self._set_config_hash(vol_path,exclude_from_hash) for vol_path in config_volumes
+                    self._set_config_hash(vol_path, exclude_from_hash) for vol_path in config_volumes
                 ]
                 new_hash = '-'.join(new_hashes)
                 if new_hash != old_config_hash:

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -172,12 +172,13 @@ class ContainerConfigHashManager:
         h = total_hash.hexdigest()
         return h
 
-    def _set_config_hash(self, config_volume, exclude_from_hash):
+    def _set_config_hash(self, config_volume, exclusions=[]):
         """Create a config hash for a config_volume.
         :param config_volume: string
+        :param exclusions: list
         :returns: string
         """
-        hash = self._create_checksum(config_volume, exclude_from_hash)
+        hash = self._create_checksum(config_volume, exclusions)
         return hash
 
     def _get_config_base(self, prefix, volume):

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -229,7 +229,7 @@ class ContainerConfigHashManager:
                 old_config_hash = startup_config_json['environment'].get(
                     'EDPM_CONFIG_HASH', '')
                 exclude_from_hash = startup_config_json.get(
-                    'edpm_exclude_from_hash', [])
+                    'edpm_exclude_files_from_hash', [])
                 new_hashes = [
                     self._calculate_checksum(vol_path, exclude_from_hash) for vol_path in config_volumes
                 ]

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -155,7 +155,8 @@ class ContainerConfigHashManager:
         return r
 
     def _calculate_checksum(self, config_volume, exclusions=[]):
-        """Calculate an hash from a list of the given folder
+        """Calculate an md5 hash from a list of files from the given folder
+           and if needed exclude files from that list.
 
         :param config_volume: string
         :param exclusions: list

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -234,20 +234,14 @@ class ContainerConfigHashManager:
             startup_config_json = json.loads(self._slurp(config))
             config_volumes = self._match_config_volumes(startup_config_json)
             if config_volumes:
-                if 'environment' in startup_config_json:
-                    old_config_hash = startup_config_json['environment'].get(
-                        'EDPM_CONFIG_HASH', '')
-                    exclude_from_hash = startup_config_json['environment'].get(
-                        'EDPM_EXCLUDE_FROM_HASH', '').split(':')
+                old_config_hash = startup_config_json['edpm_config_hash'] or ''
+                exclude_from_hash = startup_config_json['edpm_exclude_from_hash'] or []
                 new_hashes = [
                     self._set_config_hash(vol_path, exclude_from_hash) for vol_path in config_volumes
                 ]
                 new_hash = '-'.join(new_hashes)
                 if new_hash != old_config_hash:
-                    if 'environment' not in startup_config_json:
-                        startup_config_json['environment'] = {}
-                    startup_config_json['environment']['EDPM_CONFIG_HASH'] = (
-                        new_hash)
+                    startup_config_json['edpm_config_hash'] = (new_hash)
                     self._update_container_config(
                         config, startup_config_json)
                 else:

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -154,9 +154,8 @@ class ContainerConfigHashManager:
                     break
         return r
 
-    def _create_checksum(self, config_volume, exclusions=[]):
-        """Create an hash from a tar-ed version of the given
-        folder
+    def _calculate_checksum(self, config_volume, exclusions=[]):
+        """Calculate an hash from a list of the given folder
 
         :param config_volume: string
         :param exclusions: list
@@ -170,14 +169,6 @@ class ContainerConfigHashManager:
                 total_hash.update(self._read_file(file))
 
         return total_hash.hexdigest()
-
-    def _set_config_hash(self, config_volume, exclusions=[]):
-        """Create a config hash for a config_volume.
-        :param config_volume: string
-        :param exclusions: list
-        :returns: string
-        """
-        return self._create_checksum(config_volume, exclusions)
 
     def _get_config_base(self, prefix, volume):
         """Returns a config base path for a specific volume.
@@ -234,10 +225,12 @@ class ContainerConfigHashManager:
             startup_config_json = json.loads(self._slurp(config))
             config_volumes = self._match_config_volumes(startup_config_json)
             if config_volumes:
-                old_config_hash = startup_config_json.get('edpm_config_hash', '')
-                exclude_from_hash = startup_config_json.get('edpm_exclude_from_hash', [])
+                old_config_hash = startup_config_json.get(
+                    'edpm_config_hash', '')
+                exclude_from_hash = startup_config_json.get(
+                    'edpm_exclude_from_hash', [])
                 new_hashes = [
-                    self._set_config_hash(vol_path, exclude_from_hash) for vol_path in config_volumes
+                    self._calculate_checksum(vol_path, exclude_from_hash) for vol_path in config_volumes
                 ]
                 new_hash = '-'.join(new_hashes)
                 if new_hash != old_config_hash:

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -19,11 +19,11 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule
 
 import fnmatch
+import glob
+import hashlib
 import json
 import os
 import yaml
-import glob
-import hashlib
 
 
 ANSIBLE_METADATA = {

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -225,8 +225,8 @@ class ContainerConfigHashManager:
             startup_config_json = json.loads(self._slurp(config))
             config_volumes = self._match_config_volumes(startup_config_json)
             if config_volumes:
-                old_config_hash = startup_config_json.get(
-                    'edpm_config_hash', '')
+                old_config_hash = startup_config_json['environment'].get(
+                    'EDPM_CONFIG_HASH', '')
                 exclude_from_hash = startup_config_json.get(
                     'edpm_exclude_from_hash', [])
                 new_hashes = [
@@ -234,7 +234,8 @@ class ContainerConfigHashManager:
                 ]
                 new_hash = '-'.join(new_hashes)
                 if new_hash != old_config_hash:
-                    startup_config_json['edpm_config_hash'] = (new_hash)
+                    startup_config_json['environment']['EDPM_CONFIG_HASH'] = (
+                        new_hash)
                     self._update_container_config(
                         config, startup_config_json)
                 else:

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -239,7 +239,7 @@ class ContainerConfigHashManager:
                     old_config_hash = startup_config_json['environment'].get(
                         'EDPM_CONFIG_HASH', '')
                     exclude_from_hash = startup_config_json['environment'].get(
-                        'EDPM_EXCLUDE_FROM_HASH', '')
+                        'EDPM_EXCLUDE_FROM_HASH', '').split(':')
                 new_hashes = [
                     self._set_config_hash(vol_path,exclude_from_hash) for vol_path in config_volumes
                 ]

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -66,6 +66,7 @@ EXAMPLES = """
 CONTAINER_STARTUP_CONFIG = '/var/lib/edpm-config/container-startup-config'
 BUF_SIZE = 65536
 
+
 class ContainerConfigHashManager:
     """Notes about this module.
 
@@ -170,27 +171,12 @@ class ContainerConfigHashManager:
         h = total_hash.hexdigest()
         return h
 
-    def _get_config_hash(self, config_volume):
-        """Returns a config hash from a config_volume.
-
-        :param config_volume: string
-        :returns: string
-        """
-        hashfile = "%s.md5sum" % config_volume
-        if os.path.exists(hashfile):
-            return self._slurp(hashfile).strip('\n')
-
     def _set_config_hash(self, config_volume):
         """Create a config hash for a config_volume.
         :param config_volume: string
         :returns: string
         """
         hash = self._create_checksum(config_volume)
-        hashfile = "%s.md5sum" % config_volume
-        with open(hashfile, 'w') as f:
-            f.write(hash)
-        os.chmod(hashfile, 0o600)
-
         return hash
 
     def _get_config_base(self, prefix, volume):
@@ -248,9 +234,6 @@ class ContainerConfigHashManager:
             startup_config_json = json.loads(self._slurp(config))
             config_volumes = self._match_config_volumes(startup_config_json)
             if config_volumes:
-                config_hashes = [
-                    self._get_config_hash(vol_path) for vol_path in config_volumes
-                ]
                 if 'environment' in startup_config_json:
                     old_config_hash = startup_config_json['environment'].get(
                         'EDPM_CONFIG_HASH', '')

--- a/edpm_ansible/ansible_plugins/modules/container_config_hash.py
+++ b/edpm_ansible/ansible_plugins/modules/container_config_hash.py
@@ -234,8 +234,8 @@ class ContainerConfigHashManager:
             startup_config_json = json.loads(self._slurp(config))
             config_volumes = self._match_config_volumes(startup_config_json)
             if config_volumes:
-                old_config_hash = startup_config_json['edpm_config_hash'] or ''
-                exclude_from_hash = startup_config_json['edpm_exclude_from_hash'] or []
+                old_config_hash = startup_config_json.get('edpm_config_hash', '')
+                exclude_from_hash = startup_config_json.get('edpm_exclude_from_hash', [])
                 new_hashes = [
                     self._set_config_hash(vol_path, exclude_from_hash) for vol_path in config_volumes
                 ]

--- a/edpm_ansible/roles/edpm_container_manage/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_container_manage/defaults/main.yml
@@ -21,7 +21,7 @@ edpm_container_manage_debug: "{{ ((ansible_verbosity | int) >= 2) | bool }}"
 edpm_container_manage_clean_orphans: true
 
 # All variables within this role should have a prefix of "edpm_container_manage"
-edpm_container_manage_update_config_hash: false
+edpm_container_manage_update_config_hash: true
 edpm_container_manage_cli: podman
 edpm_container_manage_concurrency: 1
 edpm_container_manage_config: "/var/lib/edpm-config/"

--- a/edpm_ansible/roles/edpm_container_manage/tasks/main.yml
+++ b/edpm_ansible/roles/edpm_container_manage/tasks/main.yml
@@ -63,6 +63,8 @@
   block:
     - name: "Update container configs with new config hashes"
       container_config_hash:
+      when:
+        - edpm_container_manage_update_config_hash|bool
     - name: "Delete orphan containers from {{ edpm_container_manage_config }}"
       ansible.builtin.include_tasks: delete_orphan.yml
       when:

--- a/edpm_ansible/roles/edpm_container_manage/tasks/main.yml
+++ b/edpm_ansible/roles/edpm_container_manage/tasks/main.yml
@@ -63,8 +63,6 @@
   block:
     - name: "Update container configs with new config hashes"
       container_config_hash:
-      when:
-        - edpm_container_manage_update_config_hash|bool
     - name: "Delete orphan containers from {{ edpm_container_manage_config }}"
       ansible.builtin.include_tasks: delete_orphan.yml
       when:


### PR DESCRIPTION
- added `_create_checksum` function in `container_config_hash` ansible module, to generate hashes for given folders of configuration files. This function was performed in a bash script called `container-puppet.sh`
- removed debug and step parameters from `container_config_hash` ansible module
- changed `edpm_container_manage_update_config_hash` boolean variable to true in edpm_container_manage role in order to enable hashes updates.