### PR TITLE
Basic documentation for our filters

### DIFF
--- a/plugins/filter/dict_to_list.yml
+++ b/plugins/filter/dict_to_list.yml
@@ -1,0 +1,14 @@
+DOCUMENTATION:
+  name: dict_to_list
+  author: "EDPM team"
+  version_added: 2.9
+  description: |
+    This filter will take a dictionary which itself containers
+    multiple dictionaries; and will convert that to a list
+    of dictionaries.
+EXAMPLES: |
+  "{{ all_containers_hash | osp.edpm.dict_to_list }}"
+RETURN:
+  _value:
+    description:
+    type: list

--- a/plugins/filter/haskey.yml
+++ b/plugins/filter/haskey.yml
@@ -1,0 +1,22 @@
+DOCUMENTATION:
+  name: haskey
+  author: "EDPM team"
+  version_added: 2.9
+  description: |
+    This filter will take a list of dictionaries (data)
+    and will return the dictionnaries which have a certain key given
+    in parameter with 'attribute'.
+    If reverse is set to True, the returned list won't contain dictionaries
+    which have the attribute.
+    If any is set to True, the returned list will match any value in
+    the list of values for "value" parameter which has to be a list.
+    If we want to exclude items which have certain key(s); these keys
+    should be added to the excluded_keys list. If excluded_keys is used
+    with reverse, we'll just exclude the items which had a key from
+    excluded_keys in the reversed list.
+EXAMPLES: |
+ "{{ all_containers_hash | osp.edpm.dict_to_list | osp.edpm.haskey(attribute='restart', value=['always','unless-stopped'], any=True) | default([]) }}"
+RETURN:
+  _value:
+    description: dictionaries containing key
+    type: list

--- a/plugins/filter/needs_delete.yml
+++ b/plugins/filter/needs_delete.yml
@@ -1,0 +1,16 @@
+DOCUMENTATION:
+  name: needs_delete
+  author: "EDPM team"
+  version_added: 2.9
+  description: |
+    This filter will check which containers need to be removed for these
+    reasons: no config_data, updated config_data or container not
+    part of the global config.
+EXAMPLES: |
+    {{ podman_containers.containers | osp.edpm.needs_delete(config=all_containers_hash,
+    config_id=edpm_container_manage_config_id, check_config=False,
+    clean_orphans=True) }}
+RETURN:
+  _value:
+    description: list of containers to delete
+    type: list


### PR DESCRIPTION
Our filter plugins don't have ansible compliant docs yet. That complicates things during the doc build process using antsibull-docs. These files will stand in for module attributes usually leveraged to define documentation of ansible plugins. 

This practice is comparable to the one employed by ansible core plugins[0].

[0] https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/filter/to_json.yml