### PR TITLE
Improving versatility of the env_data role

### DIFF
--- a/roles/env_data/meta/argument_specs.yml
+++ b/roles/env_data/meta/argument_specs.yml
@@ -3,4 +3,7 @@ argument_specs:
   # ./roles/env_data/tasks/main.yml entry point
   main:
     short_description: The main entry point for the env_data role.
+    description:
+    - Role gathers information about local env and prints it as debug.
+    - No arguments are expected or necessary.
     options: {}

--- a/roles/env_data/meta/main.yml
+++ b/roles/env_data/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  namespace: openstack
+  author: OpenStack
+  description: EDPM OpenStack Role -- env_data
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.9'
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/env_data/tasks/main.yml
+++ b/roles/env_data/tasks/main.yml
@@ -16,17 +16,18 @@
 
 
 - name: Gather all installed packages
-  ansible.builtin.shell: |
-    set -o pipefail
-    rpm -qa | sort
-  register: package_list
+  ansible.builtin.package_facts:
+
 - name: Gather repository list
   ansible.builtin.command: dnf repolist
   register: repo_list
+
 - name: Output installed packages
   ansible.builtin.debug:
+    msg: "{{ ansible_facts.packages | community.general.json_query('*') | flatten | join('\n') }}"
+
+- name: Output installed repositories
+  ansible.builtin.debug:
     msg: |
-      #### INSTALLED PACKAGES
-      {{ package_list.stdout }}
       #### REPOSITORIES
       {{ repo_list.stdout }}


### PR DESCRIPTION
env_data now has a proper meta/main.yml file.

Printing of repository and package information was split. Rather than using inline shell script the role now uses ansible module to obtain information about installed packages.

As an added value, the packages installed are now registered as a fact.

The new output of the installed packages section would be:

```
   {'name': 'libgcc', 'version': '11.3.1', 'release': '2.1.el9', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'crypto-policies', 'version': '20220815', 'release': '1.git0fbe86f.el9', 'epoch': None, 'arch': 'noarch', 'source': 'rpm'}
    {'name': 'tzdata', 'version': '2023c', 'release': '1.el9', 'epoch': None, 'arch': 'noarch', 'source': 'rpm'}
    {'name': 'subscription-manager-rhsm-certificates', 'version': '20220623', 'release': '1.el9', 'epoch': None, 'arch': 'noarch', 'source': 'rpm'}
    {'name': 'redhat-release', 'version': '9.1', 'release': '1.9.el9', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'setup', 'version': '2.13.7', 'release': '7.el9', 'epoch': None, 'arch': 'noarch', 'source': 'rpm'}
    {'name': 'filesystem', 'version': '3.16', 'release': '2.el9', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'basesystem', 'version': '11', 'release': '13.el9', 'epoch': None, 'arch': 'noarch', 'source': 'rpm'}
    {'name': 'python3-setuptools-wheel', 'version': '53.0.0', 'release': '10.el9_1.1', 'epoch': None, 'arch': 'noarch', 'source': 'rpm'}
    {'name': 'pcre2-syntax', 'version': '10.40', 'release': '2.el9', 'epoch': None, 'arch': 'noarch', 'source': 'rpm'}
    {'name': 'ncurses-base', 'version': '6.2', 'release': '8.20210508.el9', 'epoch': None, 'arch': 'noarch', 'source': 'rpm'}
    {'name': 'glibc-minimal-langpack', 'version': '2.34', 'release': '40.el9_1.1', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'glibc-common', 'version': '2.34', 'release': '40.el9_1.1', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'glibc', 'version': '2.34', 'release': '40.el9_1.1', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'ncurses-libs', 'version': '6.2', 'release': '8.20210508.el9', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'bash', 'version': '5.1.8', 'release': '6.el9_1', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'zlib', 'version': '1.2.11', 'release': '35.el9_1', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'xz-libs', 'version': '5.2.5', 'release': '8.el9_0', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}
    {'name': 'bzip2-libs', 'version': '1.0.8', 'release': '8.el9', 'epoch': None, 'arch': 'x86_64', 'source': 'rpm'}