### PR TITLE
Default edpm_ceph_client_files_source to /etc/ceph

### DIFF
--- a/roles/edpm_ceph_client_files/defaults/main.yml
+++ b/roles/edpm_ceph_client_files/defaults/main.yml
@@ -20,5 +20,5 @@
 # All variables within this role should have a prefix of "edpm_ceph_client_files"
 edpm_ceph_client_files_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 edpm_ceph_client_files_hide_sensitive_logs: true
-edpm_ceph_client_files_source: ""
-edpm_ceph_client_files_config_home: "{{ edpm_ceph_client_config_home | default('/var/lib/edpm-config/ceph/') }}"
+edpm_ceph_client_files_source: '/etc/ceph'
+edpm_ceph_client_files_config_home: "{{ edpm_ceph_client_config_home | default('/etc/ceph/') }}"

--- a/roles/edpm_ceph_client_files/tasks/main.yml
+++ b/roles/edpm_ceph_client_files/tasks/main.yml
@@ -14,17 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Fail if edpm_ceph_client_files_source is missing
-  ansible.builtin.fail:
-    msg: >-
-      edpm_ceph_client_files_source must be set to a path that
-      already exists on the Ansible host which contains Ceph
-      configuration and Cephx key files.
-  when:
-    - edpm_ceph_client_files_source is not defined or
-      (edpm_ceph_client_files_source is defined and
-       edpm_ceph_client_files_source | length < 1)
-
 - name: Get list ceph files to copy from localhost edpm_ceph_client_files_source
   delegate_to: localhost
   become: true


### PR DESCRIPTION
Remove task to fail role if edpm_ceph_client_files_source is empty/undefined. Default edpm_ceph_client_files_source and edpm_ceph_client_files_config_home to /etc/ceph.

If edpm_ceph_client_files_source does not exist on Ansible host (e.g. stat returns "No such file or directory"), task will warn ("Unable to find '/etc/ceph' in expected paths") but not fail.

The dataplane-operator will invoke this role only when the extraMounts has an extraVolType of Ceph. In that case it is expected that /etc/ceph is mounted in the AEE pod as it is for other pods which use Ceph (e.g. Cinder or Glance). This role will then copy files in that directory to the EDPM node.

This change makes it easier for users since they don't need to override the variables edpm_ceph_client_files_config_home and edpm_ceph_client_files_source in the ansibleVars of the OpenStackDataPlane CR.