### PR TITLE
Remove plan and edpm_stack_name 

### DIFF
--- a/roles/edpm_hosts_entries/molecule/default/molecule.yml
+++ b/roles/edpm_hosts_entries/molecule/default/molecule.yml
@@ -23,8 +23,6 @@ provisioner:
             - 172.17.0.1 centos.internalapi.localdomain centos.internalapi
           edpm_hosts_entries_undercloud_hosts_entries: []
           edpm_hosts_entries_extra_hosts_entries: []
-          edpm_stack_name: overcloud
-          plan: overcloud
         children:
           allovercloud:
             hosts:

--- a/roles/edpm_hosts_entries/tasks/main.yml
+++ b/roles/edpm_hosts_entries/tasks/main.yml
@@ -57,8 +57,8 @@
     insertbefore: BOF
     block: "{{ edpm_hosts_entries_block }}"
     marker: "# {mark}"
-    marker_begin: "START_HOST_ENTRIES_FOR_STACK: {{ edpm_stack_name | default(plan) }}"
-    marker_end: "END_HOST_ENTRIES_FOR_STACK: {{ edpm_stack_name | default(plan) }}"
+    marker_begin: START_HOST_ENTRIES_FOR_STACK
+    marker_end: END_HOST_ENTRIES_FOR_STACK
   register: edpm_hosts_entries_new_entries
   tags:
     - edpm_hosts_entries


### PR DESCRIPTION
```
TASK [osp.edpm.edpm_hosts_entries : Prepare new /etc/hosts] ********************
fatal: [edpm-compute-0]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'plan' is undefined. 'plan' is undefined\n\nThe error appears to be in '/usr/share/ansible/collections/ansible_collections/osp/edpm/roles/edpm_hosts_entries/tasks/main.yml': line 50, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Prepare new /etc/hosts\n  ^ here\n"}
```
https://github.com/openstack-k8s-operators/dataplane-operator/pull/116#discussion_r1145298940