### PR TITLE
Clean dnf/yum cache

### DIFF
--- a/openstack_ansibleee/Dockerfile
+++ b/openstack_ansibleee/Dockerfile
@@ -4,7 +4,6 @@ ARG REMOTE_SOURCE=.
 ARG REMOTE_SOURCE_DIR=/var/tmp/edpm-ansible
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
-
 RUN cd /var/tmp/edpm-ansible && \
     ansible-galaxy collection install --timeout 120 -r requirements.yml --collections-path "/usr/share/ansible/collections" && \
     ansible-galaxy collection install $REMOTE_SOURCE_DIR --collections-path "/usr/share/ansible/collections"
@@ -13,7 +12,7 @@ FROM quay.io/ansible/creator-ee:v0.14.1 as runner
 
 COPY --from=builder /usr/share/ansible /usr/share/ansible
 
-RUN microdnf -y install python3-tenacity
+RUN microdnf -y install python3-tenacity && microdnf clean all
 
 COPY $REMOTE_SOURCE/openstack_ansibleee/settings /runner/env/settings
 RUN chmod 775 /runner/env/settings


### PR DESCRIPTION
This ensures dnf/yum cache are cleared after package installation, to minimize container image size.