### PR TITLE
Expanding argspec with minimum arguments

### DIFF
--- a/roles/edpm_kernel/meta/argument_specs.yml
+++ b/roles/edpm_kernel/meta/argument_specs.yml
@@ -3,4 +3,16 @@ argument_specs:
   # ./roles/edpm_kernel/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_kernel role.
-    options: {}
+    options:
+      edpm_kernel_extra_modules:
+          type: dict
+          default: {}
+          description: Additional kernel modules to load
+      edpm_kernel_extra_packages:
+        type: dict
+        default: {}
+        description: Additional packages to install before handling kernel modules.
+      edpm_kernel_sysctl_extra_settings:
+        type: dict
+        default: {}
+        description: Additional sysctl settings.


### PR DESCRIPTION
Several arguments, along with their descriptions, types and default values, were added to the argument spec.

- edpm_kernel_extra_modules
- edpm_kernel_extra_packages
- edpm_kernel_sysctl_extra_setting

Pull request for edpm_kernel job #168 has uncovered another deficiency in the current state of the role.
This time it's in the newly implemented argspec, which was intended as temporary placeholder [0].

[0]https://review.rdoproject.org/zuul/build/c9ffa34aca5843368c48da4106a905a9