### PR TITLE
Setting molecule playbook to target localhost explictly

### DIFF
--- a/.github/playbooks/molecule-run.yml
+++ b/.github/playbooks/molecule-run.yml
@@ -1,17 +1,13 @@
 ---
 - name: Molecule tests
-  hosts: all
+  hosts: localhost
+  connection: local
   vars:
     role_dir: "{{ [
       lookup('ansible.builtin.env', 'GITHUB_WORKSPACE'), 'roles', lookup('ansible.builtin.env', 'ROLE_NAME')] | path_join }}"
   tasks:
   - debug:
       msg: "{{ role_dir }}"
-  - name: Install podman
-    become: true
-    ansible.builtin.package:
-      name:
-        - podman
   - name: Run molecule tests
     ansible.builtin.shell:
       chdir: "{{ role_dir }}"

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -59,6 +59,6 @@ jobs:
     - name: Install molecule deps
       run: pip install -r molecule-requirements.txt
     - name: Run molecule test
-      run: ansible-playbook .github/playbooks/molecule-run.yml -vvvv
+      run: ansible-playbook .github/playbooks/molecule-run.yml -vvvv --connection=local -i localhost
       env:
         ROLE_NAME: ${{ matrix.tested_role }}


### PR DESCRIPTION
This change explicitly defines host and connection to be used by molecule test playbook. 
Furthermore, a superfluous task was removed from the playbook, as the podman is already installed during the previous action stages. 