### PR TITLE
Ensure bridge mappings do not have spaces

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -47,7 +47,7 @@ edpm_ovn_controller_tls_volumes:
 edpm_ovn_ovs_external_ids:
   hostname: "{{ ansible_facts['fqdn'] }}"
   ovn-bridge: "{{ edpm_ovn_bridge }}"
-  ovn-bridge-mappings: "{{ edpm_ovn_bridge_mappings | join(', ') }}"
+  ovn-bridge-mappings: "{{ edpm_ovn_bridge_mappings | join(',') }}"
   ovn-chassis-mac-mappings:
     "{%- set chassis_mac_mappings = [] -%}
      {%- for physnet, mac_prefix in edpm_ovn_chassis_mac_mapping_prefixes.items() -%}


### PR DESCRIPTION
when creating the ovs-vsctl set command, the bridge mappings should be a list without spaces, otherwise if you have more than one bridge mapping, the command will fail