### PR TITLE
Remove ansible-requirements.txt

### DIFF
--- a/ansible-requirements.txt
+++ b/ansible-requirements.txt
@@ -1,4 +1,0 @@
-ansible
-metalsmith>=1.4.0 # Apache-2.0
-importlib-metadata
-jsonschema  # MIT

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -29,5 +29,4 @@ build_ignore:
   - ".github"
   - ".venv"
   - "zuul.d"
-  - "ansible-requirements.txt"
   - "molecule-requirements.txt"

--- a/zuul.d/playbooks/pre.yml
+++ b/zuul.d/playbooks/pre.yml
@@ -38,8 +38,6 @@
         virtualenv: "{{ ansible_user_dir }}/test-python"
         virtualenv_command: "{{ ensure_pip_virtualenv_command }}"
         virtualenv_site_packages: true
-        extra_args: >-
-          --constraint "{{ edpm_ansible_project_path }}/ansible-requirements.txt"
 
     - name: Display test-python virtualenv package versions
       ansible.builtin.shell: |-


### PR DESCRIPTION
This file is not really a requirements file but a upper-constraints file but the current content does not define any constraints so can be removed.

We probably need this later when we pin ansible to a specific version but the file can be re-added at that time.