### PR TITLE
chronyc makestep requires privilege escalation

### DIFF
--- a/roles/edpm_chrony/tasks/sync.yml
+++ b/roles/edpm_chrony/tasks/sync.yml
@@ -16,6 +16,7 @@
 
 
 - name: Force NTP sync
+  become: true
   ansible.builtin.command: chronyc makestep
 
 - name: Ensure system is NTP time synced

--- a/roles/edpm_timezone/tasks/run.yml
+++ b/roles/edpm_timezone/tasks/run.yml
@@ -16,6 +16,7 @@
 
 
 - name: Restart time services
+  become: true
   ansible.builtin.systemd:
     name: "{{ time_svc }}"
     state: restarted


### PR DESCRIPTION
Can't be run without sudo. Also does the same for some edpm_timezone role tasks that would require it.