### PR TITLE
Setting hugetlbfs gid to kolla preset in the bootstrap instead of the…

### DIFF
--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -160,3 +160,9 @@
       ansible.builtin.service:
         name: NetworkManager
         state: reloaded
+
+- name: Set GID hugetlbfs user to match kolla pre-set
+  become: true
+  group:
+    name: hugetlbfs
+    gid: 42477

--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -194,13 +194,6 @@
       ansible.builtin.set_fact:
         reboot_required: true
 
-# Apply DPDK workarounds before reboot
-- name: Apply DPDK workarounds
-  ansible.builtin.include_role:
-    name: edpm_ovs_dpdk
-    tasks_from: workarounds.yml
-  when: reboot_required is defined and reboot_required
-
 # Kernel modules loading
 - name: Load type1 IOMMU driver for VFIO on boot
   ansible.builtin.import_role:


### PR DESCRIPTION
… kernel role.

The original task was defined in tripleo_ovs_dpdk role and used before reboot by the kernel role. This modification move the action to bootstrap, removing the dependency from the kernel role in the process.