### PR TITLE
Explaining lack of tests for edpm_nova_libvirt role

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -40,7 +40,7 @@ jobs:
         # - edpm_ceph_client_files
         # - edpm_chrony
         # - edpm_podman
-        # - edpm_nova_libvirt
+        # - edpm_nova_libvirt # Will not be tested PR#94
         # - edpm_ovn
         # - edpm_module_load
         # - edpm_kernel


### PR DESCRIPTION
Exceedingly minor change, but it should probably get in for future reference.