### PR TITLE
use stable/zed images by default

### DIFF
--- a/edpm_ansible/roles/edpm_iscsid/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_iscsid/defaults/main.yml
@@ -22,7 +22,7 @@ edpm_iscsid_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 
 edpm_iscsid_hide_sensitive_logs: true
 
-edpm_iscsid_image: "quay.io/tripleomastercentos9/openstack-iscsid:current-tripleo"
+edpm_iscsid_image: "quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo"
 edpm_iscsid_config_dir: /var/lib/config-data/ansible-generated/iscsid
 edpm_iscsid_volumes:
   - /var/lib/kolla/config_files/iscsid.json:/var/lib/kolla/config_files/config.json:ro

--- a/edpm_ansible/roles/edpm_logrotate_crond/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_logrotate_crond/defaults/main.yml
@@ -27,7 +27,7 @@ edpm_logrotate_crond_cronie_package: cronie
 # Pid namespace for podman container. Only change for testing.
 edpm_logrotate_crond_podman_pid: host
 
-edpm_logrotate_crond_image: "quay.io/tripleomastercentos9/openstack-cron:current-tripleo"
+edpm_logrotate_crond_image: "quay.io/tripleozedcentos9/openstack-cron:current-tripleo"
 edpm_logrotate_crond_config_use_ansible: true
 edpm_logrotate_crond_config_dir: /var/lib/config-data/ansible-generated/crond
 edpm_logrotate_crond_volumes:

--- a/edpm_ansible/roles/edpm_nova_compute/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_nova_compute/defaults/main.yml
@@ -21,7 +21,7 @@
 edpm_nova_compute_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 edpm_nova_compute_deploy_identifier: "{{ edpm_deploy_identifier | default('') }}"
 edpm_nova_compute_hide_sensitive_logs: true
-edpm_nova_compute_container_image: "quay.io/tripleomastercentos9/openstack-nova-compute:current-tripleo"  # role specific
+edpm_nova_compute_container_image: "quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo"  # role specific
 edpm_nova_compute_container_nova_libvirt_config_image: "{{ edpm_nova_libvirt_container_config_image | default(edpm_nova_compute_container_image) }}"
 edpm_nova_compute_docker_ulimit: ['nofile=131072', 'memlock=67108864']
 edpm_nova_compute_logging_source:

--- a/edpm_ansible/roles/edpm_nova_libvirt/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_nova_libvirt/defaults/main.yml
@@ -22,7 +22,7 @@ edpm_nova_libvirt_rootless_podman: false
 edpm_nova_libvirt_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 edpm_nova_libvirt_deploy_identifier: "{{ edpm_deploy_identifier | default('') }}"
 edpm_nova_libvirt_hide_sensitive_logs: true
-edpm_nova_libvirt_container_image: "quay.io/tripleomastercentos9/openstack-nova-libvirt:current-tripleo"  # role specific
+edpm_nova_libvirt_container_image: "quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo"  # role specific
 edpm_nova_libvirt_container_config_image: "{{ edpm_nova_libvirt_container_image }}"  # role specific
 edpm_nova_libvirt_container_ulimit: ['nofile=131072', 'nproc=126960']
 edpm_nova_libvirt_container_pid: host

--- a/edpm_ansible/roles/edpm_nova_libvirt/molecule/run_virtqemud/test_vars.yml
+++ b/edpm_ansible/roles/edpm_nova_libvirt/molecule/run_virtqemud/test_vars.yml
@@ -4,7 +4,7 @@
 config:
   - name: /var/lib/edpm-config/container-startup-config/nova_libvirt/nova_virtqemud.json
     expected_lines:
-      - '    "image": "quay.io/tripleomastercentos9/openstack-nova-libvirt:current-tripleo",'
+      - '    "image": "quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo",'
       - '        "nofile=131072",'
       - '        "nproc=126960"'
       - '    "pids_limit": 65536,'

--- a/edpm_ansible/roles/edpm_ovn/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_ovn/defaults/main.yml
@@ -15,8 +15,8 @@ edpm_ovn_sb_server_port: 6642
 edpm_ovn_of_probe_interval: 60
 edpm_ovn_remote_probe_interval: 60000
 edpm_ovn_ofctrl_wait_before_clear: 8000
-edpm_ovn_controller_agent_image: "quay.io/tripleomastercentos9/openstack-ovn-controller:current-tripleo"
-edpm_ovn_metadata_agent_image: "quay.io/tripleomastercentos9/openstack-neutron-metadata-agent-ovn:current-tripleo"
+edpm_ovn_controller_agent_image: "quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo"
+edpm_ovn_metadata_agent_image: "quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo"
 edpm_ovn_encap_ip: "{{ tenant_ip }}"
 edpm_ovn_protocol: "{% if edpm_enable_internal_tls | bool %}ssl{% else %}tcp{% endif %}"
 


### PR DESCRIPTION
This change updates the contianer images in the role defaults
to use stable/zed to align with the current images used in the
operators.

Closes: #68
