### PR TITLE
Setting default verbosity of molecule tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ ifndef ENV_DIR
 override ENV_DIR := $(shell mktemp -d)/ci-framework
 endif
 
+TEST_VERBOSITY := '-vvv'
+
 .PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -29,6 +31,7 @@ execute_molecule: setup_test_environment ## Execute molecule tests
 				 -e HOME=/tmp \
 				 -e MOLECULE_CONFIG=.config/molecule/config_local.yml \
 				 -e TEST_ALL_ROLES=yes \
+				 -e TEST_VERBOSITY=$(TEST_VERBOSITY) \
 				 --user root \
 				 cifmw:latest bash -c "/opt/ci_framework/scripts/run_molecule \
 									/opt/edpm-ansible/roles/"


### PR DESCRIPTION
Verbosity of the molecule tests in ci-framwork has been opened[0] to external control.
With this patch we will take up the argument and set default verbosity to triple `v`.

[0]https://github.com/openstack-k8s-operators/ci-framework/pull/76