### PR TITLE
Argspecs for edpm-ansible roles

### DIFF
--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_bootstrap/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_bootstrap role.
+    options: {}

--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -3,4 +3,48 @@ argument_specs:
   # ./roles/edpm_bootstrap/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_bootstrap role.
-    options: {}
+    options:
+      edpm_bootstrap_packages_bootstrap:
+        type: list
+        default:
+          - driverctl
+          - lvm2
+          - crudini
+          - jq
+          - nftables
+          - openvswitch
+          - openstack-selinux
+          - os-net-config
+          - python3-libselinux
+          - python3-pyyaml
+          - rsync
+          - tmpwatch
+          - sysstat
+        description: "List of packages that are requred to bootstrap EDPM."
+
+      edpm_bootstrap_release_version_package:
+        type: list
+        default:
+          - rhosp-release
+
+      edpm_bootstrap_legacy_network_packages:
+        type: list
+        default:
+          - openstack-network-scripts
+        description: |
+          List of packages that are required for legacy networking to function.
+          NOTE: We are using 'network' service provided by 'network-scripts' (initscripts)
+                which deprecated in recent releases but os-net-config doesn't support yet
+                NetworkManager. Until it happens, we need to ensure that network is started
+                at boot, as it'll take care of restarting the network interfaces managed by
+                OVS. Note that OVS unit service is already configure to start before
+                network.service.
+
+      edpm_bootstrap_network_service:
+        type: str
+        default: NetworkManager
+
+      edpm_bootstrap_selinux_mode:
+        type: str
+        default: enforcing
+        description: "String for SELinux state. One of: disabled, enforcing, permissive"

--- a/roles/edpm_ceph_client_files/meta/argument_specs.yml
+++ b/roles/edpm_ceph_client_files/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_ceph_client_files/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_ceph_client_files role.
+    options: {}

--- a/roles/edpm_chrony/meta/argument_specs.yml
+++ b/roles/edpm_chrony/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_chrony/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_chrony role.
+    options: {}

--- a/roles/edpm_container_manage/meta/argument_specs.yml
+++ b/roles/edpm_container_manage/meta/argument_specs.yml
@@ -3,4 +3,43 @@ argument_specs:
   # ./roles/edpm_container_manage/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_container_manage role.
-    options: {}
+    options:
+      edpm_container_manage_hide_sensitive_logs:
+        type: bool
+        default: "{{ hide_sensitive_logs | default(true) }}"
+      edpm_container_manage_debug:
+        type: bool
+        default: "{{ ((ansible_verbosity | int) >= 2) | bool }}"
+      edpm_container_manage_clean_orphans:
+        type: bool
+        default: true
+      edpm_container_manage_update_config_hash:
+        type: bool
+        default: true
+      edpm_container_manage_cli:
+        type: str
+        default: podman
+      edpm_container_manage_concurrency:
+        type: int
+        default: 1
+      edpm_container_manage_config:
+        type: str
+        default: "/var/lib/edpm-config/"
+      edpm_container_manage_config_id:
+        type: str
+        default: edpm
+      edpm_container_manage_config_overrides:
+        type: dict
+        default: {}
+      edpm_container_manage_config_patterns:
+        type: str
+        default: '*.json'
+      edpm_container_manage_healthcheck_disabled:
+        type: bool
+        default: false
+      edpm_container_manage_log_path:
+        type: str
+        default: '/var/log/containers/stdouts'
+      edpm_container_manage_systemd_teardown:
+        type: bool
+        default: true

--- a/roles/edpm_container_manage/meta/argument_specs.yml
+++ b/roles/edpm_container_manage/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_container_manage/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_container_manage role.
+    options: {}

--- a/roles/edpm_container_rm/meta/argument_specs.yml
+++ b/roles/edpm_container_rm/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_container_rm/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_container_rm role.
+    options: {}

--- a/roles/edpm_container_rm/meta/argument_specs.yml
+++ b/roles/edpm_container_rm/meta/argument_specs.yml
@@ -3,4 +3,13 @@ argument_specs:
   # ./roles/edpm_container_rm/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_container_rm role.
-    options: {}
+    options:
+      edpm_container_cli:
+        type: str
+        description: Set the container command line entry-point
+        default: "{{ container_cli | default('podman') }}"
+
+      edpm_containers_to_rm:
+        type: list
+        default: "{{ containers_to_rm | default([]) }}"
+        description: "List of containers to delete"

--- a/roles/edpm_container_standalone/meta/argument_specs.yml
+++ b/roles/edpm_container_standalone/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_container_standalone/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_container_standalone role.
+    options: {}

--- a/roles/edpm_frr/meta/argument_specs.yml
+++ b/roles/edpm_frr/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_frr/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_frr role.
+    options: {}

--- a/roles/edpm_growvols/meta/argument_specs.yml
+++ b/roles/edpm_growvols/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_growvols/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_growvols role.
+    options: {}

