### PR TITLE
Reuse container images variable in EDPM role

### DIFF
--- a/edpm_ansible/roles/edpm_nova_libvirt/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_nova_libvirt/defaults/main.yml
@@ -23,7 +23,7 @@ edpm_nova_libvirt_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 edpm_nova_libvirt_deploy_identifier: "{{ edpm_deploy_identifier | default('') }}"
 edpm_nova_libvirt_hide_sensitive_logs: true
 edpm_nova_libvirt_container_image: "quay.io/tripleomastercentos9/openstack-nova-libvirt:current-tripleo"  # role specific
-edpm_nova_libvirt_container_config_image: "quay.io/tripleomastercentos9/openstack-nova-libvirt:current-tripleo"  # role specific
+edpm_nova_libvirt_container_config_image: "{{ edpm_nova_libvirt_container_image }}"  # role specific
 edpm_nova_libvirt_container_ulimit: ['nofile=131072', 'nproc=126960']
 edpm_nova_libvirt_container_pid: host
 edpm_nova_libvirt_container_pids_limit: 65536

--- a/edpm_ansible/roles/edpm_ovn/tasks/configure.yml
+++ b/edpm_ansible/roles/edpm_ovn/tasks/configure.yml
@@ -72,7 +72,7 @@
 
     - name: Run neutron_metadata_agent container
       ansible.builtin.shell: >
-          podman run --detach --name neutron_metadata_config quay.io/tripleomastercentos9/openstack-neutron-metadata-agent-ovn:current-tripleo sleep infinity
+          podman run --detach --name neutron_metadata_config {{ edpm_ovn_metadata_agent_image }} sleep infinity
       register: metadata_container_id
 
     - name: register_metadata_id


### PR DESCRIPTION
It modifies following roles to use existing container image variables:
- In edpm_nova_libvirt role
  - use edpm_nova_libvirt_container_image as edpm_nova_libvirt_container_config_image
- In edpm_ovn
  - use edpm_ovn_metadata_agent_image instead of hardcoding it.