### PR TITLE
Adding zuul job for `edpm_kernel` molecule tests

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -20,6 +20,11 @@
     parent: edpm-ansible-molecule-base
     vars:
       TEST_RUN: edpm_module_load
+- job:
+    name: edpm-ansible-molecule-edpm-kernel
+    parent: edpm-ansible-molecule-base
+    vars:
+      TEST_RUN: edpm_kernel
 
 # EDPM jobs
 - job:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -5,4 +5,5 @@
       jobs:
         - edpm-ansible-molecule-edpm-podman
         - edpm-ansible-molecule-edpm-module_load
+        - edpm-ansible-molecule-edpm-kernel
         - edpm-ansible-crc-podified-edpm-deployment


### PR DESCRIPTION
Zuul will now take care of molecule tests for the `edpm_kernel` role.

Closes: #103 