### PR TITLE
Consistent naming of bond_interface_ovs_options variable

### DIFF
--- a/edpm_ansible/roles/edpm_network_config/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_network_config/defaults/main.yml
@@ -32,3 +32,4 @@ edpm_network_config_safe_defaults: true
 edpm_network_config_with_ansible: true
 edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
 edpm_network_config_override: {}
+edpm_bond_interface_ovs_options: "bond_mode=active-backup"

--- a/edpm_ansible/roles/edpm_network_config/templates/2_linux_bonds_vlans/2_linux_bonds_vlans.j2
+++ b/edpm_ansible/roles/edpm_network_config/templates/2_linux_bonds_vlans/2_linux_bonds_vlans.j2
@@ -32,7 +32,7 @@ network_config:
   name: bond_api
   mtu: {{ min_viable_mtu_ctlplane }}
   use_dhcp: false
-  bonding_options: {{ bond_interface_ovs_options }}
+  bonding_options: {{ edpm_bond_interface_ovs_options }}
   dns_servers: {{ ctlplane_dns_nameservers }}
   domain: {{ dns_search_domains }}
   members:
@@ -59,7 +59,7 @@ network_config:
   - type: linux_bond
     name: bond-data
     mtu: {{ min_viable_mtu_dataplane }}
-    bonding_options: {{ bond_interface_ovs_options }}
+    bonding_options: {{ edpm_bond_interface_ovs_options }}
     members:
     - type: interface
       name: nic4

--- a/edpm_ansible/roles/edpm_network_config/templates/2_linux_bonds_vlans/2_linux_bonds_vlans_dpdk.j2
+++ b/edpm_ansible/roles/edpm_network_config/templates/2_linux_bonds_vlans/2_linux_bonds_vlans_dpdk.j2
@@ -21,7 +21,7 @@ network_config:
   name: bond_api
   mtu: {{ min_viable_mtu }}
   use_dhcp: false
-  bonding_options: {{ bond_interface_ovs_options }}
+  bonding_options: {{ edpm_bond_interface_ovs_options }}
   dns_servers: {{ ctlplane_dns_nameservers }}
   domain: {{ dns_search_domains }}
   members:

--- a/edpm_ansible/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans.j2
+++ b/edpm_ansible/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans.j2
@@ -20,7 +20,7 @@ network_config:
   - type: ovs_bond
     name: bond1
     mtu: {{ min_viable_mtu }}
-    ovs_options: {{ bond_interface_ovs_options }}
+    ovs_options: {{ edpm_bond_interface_ovs_options }}
     members:
     - type: interface
       name: nic2

--- a/edpm_ansible/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans_dpdk.j2
+++ b/edpm_ansible/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans_dpdk.j2
@@ -15,7 +15,7 @@ network_config:
 - type: linux_bond
   name: bond_api
   mtu: {{ min_viable_mtu }}
-  bonding_options: {{ bond_interface_ovs_options }}
+  bonding_options: {{ edpm_bond_interface_ovs_options }}
   use_dhcp: false
   dns_servers: {{ ctlplane_dns_nameservers }}
   members:

--- a/edpm_ansible/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans_storage.j2
+++ b/edpm_ansible/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans_storage.j2
@@ -20,7 +20,7 @@ network_config:
   - type: ovs_bond
     name: bond1
     mtu: {{ min_viable_mtu }}
-    ovs_options: {{ bond_interface_ovs_options }}
+    ovs_options: {{ edpm_bond_interface_ovs_options }}
     members:
     - type: interface
       name: nic2

--- a/edpm_ansible/roles/edpm_network_config/templates/bonds_vlans/controller_no_external.j2
+++ b/edpm_ansible/roles/edpm_network_config/templates/bonds_vlans/controller_no_external.j2
@@ -20,7 +20,7 @@ network_config:
   - type: ovs_bond
     name: bond1
     mtu: {{ min_viable_mtu }}
-    ovs_options: {{ bond_interface_ovs_options }}
+    ovs_options: {{ edpm_bond_interface_ovs_options }}
     members:
     - type: interface
       name: nic2

--- a/edpm_ansible/roles/edpm_network_config/templates/ci/public_bond.j2
+++ b/edpm_ansible/roles/edpm_network_config/templates/ci/public_bond.j2
@@ -21,7 +21,7 @@ network_config:
   members:
   - type: ovs_bond
     name: bond1
-    ovs_options: {{ bond_interface_ovs_options }}
+    ovs_options: {{ edpm_bond_interface_ovs_options }}
     members:
     - type: interface
       name: nic2

--- a/edpm_ansible/roles/edpm_network_config/templates/net_config_bond.j2
+++ b/edpm_ansible/roles/edpm_network_config/templates/net_config_bond.j2
@@ -9,7 +9,7 @@ network_config:
   - type: ovs_bond
     name: bond1
     use_dhcp: true
-    ovs_options: {{ bond_interface_ovs_options }}
+    ovs_options: {{ edpm_bond_interface_ovs_options }}
     members:
     - type: interface
       name: nic1


### PR DESCRIPTION
There is currently no default defined for bond_interface_ovs_options. This change adds a default for the option to avoid Ansible issues if the variable isn't defined. This default was determined using the defaults were using in TripleO.

Additionally, this change is also bringing the name of the variable in-line with the standard variable naming convention used in the module by pre-pending edpm_ to the start of the name.