### PR TITLE
Adding argument spec template to skeleton role

### DIFF
--- a/contribute/_skeleton_role_/meta/argument_specs.yml.j2
+++ b/contribute/_skeleton_role_/meta/argument_specs.yml.j2
@@ -1,0 +1,7 @@
+---
+argument_specs:
+  # ./roles/{{ role_name }}/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the {{ role_name }} role.
+    description: Multiple lines description
+    options: {}


### PR DESCRIPTION
Minimal template for role argument specification [0]. By defining role interface we can cut down bugs caused by incorrect parameters. Furthermore, roles with args are easier to automatically document.

[0]https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#specification-format