### PR TITLE
Fix applying sysctl kernel settings

### DIFF
--- a/roles/edpm_kernel/defaults/main.yml
+++ b/roles/edpm_kernel/defaults/main.yml
@@ -18,47 +18,13 @@
 # All variables intended for modification should be placed in this file.
 edpm_kernel_extra_modules: {}
 edpm_kernel_extra_packages: {}
+edpm_kernel_sysctl_extra_settings: {}
 edpm_kernel_args: ""
 edpm_kernel_reboot_timeout: 3600
 edpm_kernel_post_reboot_delay: 60
 edpm_kernel_defer_reboot: false
 edpm_kernel_hugepages: {}
 edpm_kernel_hugepages_remove: false
-edpm_kernel_sysctl_extra_settings:
-  net.ipv6.conf.default.disable_ipv6:
-    value: 0
-  net.ipv4.ip_local_reserved_ports:
-    value: "35357,49000-49001"
-  net.ipv6.conf.all.disable_ipv6:
-    value: 0
-  net.ipv6.conf.lo.disable_ipv6:
-    value: 0
-  net.ipv4.ip_forward:
-    value: 1
-  net.ipv4.conf.all.rp_filter:
-    value: 1
-  net.ipv6.conf.all.forwarding:
-    value: 0
-  net.ipv4.ip_nonlocal_bind:
-    value: 1
-  net.ipv6.ip_nonlocal_bind:
-    value: 1
-  kernel.pid_max:
-    value: 1048576
-  net.ipv4.neigh.default.gc_thresh1:
-    value: 1024
-  net.ipv4.neigh.default.gc_thresh2:
-    value: 2048
-  net.ipv4.neigh.default.gc_thresh3:
-    value: 4096
-  net.bridge.bridge-nf-call-arptables:
-    value: 1
-  net.bridge.bridge-nf-call-iptables:
-    value: 1
-  net.bridge.bridge-nf-call-ip6tables:
-    value: 1
-  fs.inotify.max_user_instances:
-    value: 1024
 
 # This should be synced with edpm_nova_compute role
 edpm_nova_compute_config_dir: /var/lib/config-data/ansible-generated/nova_libvirt

--- a/roles/edpm_kernel/tasks/main.yml
+++ b/roles/edpm_kernel/tasks/main.yml
@@ -76,7 +76,7 @@
         state: "{{ setting.opt.state | default('present') }}"
         sysctl_file: "/etc/sysctl.d/99-edpm.conf"
         reload: false
-      loop: "{{ edpm_kernel_sysctl_extra_settings | dict2items(key_name='key', value_name='opt') }}"
+      loop: "{{ edpm_kernel_sysctl_settings | combine(edpm_kernel_sysctl_extra_settings) | dict2items(key_name='key', value_name='opt') }}"
       loop_control:
         label: "{{ setting.key }}"
         loop_var: setting

--- a/roles/edpm_kernel/templates/edpm-sysctl.conf.j2
+++ b/roles/edpm_kernel/templates/edpm-sysctl.conf.j2
@@ -1,5 +1,4 @@
 # {{ ansible_managed }}
-
-{% for item in edpm_kernel_sysctl_settings | dict2items(key_name='key', value_name='opt') %}
+{% for item in edpm_kernel_sysctl_settings | combine(edpm_kernel_sysctl_extra_settings) | dict2items(key_name='key', value_name='opt') %}
 {{ item.key }} = {{ item.opt.value }}
 {% endfor %}

--- a/roles/edpm_kernel/vars/main.yml
+++ b/roles/edpm_kernel/vars/main.yml
@@ -20,51 +20,87 @@ edpm_kernel_modules:
   nf_conntrack: {}
 
 edpm_kernel_sysctl_settings:
