### PR TITLE
fixing no_networks scenario of edpm_ssh_known_hosts

### DIFF
--- a/roles/edpm_ssh_known_hosts/molecule/no_networks/molecule.yml
+++ b/roles/edpm_ssh_known_hosts/molecule/no_networks/molecule.yml
@@ -1,19 +1,28 @@
 ---
 driver:
   name: podman
-
+platforms:
+  - name: instance
+    image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+    registry:
+      url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+    command: /sbin/init
+    dockerfile: ../../../../molecule/common/Containerfile.j2
+    privileged: true
+    ulimits: &ulimit
+      - host
 provisioner:
   name: ansible
   inventory:
     hosts:
       all:
         hosts:
-          centos:
+          instance:
             ansible_python_interpreter: /usr/bin/python3
         children:
           allovercloud:
             hosts:
-              centos:
+              instance:
   log: true
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/edpm_ssh_known_hosts/molecule/no_networks/tests/test_no_networks.py
+++ b/roles/edpm_ssh_known_hosts/molecule/no_networks/tests/test_no_networks.py
@@ -25,7 +25,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ssh_host_keys(host):
     expected = [
-        '[centos]* ssh-rsa AAAATEST',
+        '[instance]* ssh-rsa AAAATEST',
     ]
 
     for line in expected:


### PR DESCRIPTION
Provisioned host now has the same name in both scenarios. Tests were adjusted accordingly.