### PR TITLE
updated pre-commit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         files: .*\.(yaml|yml)$
         args: [--allow-multiple-documents]
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [flake8-typing-imports==1.6.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -15,7 +15,7 @@ repos:
         files: .*\.(yaml|yml)$
         args: [--allow-multiple-documents]
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.0
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-typing-imports==1.6.0]
@@ -26,14 +26,14 @@ repos:
         # W503 - line break before binary operator, ignored by default
         entry: flake8 --ignore=E501,W503
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v5.3.2
+    rev: v6.14.2
     hooks:
       - id: ansible-lint
         additional_dependencies:
-          - 'ansible-core<2.12'
+          - ansible-core
           - yamllint
   - repo: https://github.com/openstack-dev/bashate.git
-    rev: 2.0.0
+    rev: 2.1.1
     hooks:
       - id: bashate
         entry: bashate --error . --ignore=E006,E040


### PR DESCRIPTION
This PR aim to upgrade the `pre-commit` hooks since they were imported from the parent project and they were rather old.

* pre-commit from version 3.4.0 to 4.4.0
* flake8 from version 3.9.0 to version 5.0.4 (version 6.0.0 is failing with an error, see comments)
* ansible-lint from 5.3.2 to 6.14.2 (old version requires ansible < 2.12 and we're using ansible 2.14)
* bashate from version 2.0.0 to version 2.1.1
