### PR TITLE
molecule tests for edpm_ssh_knonw_hosts

### DIFF
--- a/roles/edpm_ssh_known_hosts/molecule/default/converge.yml
+++ b/roles/edpm_ssh_known_hosts/molecule/default/converge.yml
@@ -19,7 +19,9 @@
   hosts: all
   pre_tasks:
     - name: Override ssh_host_key_rsa_public test value in ansible_facts
-      set_fact:
+      ansible.builtin.set_fact:
         ansible_facts: "{{ ansible_facts|combine({'ssh_host_key_rsa_public': 'AAAATEST'}) }}"
-  roles:
-    - role: "edpm_ssh_known_hosts"
+  tasks:
+  - name: "Include edpm_ssh_known_hosts"
+    ansible.builtin.include_role:
+      name: "osp.edpm.edpm_ssh_known_hosts"

--- a/roles/edpm_ssh_known_hosts/molecule/default/molecule.yml
+++ b/roles/edpm_ssh_known_hosts/molecule/default/molecule.yml
@@ -1,19 +1,26 @@
 ---
 driver:
   name: podman
-
+platforms:
+  - name: instance
+    image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+    registry:
+      url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+    command: /sbin/init
+    dockerfile: ../../../../molecule/common/Containerfile.j2
+    privileged: true
 provisioner:
   name: ansible
   inventory:
     hosts:
       all:
         hosts:
-          centos:
+          instance:
             ansible_python_interpreter: /usr/bin/python3
         children:
           allovercloud:
             hosts:
-              centos:
+              instance:
                 ctlplane_ip: 10.0.0.1
                 ctlplane_hostname: centos.ctlplane.localdomain
                 internal_api_ip: 10.0.1.1
@@ -34,6 +41,7 @@ scenario:
     - check
     - verify
     - destroy
+
 
 verifier:
   name: testinfra

--- a/roles/edpm_ssh_known_hosts/molecule/default/prepare.yml
+++ b/roles/edpm_ssh_known_hosts/molecule/default/prepare.yml
@@ -14,11 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
-- name: Prepare
+- name: Prepare container
   hosts: all
   roles:
     - role: test_deps
+      test_deps_setup_edpm: true
       test_deps_extra_packages:
         - openssh
     - role: env_data

--- a/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
+++ b/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
@@ -25,7 +25,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ssh_host_keys(host):
     expected = [
-        '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[centos]* ssh-rsa AAAATEST',
+        '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[instance]* ssh-rsa AAAATEST',
     ]
 
     for line in expected:


### PR DESCRIPTION
Slight adjustment was made to the name of provisioned host, in order to align with other refactored tests.
#108 