### PR TITLE
Molecule test skeleton for edpm_chrony role

### DIFF
--- a/roles/edpm_chrony/molecule/default/Dockerfile.j2
+++ b/roles/edpm_chrony/molecule/default/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi9/ubi-init:latest
+
+RUN dnf upgrade -y && \
+    dnf -y install sudo python3-libselinux selinux-policy && \
+    dnf clean all -y
+
+CMD [ '/sbin/init' ]

--- a/roles/edpm_chrony/molecule/default/collections.yml
+++ b/roles/edpm_chrony/molecule/default/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - community.general

--- a/roles/edpm_chrony/molecule/default/converge.yml
+++ b/roles/edpm_chrony/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include edpm_chrony"
+      include_role:
+        name: "osp.edpm.edpm_chrony"

--- a/roles/edpm_chrony/molecule/default/destroy.yml
+++ b/roles/edpm_chrony/molecule/default/destroy.yml
@@ -1,0 +1,24 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    # Developer must implement.
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config
+      set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      copy:
+        content: |
+          # Molecule managed
+
+          {{ instance_conf | to_json | from_json | to_yaml }}
+        dest: "{{ molecule_instance_config }}"
+        mode: 0600
+      when: server.changed | default(false) | bool

--- a/roles/edpm_chrony/molecule/default/molecule.yml
+++ b/roles/edpm_chrony/molecule/default/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+    registry:
+      url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+    command: /sbin/init
+    dockerfile: Dockerfile.j2
+    privileged: true
+    ulimits: &ulimit
+      - host
+provisioner:
+  name: ansible
+  log: true
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/roles/edpm_chrony/molecule/default/prepare.yml
+++ b/roles/edpm_chrony/molecule/default/prepare.yml
@@ -1,0 +1,14 @@
+---
+- name: Prepare container
+  hosts: instance
+  roles:
+    - role: test_deps
+      test_deps_extra_packages:
+        - podman
+      test_deps_setup_edpm: true
+      test_deps_setup_stream: true
+    - role: env_data
+  tasks:
+    - name: Force systemd to reread configs
+      ansible.builtin.systemd:
+        daemon_reload: true


### PR DESCRIPTION
The converge playbook is failing due to the permissions issue. The issue was reported previously, and was resolved, in these cases, however it persist in our situation.

Furthermore, allowing our container access to system clock is not necessarily a good idea. Until the situation is resolved, this role will only possess minimum test configuration, with a view that it will be fixed at later date.