+  fs.inotify.max_user_instances:
+    value: 1024
+  fs.suid_dumpable:
+    value: 0
+  kernel.dmesg_restrict:
+    value: 1
+  kernel.pid_max:
+    value: 1048576
+  net.bridge.bridge-nf-call-arptables:
+    value: 1
+  net.bridge.bridge-nf-call-ip6tables:
+    value: 1
+  net.bridge.bridge-nf-call-iptables:
+    value: 1
+  net.core.netdev_max_backlog:
+    value: 10000
+  net.ipv4.conf.all.arp_accept:
+    value: 1
+  net.ipv4.conf.all.arp_notify:
+    value: 1
+  net.ipv4.conf.all.log_martians:
+    value: 1
+  net.ipv4.conf.all.rp_filter:
+    value: 1
+  net.ipv4.conf.all.secure_redirects:
+    value: 0
+  net.ipv4.conf.all.send_redirects:
+    value: 0
+  net.ipv4.conf.default.accept_redirects:
+    value: 0
+  net.ipv4.conf.default.log_martians:
+    value: 1
+  net.ipv4.conf.default.secure_redirects:
+    value: 0
+  net.ipv4.conf.default.send_redirects:
+    value: 0
+  net.ipv4.ip_forward:
+    value: 1
+  net.ipv4.ip_local_reserved_ports:
+    value: "35357,49000-49001"
+  net.ipv4.ip_nonlocal_bind:
+    value: 1
+  net.ipv4.neigh.default.gc_thresh1:
+    value: 1024
+  net.ipv4.neigh.default.gc_thresh2:
+    value: 2048
+  net.ipv4.neigh.default.gc_thresh3:
+    value: 4096
   net.ipv4.tcp_keepalive_intvl:
     value: 1
   net.ipv4.tcp_keepalive_probes:
     value: 5
   net.ipv4.tcp_keepalive_time:
     value: 5
-  net.ipv4.conf.default.send_redirects:
-    value: 0
-  net.ipv4.conf.all.send_redirects:
-    value: 0
-  net.ipv4.conf.all.arp_accept:
-    value: 1
-  net.ipv4.conf.default.accept_redirects:
-    value: 0
-  net.ipv4.conf.default.secure_redirects:
-    value: 0
-  net.ipv4.conf.all.secure_redirects:
-    value: 0
-  net.ipv4.conf.default.log_martians:
-    value: 1
-  net.ipv4.conf.all.log_martians:
-    value: 1
-  net.nf_conntrack_max:
-    value: 500000
-  net.netfilter.nf_conntrack_max:
-    value: 500000
   net.ipv6.conf.all.accept_ra:
-    value: 0
-  net.ipv6.conf.default.accept_ra:
-    value: 0
-  net.ipv6.conf.all.autoconf:
-    value: 0
-  net.ipv6.conf.default.autoconf:
-    value: 0
-  net.ipv6.conf.default.accept_redirects:
     value: 0
   net.ipv6.conf.all.accept_redirects:
     value: 0
-  net.ipv4.conf.all.arp_notify:
-    value: 1
+  net.ipv6.conf.all.autoconf:
+    value: 0
+  net.ipv6.conf.all.disable_ipv6:
+    value: 0
+  net.ipv6.conf.all.forwarding:
+    value: 0
   net.ipv6.conf.all.ndisc_notify:
     value: 1
-  net.core.netdev_max_backlog:
-    value: 10000
-  kernel.dmesg_restrict:
-    value: 1
-  fs.suid_dumpable:
+  net.ipv6.conf.default.accept_ra:
     value: 0
+  net.ipv6.conf.default.accept_redirects:
+    value: 0
+  net.ipv6.conf.default.autoconf:
+    value: 0
+  net.ipv6.conf.default.disable_ipv6:
+    value: 0
+  net.ipv6.conf.lo.disable_ipv6:
+    value: 0
+  net.ipv6.ip_nonlocal_bind:
+    value: 1
+  net.netfilter.nf_conntrack_max:
+    value: 500000
+  net.nf_conntrack_max:
+    value: 500000
+  vm.unprivileged_userfaultfd:
+    value: 1


### PR DESCRIPTION
Extend the pattern used for merging edpm_kernel_modules and edpm_kernel_extra_modules, for edpm_kernel_sysctl_settings and edpm_kernel_sysctl_extra_settings.

Provide a cleaner and consistend with ketnel modules user interface, for systcl overrides as well. Merge it with opinionated extra sysctl defaults that we ship with the ansible role.

Fix the missing combine() logic for the existing sysctl role defaults and extras in role vars. Define opnionated defaults in the role vars instead of splitting them into different places in the role.

Add the former nova compute specific setting for
vm.unprivileged_userfaultfd to extend it for all EDPM hosts.

Closes: OSPRH-155