### PR TITLE
Update creator-ee image to version v0.18.0

### DIFF
--- a/openstack_ansibleee/Dockerfile
+++ b/openstack_ansibleee/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/creator-ee:v0.14.1 as builder
+FROM quay.io/ansible/creator-ee:v0.18.0 as builder
 
 ARG REMOTE_SOURCE=.
 ARG REMOTE_SOURCE_DIR=/var/tmp/edpm-ansible
@@ -8,7 +8,7 @@ RUN cd /var/tmp/edpm-ansible && \
     ansible-galaxy collection install --timeout 120 -r requirements.yml --collections-path "/usr/share/ansible/collections" && \
     ansible-galaxy collection install $REMOTE_SOURCE_DIR --collections-path "/usr/share/ansible/collections"
 
-FROM quay.io/ansible/creator-ee:v0.14.1 as runner
+FROM quay.io/ansible/creator-ee:v0.18.0 as runner
 
 COPY --from=builder /usr/share/ansible /usr/share/ansible
 


### PR DESCRIPTION
[Here](https://github.com/ansible/creator-ee/releases)'s the changes for this new version.

Useful changes includes:

* bump to Fedora 38
* bump to ansible 2.15 (we need to verify if it works well with our playbooks/roles/modules)
* bump to ansible-runner 2.3.2
* bump to paramiko 3.1.0