### PR TITLE
Removing obsolete settings from ansible-lint config

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,15 +1,10 @@
 exclude_paths:
-    - releasenotes/
     - ../
 parseable: true
 quiet: false
-rulesdir:
-    - .ansible-lint_rules/
 verbosity: 1
 # Mocking modules is not recommended as it prevents testing of invalid
 # arguments or lack of their presence at runtime. It is preffered to
 # make use of requirements.yml to declare them.
 # mock_roles:
-mock_modules:
-    - config_template
-    - container_startup_config
+# mock_modules:


### PR DESCRIPTION
Some of the directives for ansible lint are no longer necessary, as they were carried over from tripleo-ansible, and can be dropped. 