### PR TITLE
Update resync default value for the agent

### DIFF
--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -21,7 +21,7 @@
 
 edpm_ovn_bgp_agent_enable: true
 edpm_ovn_bgp_agent_debug: true
-edpm_ovn_bgp_agent_reconcile_interval: 120
+edpm_ovn_bgp_agent_reconcile_interval: 300
 edpm_ovn_bgp_agent_expose_tenant_networks: false
 edpm_ovn_bgp_agent_expose_ipv6_gua_tenant_networks: false
 edpm_ovn_bgp_agent_driver: ovn_bgp_driver


### PR DESCRIPTION
The default value has been increased at the agent [1]

[1] https://review.opendev.org/c/openstack/ovn-bgp-agent/+/881171