--- a/roles/edpm_hosts_entries/meta/argument_specs.yml
+++ b/roles/edpm_hosts_entries/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_hosts_entries/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_hosts_entries role.
+    options: {}

--- a/roles/edpm_iscsid/meta/argument_specs.yml
+++ b/roles/edpm_iscsid/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_iscsid/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_iscsid role.
+    options: {}

--- a/roles/edpm_kernel/meta/argument_specs.yml
+++ b/roles/edpm_kernel/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_kernel/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_kernel role.
+    options: {}

--- a/roles/edpm_logrotate_crond/meta/argument_specs.yml
+++ b/roles/edpm_logrotate_crond/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_logrotate_crond/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_logrotate_crond role.
+    options: {}

--- a/roles/edpm_module_load/meta/argument_specs.yml
+++ b/roles/edpm_module_load/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_module_load/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_module_load role.
+    options: {}

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_network_config/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_network_config role.
+    options: {}

--- a/roles/edpm_nftables/meta/argument_specs.yml
+++ b/roles/edpm_nftables/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_nftables/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_nftables role.
+    options: {}

--- a/roles/edpm_nodes_validation/meta/argument_specs.yml
+++ b/roles/edpm_nodes_validation/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_nodes_validation/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_nodes_validation role.
+    options: {}

--- a/roles/edpm_nova_compute/meta/argument_specs.yml
+++ b/roles/edpm_nova_compute/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_nova_compute/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_nova_compute role.
+    options: {}

--- a/roles/edpm_nova_libvirt/meta/argument_specs.yml
+++ b/roles/edpm_nova_libvirt/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_nova_libvirt/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_nova_libvirt role.
+    options: {}

--- a/roles/edpm_nvdimm/meta/argument_specs.yml
+++ b/roles/edpm_nvdimm/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_nvdimm/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_nvdimm role.
+    options: {}

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_ovn/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_ovn role.
+    options: {}

--- a/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
+++ b/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_ovn_bgp_agent/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_ovn_bgp_agent role.
+    options: {}

--- a/roles/edpm_podman/meta/argument_specs.yml
+++ b/roles/edpm_podman/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_podman/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_podman role.
+    options: {}

--- a/roles/edpm_ssh_known_hosts/meta/argument_specs.yml
+++ b/roles/edpm_ssh_known_hosts/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_ssh_known_hosts/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_ssh_known_hosts role.
+    options: {}

--- a/roles/edpm_sshd/meta/argument_specs.yml
+++ b/roles/edpm_sshd/meta/argument_specs.yml
@@ -3,4 +3,13 @@ argument_specs:
   # ./roles/edpm_sshd/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_sshd role.
-    options: {}
+    options:
+      edpm_sshd_banner_enabled:
+        type: bool
+        default: false
+      edpm_sshd_motd_enabled:
+        type: bool
+        default: false
+      edpm_sshd_gssapi_authentication:
+        type: str
+        required: true

--- a/roles/edpm_sshd/meta/argument_specs.yml
+++ b/roles/edpm_sshd/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_sshd/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_sshd role.
+    options: {}

--- a/roles/edpm_timezone/meta/argument_specs.yml
+++ b/roles/edpm_timezone/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_timezone/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_timezone role.
+    options: {}

--- a/roles/edpm_tuned/meta/argument_specs.yml
+++ b/roles/edpm_tuned/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_tuned/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_tuned role.
+    options: {}

--- a/roles/env_data/meta/argument_specs.yml
+++ b/roles/env_data/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/env_data/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the env_data role.
+    options: {}

--- a/roles/test_deps/meta/argument_specs.yml
+++ b/roles/test_deps/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/test_deps/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the test_deps role.
+    options: {}

--- a/roles/test_deps/meta/argument_specs.yml
+++ b/roles/test_deps/meta/argument_specs.yml
@@ -3,4 +3,31 @@ argument_specs:
   # ./roles/test_deps/tasks/main.yml entry point
   main:
     short_description: The main entry point for the test_deps role.
-    options: {}
+    options:
+      test_deps_extra_packages:
+        type: list
+        default: []
+
+      test_deps_setup_edpm:
+        type: bool
+        default: false
+
+      test_deps_repo_version:
+        type: str
+        default: "{{ ansible_facts['distribution'] | lower }}{{ ansible_facts['distribution_major_version'] }}-master"
+
+      test_deps_mirrors_file_path:
+        type: str
+        default: /etc/ci/mirror_info.sh
+
+      test_deps_setup_stream:
+        type: bool
+        default: true
+
+      test_deps_setup_ceph:
+        type: bool
+        default: false
+
+      test_deps_edpm_packages:
+        type: list
+        required: false


### PR DESCRIPTION
Basic argument specs for our roles. In most cases they are left to be filled out later, although they are still possible to verify. In long run this should simplify maintenance, as we will, in effect, have a well defined interface for our roles.

Practical impact at this point is mostly with enabling antsibull-docs functionality.