### PR TITLE
Adding edpm_ssh_known_hosts molecule tests into CI

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -28,12 +28,12 @@ jobs:
         - edpm_nftables
         - edpm_nodes_validation
         - edpm_sshd
+        - edpm_ssh_known_hosts
         - edpm_timezone
         - edpm_tuned
         # Following roles will be included in test matrix only after their
         # molecule tests deemed functional and stable
         # - edpm_iscsid
-        # - edpm_ssh_known_hosts
         # - edpm_ovn_bgp_agent
         # - edpm_ceph_client_files
         # - edpm_chrony


### PR DESCRIPTION
Molecule tests for the role have been stabilized.
It is now possible to run them in github CI along with others.