### PR TITLE
Removing the requirements.txt

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: ./docs/docs-requirements.txt
       - name: Build documentation
         run: |
           docs/build-docs.sh

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -7,7 +7,7 @@ DOCS_DIR="./docs"
 
 python -m venv ${TEMP_VENV_ENV} && source ${TEMP_VENV_ENV}/bin/activate
 
-pip install -r requirements.txt -r ${DOCS_DIR}/docs-requirements.txt
+pip install -r ${DOCS_DIR}/docs-requirements.txt
 ansible-galaxy install -r requirements.yml
 
 doc8 --config ${DOCS_DIR}/doc8.ini ${DOCS_DIR}/source


### PR DESCRIPTION
The file has been empty since tenacity removal in dc26e33a9a8004b7b1c3714027253e8b2b931908 If it is ever needed again we can create it again, but since this is not a standard python package we can continue without it.