### PR TITLE
Escalate privileges for edpdm_iscsid and edpm_tuned tasks

### DIFF
--- a/roles/edpm_iscsid/tasks/configure.yml
+++ b/roles/edpm_iscsid/tasks/configure.yml
@@ -50,6 +50,7 @@
 
 - name: Create /etc/iscsi/iscsid.conf if necessary
   when: result.stat.exists == False
+  become: true
   block:
 
   - name: Fetch iscsid.conf from the iscsid container
@@ -69,10 +70,12 @@
     line: "node.session.auth.chap_algs = {{ edpm_iscsid_chap_algs }}"
     regexp: "^node.session.auth.chap_algs"
     insertafter: "^#node.session.auth.chap.algs"
+  become: true
   register: modify_stat
 
 - name: Record the iscsid container restart is required
   when : modify_stat.changed
+  become: true
   ansible.builtin.file:
    path: /etc/iscsi/.iscsid_restart_required
    state: touch

--- a/roles/edpm_tuned/tasks/configure.yml
+++ b/roles/edpm_tuned/tasks/configure.yml
@@ -63,6 +63,7 @@
     mode: 0644
     regexp: '^isolated_cores=.*'
     line: 'isolated_cores={{ edpm_tuned_isolated_cores }}'
+  become: true
   when:
     - edpm_tuned_isolated_cores is defined
     - (edpm_tuned_isolated_cores | length) > 0
@@ -71,6 +72,7 @@
 - name: Enable tuned profile
   ansible.builtin.command: >-
     /usr/sbin/tuned-adm profile {{ edpm_tuned_profile }}
+  become: true
   when:
     - not edpm_tuned_active_profile_file.stat.exists or (
       edpm_tuned_active_profile_file.stat.exists and (


### PR DESCRIPTION
We need root privileges for some of the configuration tasks.