### PR TITLE
Add a growvols role and playbook

### DIFF
--- a/edpm_ansible/roles/edpm_growvols/defaults/main.yml
+++ b/edpm_ansible/roles/edpm_growvols/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+growvols_args: >
+  /=8GB
+  /tmp=1GB
+  /var/log=10GB
+  /var/log/audit=2GB
+  /home=1GB
+  /var=100%

--- a/edpm_ansible/roles/edpm_growvols/meta/main.yml
+++ b/edpm_ansible/roles/edpm_growvols/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2019 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  namespace: openstack
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_growvols
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.9'
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/edpm_ansible/roles/edpm_growvols/molecule/default/converge.yml
+++ b/edpm_ansible/roles/edpm_growvols/molecule/default/converge.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "edpm_growvols"

--- a/edpm_ansible/roles/edpm_growvols/molecule/default/molecule.yml
+++ b/edpm_ansible/roles/edpm_growvols/molecule/default/molecule.yml
@@ -1,0 +1,28 @@
+---
+driver:
+  name: podman
+
+provisioner:
+  inventory:
+    hosts:
+      all:
+        hosts:
+          centos:
+            ansible_python_interpreter: /usr/bin/python3
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml
+
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - verify
+    - destroy
+
+verifier:
+  name: testinfra

--- a/edpm_ansible/roles/edpm_growvols/molecule/default/prepare.yml
+++ b/edpm_ansible/roles/edpm_growvols/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+    - role: env_data

--- a/edpm_ansible/roles/edpm_growvols/tasks/main.yml
+++ b/edpm_ansible/roles/edpm_growvols/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2019 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Output growvols_args
+  ansible.builtin.debug:
+    var: growvols_args
+
+- name: Find the growvols utility
+  ansible.builtin.shell: >
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+    which growvols
+  failed_when: false
+  become: true
+  register: find_growvols
+
+- name: Run growvols block
+  when: find_growvols.rc == 0
+  block:
+    - name: Setting growvols path
+      ansible.builtin.set_fact:
+        growvols_path: "{{ find_growvols.stdout_lines[0] }}"
+
+    - name: "Running {{ growvols_path }} {{growvols_args}}"
+      ansible.builtin.shell: "{{ growvols_path }} --yes {{growvols_args}}"
+      become: true
+      register: run_growvols
+
+    - name: Output of growvols stdout
+      ansible.builtin.debug:
+        var: run_growvols.stdout

--- a/edpm_ansible/roles/edpm_growvols/vars/redhat.yml
+++ b/edpm_ansible/roles/edpm_growvols/vars/redhat.yml
@@ -1,0 +1,15 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
When the target host has the LVM based whole disk layout, running growvols will grow each volume by the amount specified in the growvols_args variable.

The intent is that this role is invoked by a playbook after deploy-edpm-facts.yml and before deploy-edpm-pre-network.yml. If the target host has the growvols script installed, it will be run, otherwise the role is a noop.