### PR TITLE
Add edpm_growvols role to deploy_edpm_pre_network playbook

### DIFF
--- a/playbooks/deploy_edpm_os_install.yml
+++ b/playbooks/deploy_edpm_os_install.yml
@@ -21,23 +21,6 @@
   any_errors_fatal: true
   become: true
   tasks:
-    - name: Install edpm_bootstrap
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_bootstrap
-        tasks_from: bootstrap.yml
-      tags:
-        - edpm_bootstrap
-    - name: Install edpm_kernel
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_kernel
-      tags:
-        - edpm_kernel
-    - name: Install edpm_tuned
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_tuned
-        tasks_from: install.yml
-      tags:
-        - edpm_tuned
     - name: Install edpm_podman
       ansible.builtin.import_role:
         name: osp.edpm.edpm_podman

--- a/playbooks/deploy_edpm_pre_network.yml
+++ b/playbooks/deploy_edpm_pre_network.yml
@@ -21,7 +21,33 @@
   gather_facts: "{{ gather_facts | default(false) }}"
   any_errors_fatal: true
   tasks:
-
+    - name: Install edpm_bootstrap
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_bootstrap
+        tasks_from: bootstrap.yml
+      tags:
+        - edpm_bootstrap
+    - name: Grow volumes
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_growvols
+      tags:
+        - edpm_growvols
+    - name: Install edpm_kernel
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_kernel
+      tags:
+        - edpm_kernel
+    - name: Install edpm_tuned
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_tuned
+      tags:
+        - edpm_tuned
+    - name: Configure edpm_kernel
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_kernel
+        tasks_from: kernelargs.yml
+      tags:
+        - edpm_kernel
     - name: Configure Hosts Entries
       ansible.builtin.import_role:
         name: osp.edpm.edpm_hosts_entries


### PR DESCRIPTION
edpm_growvols has been added to pre_network playbook and also moves tripleo_kernel/tripeo_tuned tasks to pre_network as they need to be done before network configuration for NFV usecases.