### PR TITLE
Removing unnecessary step in the venv script

### DIFF
--- a/scripts/molecule_venv.sh
+++ b/scripts/molecule_venv.sh
@@ -3,6 +3,5 @@ LOCAL_MOLECULE_ENV=$(mktemp -d)/molecule
 python -m venv $LOCAL_MOLECULE_ENV
 source $LOCAL_MOLECULE_ENV/bin/activate
 pip install -r molecule-requirements.txt
-pip install molecule
 ./scripts/test_roles.py
 deactivate


### PR DESCRIPTION
Molecule doesn't have to be installed separately, because it already is listed in the 'molecule-requirements.txt' file.