### PR TITLE
Run molecule tests locally in sequence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,7 @@ linters: ## Execute pre-commit linters
 .PHONY: html_docs
 html_docs: ## build HTML docs
 	docs/build-docs.sh
+
+.PHONY: execute_molecule_local
+execute_molecule_local: # Run molecule tests locally with installed molecule tool
+	./scripts/test_roles.py

--- a/scripts/test_roles.py
+++ b/scripts/test_roles.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import glob
+import subprocess as sp
+import os.path
+
+
+def main():
+    role_paths = glob.glob("./roles/*")
+    print(f"Found roles: {role_paths}")
+    results = {}
+
+    for role in role_paths:
+        print(f"Testing {os.path.basename(role)} ...")
+        process = sp.Popen(
+            "PY_COLORS=0 molecule test --all",
+            cwd=role, shell=True, stdout=sp.PIPE, stderr=sp.PIPE, text=True)
+        results[os.path.basename(role)] = {
+            'outputs': process.communicate(), 'process': process}
+
+    print("*" * 80)
+
+    for key, val in results.items():
+        test_passed = True
+        if 'CRITICAL' in val['outputs'][0] or val['outputs'][1] or val['process'].return_code != 0:
+            test_passed = False
+
+        print(f"{key} - Passed: {test_passed}")
+        if not test_passed:
+            print(f"STDOUT: {val['outputs'][0]}\nSTDERR: {val['outputs'][1]}")
+
+    print("*" * 80)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Tests for all roles can now be executed locally, using make target execute_molecule_local. The script picks up all roles in the dir, runs their respective molecule tests in sequence.

Local machine needs to have a molecule runtime properly installed.