### PR TITLE
Do not dump container definitions

### DIFF
--- a/edpm_ansible/roles/edpm_container_standalone/tasks/main.yml
+++ b/edpm_ansible/roles/edpm_container_standalone/tasks/main.yml
@@ -57,6 +57,9 @@
     content: "{{ item.value | to_nice_json }}"
     dest: "{{ edpm_container_standalone_container_startup_config_dir }}/{{ edpm_container_standalone_service }}/{{ item.key }}.json"
     mode: 0644
+  # NOTE(tkajinam): Some containers can contain secrets in their environments.
+  #                 Hide the output to avoid dumping these to output.
+  no_log: true
   loop: "{{ edpm_container_standalone_container_defs | dict2items }}"
 
 - name: Run {{ edpm_container_standalone_service }}  containers


### PR DESCRIPTION
Some containers might have credentials in their environments, and dumping the whole definition can reveal the secrets. This ensures the definition is not dumped in logs. Note that users can still review the generated files to review the data.