### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -17,7 +17,6 @@ jmespath
 ansible-core
 
 # Upstream requirements from constraints.txt
-tripleo-common
 os-net-config  # Apache-2.0
 # Allows to unpin cryptography
 pyOpenSSL>=22.1.0

--- a/roles/edpm_iscsid/defaults/main.yml
+++ b/roles/edpm_iscsid/defaults/main.yml
@@ -22,7 +22,7 @@ edpm_iscsid_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 
 edpm_iscsid_hide_sensitive_logs: true
 
-edpm_iscsid_image: "quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo"
+edpm_iscsid_image: "quay.io/podified-antelope-centos9/openstack-iscsid:current-podified"
 edpm_iscsid_config_dir: /var/lib/config-data/ansible-generated/iscsid
 edpm_iscsid_volumes:
   - /var/lib/kolla/config_files/iscsid.json:/var/lib/kolla/config_files/config.json:ro

--- a/roles/edpm_logrotate_crond/defaults/main.yml
+++ b/roles/edpm_logrotate_crond/defaults/main.yml
@@ -27,7 +27,7 @@ edpm_logrotate_crond_cronie_package: cronie
 # Pid namespace for podman container. Only change for testing.
 edpm_logrotate_crond_podman_pid: host
 
-edpm_logrotate_crond_image: "quay.io/tripleozedcentos9/openstack-cron:current-tripleo"
+edpm_logrotate_crond_image: "quay.io/podified-antelope-centos9/openstack-cron:current-podified"
 edpm_logrotate_crond_config_use_ansible: true
 edpm_logrotate_crond_config_dir: /var/lib/config-data/ansible-generated/crond
 edpm_logrotate_crond_volumes:

--- a/roles/edpm_nova_compute/defaults/main.yml
+++ b/roles/edpm_nova_compute/defaults/main.yml
@@ -21,7 +21,7 @@
 edpm_nova_compute_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 edpm_nova_compute_deploy_identifier: "{{ edpm_deploy_identifier | default('') }}"
 edpm_nova_compute_hide_sensitive_logs: true
-edpm_nova_compute_container_image: "quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo"  # role specific
+edpm_nova_compute_container_image: "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"  # role specific
 edpm_nova_compute_container_nova_libvirt_config_image: "{{ edpm_nova_libvirt_container_config_image | default(edpm_nova_compute_container_image) }}"
 edpm_nova_compute_docker_ulimit: ['nofile=131072', 'memlock=67108864']
 edpm_nova_compute_logging_source:

--- a/roles/edpm_nova_libvirt/defaults/main.yml
+++ b/roles/edpm_nova_libvirt/defaults/main.yml
@@ -22,7 +22,7 @@ edpm_nova_libvirt_rootless_podman: false
 edpm_nova_libvirt_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 edpm_nova_libvirt_deploy_identifier: "{{ edpm_deploy_identifier | default('') }}"
 edpm_nova_libvirt_hide_sensitive_logs: true
-edpm_nova_libvirt_container_image: "quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo"  # role specific
+edpm_nova_libvirt_container_image: "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified"  # role specific
 edpm_nova_libvirt_container_config_image: "{{ edpm_nova_libvirt_container_image }}"  # role specific
 edpm_nova_libvirt_container_ulimit: ['nofile=131072', 'nproc=126960']
 edpm_nova_libvirt_container_pid: host

--- a/roles/edpm_nova_libvirt/molecule/run_virtqemud/test_vars.yml
+++ b/roles/edpm_nova_libvirt/molecule/run_virtqemud/test_vars.yml
@@ -4,7 +4,7 @@
 config:
   - name: /var/lib/edpm-config/container-startup-config/nova_libvirt/nova_virtqemud.json
     expected_lines:
-      - '    "image": "quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo",'
+      - '    "image": "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified",'
       - '        "nofile=131072",'
       - '        "nproc=126960"'
       - '    "pids_limit": 65536,'

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -18,8 +18,8 @@ edpm_ovn_sb_server_port: 6642
 edpm_ovn_of_probe_interval: 60
 edpm_ovn_remote_probe_interval: 60000
 edpm_ovn_ofctrl_wait_before_clear: 8000
-edpm_ovn_controller_agent_image: "quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo"
-edpm_ovn_metadata_agent_image: "quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo"
+edpm_ovn_controller_agent_image: "quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified"
+edpm_ovn_metadata_agent_image: "quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified"
 edpm_ovn_encap_ip: "{{ tenant_ip }}"
 edpm_ovn_protocol: "{% if edpm_enable_internal_tls | bool %}ssl{% else %}tcp{% endif %}"
 


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib