### PR TITLE
Correct the enable-chassis-as-gw logic

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -31,7 +31,7 @@ edpm_ovn_chassis_mac_mapping_prefixes:
 edpm_ovn_chassis_mac_mapping_seed: "{{ ansible_machine_id }}"
 edpm_ovn_encap_type: geneve
 edpm_ovn_dbs: []
-edpm_enable_dvr: true
+edpm_enable_chassis_gw: false
 edpm_enable_hw_offload: false
 edpm_ovn_multi_rhel: false
 edpm_enable_internal_tls: false

--- a/roles/edpm_ovn/tasks/cleanup.yml
+++ b/roles/edpm_ovn/tasks/cleanup.yml
@@ -19,7 +19,7 @@
     ovs-vsctl remove open . other_config hw-offload
   when: not edpm_enable_hw_offload | bool
 
-- name: Cleanup enable-chassis-as-gw when DVR not enabled
+- name: Cleanup enable-chassis-as-gw when chassis GW not enabled
   ansible.builtin.shell: >
     ovs-vsctl remove open . external_ids ovn-cms-options
-  when: not edpm_enable_dvr | bool
+  when: not edpm_enable_chassis_gw | bool

--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -14,8 +14,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Set DVR setting when enabled
-  when: edpm_enable_dvr|default(true)
+- name: Configure GW ports on chassis setting when enabled
+  when: edpm_enable_chassis_gw|default(false)
   block:
     - name: Set enable-chassis-as-gw
       ansible.builtin.set_fact:


### PR DESCRIPTION
The enable-chassis-as-gw is to enable the nodes to host ovn router gateway ports, not to enable/disable DVR [1].

This patch renames the option so that it is clear that is for making compute nodes able to host gw ports

[1] https://github.com/openstack-k8s-operators/neutron-operator/pull/153