### PR TITLE
edpm_ovn: external_ids ovn-chassis-mac-mappings

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -5,6 +5,9 @@ edpm_ovn_metadata_agent_config_dir: "/etc/neutron"
 edpm_ovn_metadata_agent_log_dir: "/var/log/neutron"
 edpm_ovn_bridge: br-int
 edpm_ovn_bridge_mappings: ["datacentre:br-ex"]
+edpm_ovn_chassis_mac_mapping_prefixes:
+  datacentre: "0e:01"
+edpm_ovn_chassis_mac_mapping_seed: "{{ ansible_machine_id }}"
 edpm_ovn_encap_type: geneve
 edpm_ovn_dbs: []
 edpm_enable_dvr: true
@@ -45,6 +48,12 @@ edpm_ovn_ovs_external_ids:
   hostname: "{{ ansible_facts['fqdn'] }}"
   ovn-bridge: "{{ edpm_ovn_bridge }}"
   ovn-bridge-mappings: "{{ edpm_ovn_bridge_mappings | join(', ') }}"
+  ovn-chassis-mac-mappings:
+    "{%- set chassis_mac_mappings = [] -%}
+     {%- for physnet, mac_prefix in edpm_ovn_chassis_mac_mapping_prefixes.items() -%}
+       {{ chassis_mac_mappings.append([physnet, mac_prefix | community.general.random_mac(seed=edpm_ovn_chassis_mac_mapping_seed)] | join(':')) }}
+     {%- endfor -%}
+     {{ chassis_mac_mappings | join(',') }}"
   ovn-encap-ip: "{{ edpm_ovn_encap_ip }}"
   ovn-encap-type: "{{ edpm_ovn_encap_type }}"
   ovn-match-northd-version: true


### PR DESCRIPTION
Added variables with default:
```
edpm_ovn_chassis_mac_mapping_prefixes:
    datacentre: "0e:01"  # {'physnet': 'mac_prefix'}
edpm_ovn_chassis_mac_mapping_seed: "{{ ansible_machine_id }}"
```
The `edpm_ovn_chassis_mac_mapping_seed` should be something machine specific - machine-id by default, but inventory_hostname, an IPv4 or IPv6 address fact etc can be used.

Example:
```
edpm_ovn_bridge_mappings:
    - "datacentre:br-ex"
    - "providernet:br-provider"
    - "baremetal:br-baremetal"
edpm_ovn_chassis_mac_mapping_prefixes:
    datacentre: "0e:01"
    providernet: "0e:02"
    baremetal: "0e:03"
```

When configuringing ovn generate a mac address using by combining the per-physnet MAC-prefix and a random generated MAC using the machine-id as the seed.