### PR TITLE
Mocking imported module to avoid ansible-autodoc import error

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,8 @@ import sys
 
 from ansible.plugins import loader # noqa F401
 
+from unittest.mock import MagicMock
+
 # Add the project
 sys.path.insert(0, os.path.abspath('../..'))
 # Add the extensions
@@ -31,6 +33,14 @@ extensions = [
     'sphinx.ext.intersphinx',
     'ansible-autodoc'
 ]
+
+# Mocking imports that are unresolvable for ansible-autodoc
+module_mock_imports = [
+    'ansible_collections.containers.podman.plugins.module_utils.podman.podman_container_lib'
+]
+
+for module in module_mock_imports:
+    sys.modules[module] = MagicMock()
 
 # autodoc generation is a bit aggressive and a nuisance when doing heavy
 # text edit cycles.


### PR DESCRIPTION
Eventually we will have to move away from ansible-autodoc, as it is no longer maintained and issues like this will only pile on. However this should enable us to build docs for the time being.