### PR TITLE
Add Makefile targets for building and pushing the ansible-runner image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 TEST_ENV_REPOSITORY := https://github.com/openstack-k8s-operators/ci-framework.git
+IMAGE_TAG_BASE ?= quay.io/openstack-k8s-operators/openstack-ansibleee-runner
+IMG ?= $(IMAGE_TAG_BASE):latest
 
 ifndef ENV_DIR
 override ENV_DIR := $(shell mktemp -d)
@@ -30,3 +32,11 @@ execute_molecule: ## Execute molecule tests
 
 .PHONY: execute_molecule_tests ## Setup the environment and execute molecule tests
 execute_molecule_tests: setup_test_environment execute_molecule
+
+.PHONY: openstack_ansibleee_build ## Build the openstack-ansibleee-runner image
+openstack_ansibleee_build:
+	podman build . -f openstack_ansibleee/Dockerfile -t ${IMG}
+
+.PHONY: openstack_ansibleee_push ## Push the openstack-ansibleee-runner image
+openstack_ansibleee_push:
+	podman push ${IMG}

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,29 @@ Note: the instruction ``execute_molecule`` has the
 tests in all the roles. In case we want to execute the tests just in
 modified roles we should delete it.
 
+Build and push the openstack-ansibleee-runner container image
+-------------------------------------------------------------
+
+In order to test a local change to edpm-ansible, the ansible-runner container
+image can be rebuilt and pushed to a container repository.
+
+To build the image:
+
+.. code:: bash
+
+    $ export IMG_BASE_TAG=quay.io/<user>/openstack-ansibleee-runner
+    $ make openstack_ansibleee_build
+
+To push the image:
+
+.. code:: bash
+
+    $ export IMG_BASE_TAG=quay.io/<user>/openstack-ansibleee-runner
+    $ make openstack_ansibleee_push
+
+Depending on the repository, a ``podman login quay.io/<user>`` may be required
+before pushing.
+
 License
 -------
 


### PR DESCRIPTION
A local change to edpm-ansible may need to be tested within a custom
openstack-ansibleee-runner image. Makefile targets are added to simplify
building and pushing the image.

Signed-off-by: James Slagle <jslagle@redhat.com>
