### PR TITLE
Cmdline setting fix

### DIFF
--- a/openstack_ansibleee/edpm_entrypoint.sh
+++ b/openstack_ansibleee/edpm_entrypoint.sh
@@ -15,7 +15,6 @@ if [ -n "$RUNNER_PLAYBOOK" ]; then
 fi
 
 if [ -n "$RUNNER_CMDLINE" ]; then
-    echo "---" > /runner/env/cmdline
     echo "$RUNNER_CMDLINE" >> /runner/env/cmdline
 fi
 


### PR DESCRIPTION
/runner/env/cmdline is not a YAML file, therefore the leading "---" is
not needed.

Signed-off-by: James Slagle <jslagle@redhat.com>
