### PR TITLE
Removed containers-common downgrade workaround

### DIFF
--- a/zuul.d/playbooks/directories.yml
+++ b/zuul.d/playbooks/directories.yml
@@ -23,12 +23,3 @@
         dest: /opt/
         remote_src: true
         mode: "0777"
-
-  # (ralfieri): I commented this task because both bugs seem to be fixed.
-  # FIXME(chandankumar): Downgrade ontainers-common due to
-  # https://bugs.launchpad.net/tripleo/+bug/1988500 and
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2123611
-  # - name: Downgrade containers-common
-  #   ansible.builtin.shell: |
-  #     if [ -n "$(rpm -qa containers-common)" ];then dnf -y downgrade containers-common-1-40.el9; fi
-  #   become: true

--- a/zuul.d/playbooks/pre.yml
+++ b/zuul.d/playbooks/pre.yml
@@ -76,14 +76,6 @@
         - name: Reset ssh connection
           ansible.builtin.meta: reset_connection
   tasks:
-      # (ralfieri): I commented this task because both bugs seem to be fixed.
-      # FIXME(chandankumar): Downgrade ontainers-common due to
-      # https://bugs.launchpad.net/edpm/+bug/1988500 and
-      # https://bugzilla.redhat.com/show_bug.cgi?id=2123611
-    # - name: Downgrade containers-common
-    #   ansible.builtin.shell: |
-    #     if [ -n "$(rpm -qa containers-common)" ];then dnf -y downgrade containers-common-1-40.el9; fi
-    #   become: true
     - name: Get Ansible Galaxy roles
       ansible.builtin.command: >-
         {{ ansible_user_dir }}/test-python/bin/ansible-galaxy install --timeout 300


### PR DESCRIPTION
I had already commented those tasks in the past, but they can be safely removed since [this](https://review.opendev.org/c/openstack/tripleo-quickstart/+/877386) has been merged.