### PR TITLE
Molecule tests for edpm_module_load role

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -24,6 +24,7 @@ jobs:
         - edpm_container_standalone
         - edpm_hosts_entries
         - edpm_logrotate_crond
+        - edpm_module_load
         - edpm_network_config
         - edpm_nftables
         - edpm_nodes_validation
@@ -54,6 +55,11 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
+    - name: apt-linux-headers
+      run: |
+        sudo apt-get update
+        sudo apt-get install build-essential linux-headers-$(uname -r) docker
+        sudo systemctl start docker
     - name: Install ansible
       run: pip install ansible
     - name: Install molecule deps

--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -10,6 +10,7 @@ pytest-xdist
 mock
 molecule>=3.3.4
 molecule-plugins[podman]
+molecule-plugins[docker]
 ruamel.yaml
 netaddr
 jinja2

--- a/roles/edpm_module_load/molecule/default/converge.yml
+++ b/roles/edpm_module_load/molecule/default/converge.yml
@@ -16,8 +16,11 @@
 
 
 - name: Converge
-  hosts: all
-  roles:
-    - role: "edpm_module_load"
-      edpm_modules:
+  hosts: instance
+  tasks:
+    - name: Use edpm_module_load to add module
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_module_load
+      vars:
+        modules:
         - name: dummy

--- a/roles/edpm_module_load/molecule/default/molecule.yml
+++ b/roles/edpm_module_load/molecule/default/molecule.yml
@@ -5,22 +5,30 @@ provisioner:
     defaults:
       fact_caching: jsonfile
       fact_caching_connection: /tmp/molecule/facts
-  inventory:
-    hosts:
-      all:
-        hosts:
-          instance:
-            ansible_host: localhost
   log: true
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
-
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+    registry:
+      url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+    command: /sbin/init
+    dockerfile: ../../../../molecule/common/Containerfile.j2
+    privileged: true
+    ulimits: &ulimit
+      - host
 scenario:
   test_sequence:
+    - destroy
+    - create
     - prepare
     - converge
     - check
+    - destroy
 
 verifier:
-  name: testinfra
+  name: ansible

--- a/roles/edpm_module_load/molecule/default/molecule.yml
+++ b/roles/edpm_module_load/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ provisioner:
     ANSIBLE_STDOUT_CALLBACK: yaml
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
 driver:
-  name: podman
+  name: docker
 platforms:
   - name: instance
     image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
@@ -18,9 +18,19 @@ platforms:
       url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
     command: /sbin/init
     dockerfile: ../../../../molecule/common/Containerfile.j2
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /lib/modules:/lib/modules:rw
+      - /proc:/proc:rw
+      - /etc/modules-load.d:/etc/modules-load:rw
+      - /var/log:/var/log:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /run:/run:rw
+      - /:/host:rw
     privileged: true
-    ulimits: &ulimit
-      - host
+    ipc: host
+    pid: host
+    user: root
 scenario:
   test_sequence:
     - destroy

--- a/roles/edpm_module_load/molecule/default/prepare.yml
+++ b/roles/edpm_module_load/molecule/default/prepare.yml
@@ -16,9 +16,25 @@
 
 
 - name: Prepare
-  hosts: all
+  hosts: instance
   roles:
     - role: test_deps
       test_deps_extra_packages:
         - kmod
     - role: env_data
+  tasks:
+    - name: Mock systemd-modules-load service
+      community.general.ini_file:
+        path: /usr/lib/systemd/system/systemd-modules-load.service
+        section: Service
+        option: "{{ item.option }}"
+        value: "{{ item.value | default(omit) }}"
+        state: "{{ item.state | default(omit) }}"
+      loop:
+        - { option: 'Type', value: 'oneshot' }
+        - { option: 'ExecStartPre', state: 'absent' }
+        - { option: 'ExecStart', value: '/bin/true' }
+
+    - name: Force systemd to reread configs
+      ansible.builtin.systemd:
+        daemon_reload: true

--- a/roles/edpm_module_load/molecule/default/prepare.yml
+++ b/roles/edpm_module_load/molecule/default/prepare.yml
@@ -38,3 +38,9 @@
     - name: Force systemd to reread configs
       ansible.builtin.systemd:
         daemon_reload: true
+    - name: Disable kernel lock
+      ansible.builtin.command:
+        cmd: |
+          echo 1 > /proc/sys/kernel/sysrq
+          echo x > /proc/sysrq-trigger
+      become: true

