### PR TITLE
Added timeout 120 to ansible-galaxy install command

### DIFF
--- a/openstack_ansibleee/Dockerfile
+++ b/openstack_ansibleee/Dockerfile
@@ -14,8 +14,8 @@ RUN if [ ! -d "/var/tmp/edpm-ansible" ] ; then \
 RUN cd /var/tmp/edpm-ansible && pip install -r requirements.txt
 # ansible-galaxy issue with PyOpenSSL https://github.com/ansible/awx/issues/12124
 RUN pip3 install 'pyOpenSSL<20.0.0' 'cryptography >35,<37'
-RUN cd /var/tmp/edpm-ansible && ansible-galaxy role install -r requirements.yml --roles-path "/usr/share/ansible/roles" && \
-    ansible-galaxy collection install -r requirements.yml --collections-path "/usr/share/ansible/collections"
+RUN cd /var/tmp/edpm-ansible && ansible-galaxy role install --timeout 120 -r requirements.yml --roles-path "/usr/share/ansible/roles" && \
+    ansible-galaxy collection install --timeout 120 -r requirements.yml --collections-path "/usr/share/ansible/collections"
 RUN cd /var/tmp/edpm-ansible && python3 setup.py install --prefix=/usr
 # When local repo of edpm-ansible is mounted as a volume, during podman build
 # It will give Device/Resource busy. In order to fix that. Clean up the directory


### PR DESCRIPTION
Currently while building openstack-ansible-runner image in Zuul CI, it got hit by following error
```
Unknown error when attempting to call Galaxy at
'https://gal\naxy.ansible.com/api/v2/collections/community/general/versions/?page_size=100
```

While looking over following issue
https://github.com/ansible/galaxy/issues/2302
adding timeout to 120 to ansible galaxy install seems to be one of the solution.

It will help to mitigate unwanted failure of the job.