### PR TITLE
`edpm_module_load` argspec definition and molecule tests

### DIFF
--- a/roles/edpm_module_load/meta/argument_specs.yml
+++ b/roles/edpm_module_load/meta/argument_specs.yml
@@ -3,4 +3,19 @@ argument_specs:
   # ./roles/edpm_module_load/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_module_load role.
-    options: {}
+    options:
+      modules:
+        type: list
+        default: []
+        description: |
+          List of dictionaries describing modules, their desired state and parameters.
+          Params is assumed to be `null` and
+          state is assumed to be "present"; state can be either "present" or "absent".
+          Example:
+
+           modules:
+             - name: foo
+               params: 'bar baz'
+             - name: starwars
+             - name: starwars
+               state: absent

--- a/roles/edpm_module_load/molecule/default/converge.yml
+++ b/roles/edpm_module_load/molecule/default/converge.yml
@@ -19,5 +19,5 @@
   hosts: all
   roles:
     - role: "edpm_module_load"
-      edpm_modules:
+      modules:
         - name: dummy

--- a/roles/edpm_module_load/molecule/remove_module/converge.yml
+++ b/roles/edpm_module_load/molecule/remove_module/converge.yml
@@ -19,9 +19,9 @@
   hosts: all
   roles:
     - role: "edpm_module_load"
-      edpm_modules:
+      modules:
         - name: dummy
     - role: "edpm_module_load"
-      edpm_modules:
+      modules:
         - name: dummy
           state: absent

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -15,6 +15,11 @@
     parent: edpm-ansible-molecule-base
     vars:
       TEST_RUN: edpm_podman
+- job:
+    name: edpm-ansible-molecule-edpm-module_load
+    parent: edpm-ansible-molecule-base
+    vars:
+      TEST_RUN: edpm_module_load
 
 # EDPM jobs
 - job:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,4 +4,5 @@
     github-check:
       jobs:
         - edpm-ansible-molecule-edpm-podman
+        - edpm-ansible-molecule-edpm-module_load
         - edpm-ansible-crc-podified-edpm-deployment


### PR DESCRIPTION
Considering the divergent use in molecule and existing invocations of the role, I have settled on the `modules` being the only parameter of the role. The molecule tests will now be executed in zuul.

Closes: #104