--- a/roles/edpm_module_load/molecule/legacy_vars/converge.yml
+++ b/roles/edpm_module_load/molecule/legacy_vars/converge.yml
@@ -16,8 +16,11 @@
 
 
 - name: Converge
-  hosts: all
-  roles:
-    - role: "edpm_module_load"
-      modules:
+  hosts: instance
+  tasks:
+    - name: Use edpm_module_load to add module
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_module_load
+      vars:
+        modules:
         - name: dummy

--- a/roles/edpm_module_load/molecule/legacy_vars/molecule.yml
+++ b/roles/edpm_module_load/molecule/legacy_vars/molecule.yml
@@ -9,7 +9,6 @@ provisioner:
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
-
 driver:
   name: podman
 platforms:
@@ -33,4 +32,4 @@ scenario:
     - destroy
 
 verifier:
-  name: testinfra
+  name: ansible

--- a/roles/edpm_module_load/molecule/legacy_vars/molecule.yml
+++ b/roles/edpm_module_load/molecule/legacy_vars/molecule.yml
@@ -10,7 +10,7 @@ provisioner:
     ANSIBLE_STDOUT_CALLBACK: yaml
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
 driver:
-  name: podman
+  name: docker
 platforms:
   - name: instance
     image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
@@ -18,9 +18,22 @@ platforms:
       url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
     command: /sbin/init
     dockerfile: ../../../../molecule/common/Containerfile.j2
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /lib/modules:/lib/modules:rw
+      - /proc:/proc:rw
+      - /etc/modules-load.d:/etc/modules-load:rw
+      - /var/log:/var/log:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /run:/run:rw
+      - /:/host:rw
     privileged: true
-    ulimits: &ulimit
-      - host
+    ipc: host
+    pid: host
+    user: root
 scenario:
   name: legacy_vars
   test_sequence:

--- a/roles/edpm_module_load/molecule/legacy_vars/molecule.yml
+++ b/roles/edpm_module_load/molecule/legacy_vars/molecule.yml
@@ -5,22 +5,32 @@ provisioner:
     defaults:
       fact_caching: jsonfile
       fact_caching_connection: /tmp/molecule/facts
-  inventory:
-    hosts:
-      all:
-        hosts:
-          instance:
-            ansible_host: localhost
   log: true
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
 
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+    registry:
+      url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+    command: /sbin/init
+    dockerfile: ../../../../molecule/common/Containerfile.j2
+    privileged: true
+    ulimits: &ulimit
+      - host
 scenario:
+  name: legacy_vars
   test_sequence:
+    - destroy
+    - create
     - prepare
     - converge
     - check
+    - destroy
 
 verifier:
   name: testinfra

--- a/roles/edpm_module_load/molecule/legacy_vars/prepare.yml
+++ b/roles/edpm_module_load/molecule/legacy_vars/prepare.yml
@@ -16,9 +16,25 @@
 
 
 - name: Prepare
-  hosts: all
+  hosts: instance
   roles:
     - role: test_deps
       test_deps_extra_packages:
         - kmod
     - role: env_data
+  tasks:
+    - name: Mock systemd-modules-load service
+      community.general.ini_file:
+        path: /usr/lib/systemd/system/systemd-modules-load.service
+        section: Service
+        option: "{{ item.option }}"
+        value: "{{ item.value | default(omit) }}"
+        state: "{{ item.state | default(omit) }}"
+      loop:
+        - { option: 'Type', value: 'oneshot' }
+        - { option: 'ExecStartPre', state: 'absent' }
+        - { option: 'ExecStart', value: '/bin/true' }
+
+    - name: Force systemd to reread configs
+      ansible.builtin.systemd:
+        daemon_reload: true

--- a/roles/edpm_module_load/molecule/legacy_vars/prepare.yml
+++ b/roles/edpm_module_load/molecule/legacy_vars/prepare.yml
@@ -38,3 +38,9 @@
     - name: Force systemd to reread configs
       ansible.builtin.systemd:
         daemon_reload: true
+    - name: Disable kernel lock
+      ansible.builtin.command:
+        cmd: |
+          echo 1 > /proc/sys/kernel/sysrq
+          echo x > /proc/sysrq-trigger
+      become: true

