### PR TITLE
Add NB DB certs config for ovn-bgp-agent NB driver

### DIFF
--- a/roles/edpm_ovn_bgp_agent/templates/ovn-bgp-agent.conf.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/ovn-bgp-agent.conf.j2
@@ -13,6 +13,9 @@ ovsdb_connection={{ edpm_ovn_bgp_agent_ovsdb_connection }}
 ovn_sb_private_key={{ edpm_ovn_bgp_agent_private_key }}
 ovn_sb_certificate={{ edpm_ovn_bgp_agent_certificate }}
 ovn_sb_ca_cert={{ edpm_ovn_bgp_agent_ca_cert }}
+ovn_nb_private_key={{ edpm_ovn_bgp_agent_private_key }}
+ovn_nb_certificate={{ edpm_ovn_bgp_agent_certificate }}
+ovn_nb_ca_cert={{ edpm_ovn_bgp_agent_ca_cert }}
 {% endif %}
 {% if edpm_ovn_bgp_agent_address_scopes %}
 address_scopes={{ edpm_ovn_bgp_agent_address_scopes }}


### PR DESCRIPTION
There is a new driver for ovn-bgp-agent that uses NB instead of SB OVN DBs, thus it needs extra information/configuration to connect to NB in case of TLS being setup