### PR TITLE
Manage swap partition as a hard requirement

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -50,6 +50,12 @@ edpm_bootstrap_network_service: NetworkManager
 # String for SELinux state. One of: disabled, enforcing, permissive
 edpm_bootstrap_selinux_mode: enforcing
 
+# Swap management
+edpm_bootstrap_swap_size_megabytes: 4096
+edpm_bootstrap_swap_path: /swap
+edpm_bootstrap_swap_partition_enabled: false
+edpm_bootstrap_swap_partition_label: swap1
+
 # Shell command that is executed before any packages are installed by the role.
 # Can be used to register systems using any arbitrary registration command(s).
 edpm_bootstrap_command: ""

--- a/roles/edpm_bootstrap/molecule/default/prepare.yml
+++ b/roles/edpm_bootstrap/molecule/default/prepare.yml
@@ -24,6 +24,9 @@
         - { option: 'ExecStartPre', state: 'absent' }
         - { option: 'ExecStart', value: '/bin/true' }
 
+    - name: Mock swapon command
+      ansible.builtin.command: ln -sf /bin/echo /sbin/swapon
+
     - name: Force systemd to reread configs
       ansible.builtin.systemd:
         daemon_reload: true

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -177,6 +177,9 @@
         name: NetworkManager
         state: reloaded
 
+- name: Configure swap
+  ansible.builtin.import_tasks: swap.yml
+
 - name: Set GID hugetlbfs user to match kolla pre-set
   become: true
   group:

--- a/roles/edpm_bootstrap/tasks/swap.yml
+++ b/roles/edpm_bootstrap/tasks/swap.yml
@@ -1,0 +1,59 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Configure swap file
+  become: true
+  when:
+    - not edpm_bootstrap_swap_partition_enabled|bool
+    - edpm_bootstrap_swap_size_megabytes|int > 0
+  shell: |
+    #!/bin/bash
+    set -eu
+    if [ ! -f {{ edpm_bootstrap_swap_path }} ]; then
+      dd if=/dev/zero of={{ edpm_bootstrap_swap_path }} count={{ edpm_bootstrap_swap_size_megabytes }} bs=1M
+      chmod 0600 {{ edpm_bootstrap_swap_path }}
+      mkswap {{ edpm_bootstrap_swap_path }}
+      swapon {{ edpm_bootstrap_swap_path }}
+      if ! grep -qE "{{ edpm_bootstrap_swap_path }}\b" /etc/fstab; then
+        echo "{{ edpm_bootstrap_swap_path }} swap swap defaults 0 0" >> /etc/fstab
+      fi
+    fi
+
+- name: Configure swap partition
+  become: true
+  when:
+    - edpm_bootstrap_swap_partition_enabled|bool
+  shell: |
+    #!/bin/bash
+    set -eu
+    changed=1
+    if [ -e "/dev/disk/by-label/{{ edpm_bootstrap_swap_partition_label }}" ]; then
+      swap_partition=$(realpath /dev/disk/by-label/{{ edpm_bootstrap_swap_partition_label }})
+      if ! grep -qE "${swap_partition}\b" /etc/fstab; then
+        echo "$swap_partition swap swap defaults 0 0" >> /etc/fstab
+        changed=0
+      fi
+    else
+      for item in $(lsblk -f --output FSTYPE,UUID | awk '/swap/ {print $2}'); do
+        if ! grep -qe "${item}" /etc/fstab; then
+          echo -e "UUID=${item} swap swap defaults 0 0" >> /etc/fstab
+          changed=0
+        fi
+      done
+    fi
+    if [ $changed -eq 0 ]; then
+      swapon -a
+    fi


### PR DESCRIPTION
Add swap partition management into the bootstrap role

The swap file/partition management logic is carried over from the existing EDPM pre-adoption implementation, but moved out of the nova compute specific scope into generic tasks for EDPM.

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/48683

Closes: [OSPRH-133](https://issues.redhat.com//browse/OSPRH-133)