### PR TITLE
Add support for /runner/env/cmdline

### DIFF
--- a/openstack_ansibleee/edpm_entrypoint.sh
+++ b/openstack_ansibleee/edpm_entrypoint.sh
@@ -14,4 +14,9 @@ if [ -n "$RUNNER_PLAYBOOK" ]; then
     echo "$RUNNER_PLAYBOOK" >> /runner/project/playbook.yaml
 fi
 
+if [ -n "$RUNNER_CMDLINE" ]; then
+    echo "---" > /runner/env/cmdline
+    echo "$RUNNER_CMDLINE" >> /runner/env/cmdline
+fi
+
 # Contents from ansible-runner entrypoint


### PR DESCRIPTION
The contents of the $RUNNER_CMDLINE env var will be written to
/runner/env/cmdline, which will be passed to the ansible execution. This
will allow further configuration of the execution to set things such as
--tags.

Signed-off-by: James Slagle <jslagle@redhat.com>
