### PR TITLE
Replacing check-byte-order-marker with fix-byte-order-marker hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: mixed-line-ending
-      - id: check-byte-order-marker
+      - id: fix-byte-order-marker
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: check-symlinks


### PR DESCRIPTION
check-byte-order-marker hook has been deprecated [0] in favor of the fix-byte-order-marker hook which fixes the issue in addtion to highlighting it.

[0] https://github.com/pre-commit/pre-commit-hooks/blob/main/CHANGELOG.md#330---2020-10-20w