--- a/roles/edpm_module_load/molecule/remove_module/converge.yml
+++ b/roles/edpm_module_load/molecule/remove_module/converge.yml
@@ -16,12 +16,18 @@
 
 
 - name: Converge
-  hosts: all
-  roles:
-    - role: "edpm_module_load"
-      edpm_modules:
+  hosts: instance
+  tasks:
+    - name: Use edpm_module_load to add module
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_module_load
+      vars:
+        modules:
         - name: dummy
-    - role: "edpm_module_load"
-      edpm_modules:
+    - name: Use edpm_module_load to remove module
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_module_load
+      vars:
+        modules:
         - name: dummy
           state: absent

--- a/roles/edpm_module_load/molecule/remove_module/molecule.yml
+++ b/roles/edpm_module_load/molecule/remove_module/molecule.yml
@@ -9,7 +9,6 @@ provisioner:
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
-
 driver:
   name: podman
 platforms:
@@ -33,4 +32,4 @@ scenario:
     - destroy
 
 verifier:
-  name: testinfra
+  name: ansible

--- a/roles/edpm_module_load/molecule/remove_module/molecule.yml
+++ b/roles/edpm_module_load/molecule/remove_module/molecule.yml
@@ -10,7 +10,7 @@ provisioner:
     ANSIBLE_STDOUT_CALLBACK: yaml
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
 driver:
-  name: podman
+  name: docker
 platforms:
   - name: instance
     image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
@@ -18,9 +18,22 @@ platforms:
       url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
     command: /sbin/init
     dockerfile: ../../../../molecule/common/Containerfile.j2
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /lib/modules:/lib/modules:rw
+      - /proc:/proc:rw
+      - /etc/modules-load.d:/etc/modules-load:rw
+      - /var/log:/var/log:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /run:/run:rw
+      - /:/host:rw
     privileged: true
-    ulimits: &ulimit
-      - host
+    ipc: host
+    pid: host
+    user: root
 scenario:
   name: remove_module
   test_sequence:

--- a/roles/edpm_module_load/molecule/remove_module/molecule.yml
+++ b/roles/edpm_module_load/molecule/remove_module/molecule.yml
@@ -5,23 +5,32 @@ provisioner:
     defaults:
       fact_caching: jsonfile
       fact_caching_connection: /tmp/molecule/facts
-  inventory:
-    hosts:
-      all:
-        hosts:
-          instance:
-            ansible_host: localhost
   log: true
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
 
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+    registry:
+      url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+    command: /sbin/init
+    dockerfile: ../../../../molecule/common/Containerfile.j2
+    privileged: true
+    ulimits: &ulimit
+      - host
 scenario:
   name: remove_module
   test_sequence:
+    - destroy
+    - create
     - prepare
     - converge
     - check
+    - destroy
 
 verifier:
   name: testinfra

--- a/roles/edpm_module_load/molecule/remove_module/prepare.yml
+++ b/roles/edpm_module_load/molecule/remove_module/prepare.yml
@@ -16,9 +16,25 @@
 
 
 - name: Prepare
-  hosts: all
+  hosts: instance
   roles:
     - role: test_deps
       test_deps_extra_packages:
         - kmod
     - role: env_data
+  tasks:
+    - name: Mock systemd-modules-load service
+      community.general.ini_file:
+        path: /usr/lib/systemd/system/systemd-modules-load.service
+        section: Service
+        option: "{{ item.option }}"
+        value: "{{ item.value | default(omit) }}"
+        state: "{{ item.state | default(omit) }}"
+      loop:
+        - { option: 'Type', value: 'exec' }
+        - { option: 'ExecStartPre', state: 'absent' }
+        - { option: 'ExecStart', value: '/bin/true' }
+
+    - name: Force systemd to reread configs
+      ansible.builtin.systemd:
+        daemon_reload: true

--- a/roles/edpm_module_load/molecule/remove_module/prepare.yml
+++ b/roles/edpm_module_load/molecule/remove_module/prepare.yml
@@ -38,3 +38,9 @@
     - name: Force systemd to reread configs
       ansible.builtin.systemd:
         daemon_reload: true
+    - name: Disable kernel lock
+      ansible.builtin.command:
+        cmd: |
+          echo 1 > /proc/sys/kernel/sysrq
+          echo x > /proc/sysrq-trigger
+      become: true


### PR DESCRIPTION
Tests work apart from the `remove_module` scenario, which is failing on the removal step.