### PR TITLE
Refactored `edpm_config_network` role to support `linux-system-role.network` in place of `os-net-config`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build
 *~
 .*.swp
 .*sw?
+.vscode
 
 # Playbook retry files
 *.retry

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build
 *~
 .*.swp
 .*sw?
-.vscode
 
 # Playbook retry files
 *.retry

--- a/requirements.yml
+++ b/requirements.yml
@@ -18,6 +18,7 @@ collections:
   - ansible.posix
   - community.general
   - containers.podman
+  - fedora.linux_system_roles
   - name: https://opendev.org/openstack/ansible-config_template
     version: master
     type: git

--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -23,7 +23,6 @@ edpm_bootstrap_packages_bootstrap:
   - lvm2
   - crudini
   - jq
-  - NetworkManager-ovs
   - nftables
   - openvswitch
   - openstack-selinux

--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -23,6 +23,7 @@ edpm_bootstrap_packages_bootstrap:
   - lvm2
   - crudini
   - jq
+  - NetworkManager-ovs
   - nftables
   - openvswitch
   - openstack-selinux

--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -27,7 +27,6 @@ edpm_bootstrap_packages_bootstrap:
   - nftables
   - openvswitch
   - openstack-selinux
-  - os-net-config
   - python3-libselinux
   - python3-pyyaml
   - rsync

--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -25,6 +25,7 @@ edpm_bootstrap_packages_bootstrap:
   - jq
   - nftables
   - openvswitch
+  - NetworkManager
   - openstack-selinux
   - python3-libselinux
   - python3-pyyaml

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -18,7 +18,15 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_network_config"
-edpm_network_config_role: os-net-config
+
+# This variable let the use choose which tool will be used to configure networking on hosts
+# Accepted values are:
+# * os-net-config (default) -> the os-net-config will be used
+# * nmstate -> the network role from linux-system-roles/rhel-system-roles will be used to
+#   configure networking on hosts. In particular, the nmstate tool should cover all the
+#   supported scenario. Refer to nmstate.io for configuration snippets.
+edpm_network_config_tool: os-net-config
+
 edpm_network_config_update: false
 edpm_network_config_async_poll: 3
 edpm_network_config_async_timeout: 300

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -18,6 +18,7 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_network_config"
+edpm_network_config_role: os-net-config
 edpm_network_config_update: false
 edpm_network_config_async_poll: 3
 edpm_network_config_async_timeout: 300

--- a/roles/edpm_network_config/molecule/nmstate/collections.yml
+++ b/roles/edpm_network_config/molecule/nmstate/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - fedora.linux_system_roles

--- a/roles/edpm_network_config/molecule/nmstate/converge.yml
+++ b/roles/edpm_network_config/molecule/nmstate/converge.yml
@@ -19,10 +19,11 @@
   hosts: all
   vars:
     edpm_network_config_tool: nmstate
+    network_provider: nm
     network_state:
       interfaces:
-      - name: dummy1
-        type: unknown
+      - name: dummy0
+        type: dummy
         state: down
         ipv4:
           enabled: false

--- a/roles/edpm_network_config/molecule/nmstate/converge.yml
+++ b/roles/edpm_network_config/molecule/nmstate/converge.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    edpm_network_config_tool: nmstate
+    interfaces:
+    - name: dummy1
+      type: unknown
+      state: down
+      ipv4:
+        enabled: false
+  roles:
+    - role: "osp.edpm.edpm_network_config"

--- a/roles/edpm_network_config/molecule/nmstate/converge.yml
+++ b/roles/edpm_network_config/molecule/nmstate/converge.yml
@@ -19,11 +19,12 @@
   hosts: all
   vars:
     edpm_network_config_tool: nmstate
-    interfaces:
-    - name: dummy1
-      type: unknown
-      state: down
-      ipv4:
-        enabled: false
+    network_state:
+      interfaces:
+      - name: dummy1
+        type: unknown
+        state: down
+        ipv4:
+          enabled: false
   roles:
     - role: "osp.edpm.edpm_network_config"

--- a/roles/edpm_network_config/molecule/nmstate/molecule.yml
+++ b/roles/edpm_network_config/molecule/nmstate/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+    registry:
+      url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+    command: /sbin/init
+    dockerfile: ../../../../molecule/common/Containerfile.j2
+    privileged: true
+    ulimits: &ulimit
+      - host
+provisioner:
+  name: ansible
+  log: true
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/roles/edpm_network_config/molecule/nmstate/prepare.yml
+++ b/roles/edpm_network_config/molecule/nmstate/prepare.yml
@@ -23,15 +23,3 @@
       test_deps_extra_packages:
         - iproute
     - role: env_data
-
-  tasks:
-    - name: Ensure legacy scripts installed
-      become: true
-      ansible.builtin.package:
-        name: network-scripts
-        state: present
-      when:
-        - ansible_facts['distribution_major_version'] is version('8', '==')
-    - name: Create a dummy network interface
-      become: true
-      ansible.builtin.command: "ip link add dummy0 type dummy"

--- a/roles/edpm_network_config/molecule/nmstate/prepare.yml
+++ b/roles/edpm_network_config/molecule/nmstate/prepare.yml
@@ -1,0 +1,37 @@
+---
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+      test_deps_setup_edpm: true
+      test_deps_extra_packages:
+        - iproute
+    - role: env_data
+
+  tasks:
+    - name: Ensure legacy scripts installed
+      become: true
+      ansible.builtin.package:
+        name: network-scripts
+        state: present
+      when:
+        - ansible_facts['distribution_major_version'] is version('8', '==')
+    - name: Create a dummy network interface
+      become: true
+      ansible.builtin.command: "ip link add dummy0 type dummy"

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -19,7 +19,11 @@
     - name: Retrieve role name [nmstate]
       ansible.builtin.set_fact:
         systemrolename:
-          "{{ ansible_facts['distribution'] | lower }}.
+          "{%- if ansible_facts['distribution'] == 'RedHat' -%}
+            redhat
+          {%- else -%}
+            fedora
+          {%- endif -%}.
           {%- if ansible_facts['distribution'] == 'RedHat' -%}
             rhel
           {%- else -%}

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -27,12 +27,16 @@
           {%- endif -%}
           _system_role.network"
       delegate_to: localhost
+    - name: Install required package
+      ansible.builtin.dnf:
+        name: NetworkManager-ovs
+        state: latest
     - name: Configure network with nmstate
       ansible.builtin.include_role:
         name: "{{ systemrolename }}"
-  when: edpm_network_config_role == 'nmstate'
+  when: edpm_network_config_tool == 'nmstate'
 
 - name: Load edpm_network_config tasks
   ansible.builtin.include_tasks:
     file: network_config.yml
-  when: edpm_network_config_role == 'os-net-config'
+  when: edpm_network_config_tool == 'os-net-config'

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -29,7 +29,7 @@
           {%- else -%}
             linux
           {%- endif -%}
-          _system_role.network"
+          _system_roles.network"
       delegate_to: localhost
     - name: Install required package [nmstate]
       ansible.builtin.dnf:

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -14,9 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Load network system role
+- name: Configure network with network role from system roles [nmstate]
   block:
-    - name: Retrieve role name
+    - name: Retrieve role name [nmstate]
       ansible.builtin.set_fact:
         systemrolename:
           "{{ ansible_facts['distribution'] | lower }}.
@@ -27,16 +27,16 @@
           {%- endif -%}
           _system_role.network"
       delegate_to: localhost
-    - name: Install required package
+    - name: Install required package [nmstate]
       ansible.builtin.dnf:
         name: NetworkManager-ovs
         state: latest
-    - name: Configure network with nmstate
+    - name: Load system-roles.network tasks [nmstate]
       ansible.builtin.include_role:
         name: "{{ systemrolename }}"
   when: edpm_network_config_tool == 'nmstate'
 
-- name: Load edpm_network_config tasks
+- name: Load edpm_network_config tasks [os-net-config]
   ansible.builtin.include_tasks:
     file: network_config.yml
   when: edpm_network_config_tool == 'os-net-config'

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2020 Red Hat, Inc.
+# Copyright 2023 Red Hat, Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,136 +14,25 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Gather SELinux fact if needed
-  when:
-    - ansible_facts.selinux is undefined
-  ansible.builtin.setup:
-    gather_subset:
-      - "!all"
-      - "!min"
-      - "selinux"
-
-- name: Create fcontext entry for edpmconfig
-  become: true
-  when:
-    - ansible_facts.selinux.status == "enabled"
-  sefcontext:
-    target: "/var/lib/edpm-config(/.*)?"
-    setype: container_file_t
-    selevel: s0
-    state: present
-
-- name: Ensure requirements are satisfied
-  ansible.builtin.include_role:
-    name: edpm_bootstrap
-    tasks_from: packages.yml
-
-- name: Ensure /var/lib/edpm-config directory exists
-  become: true
-  ansible.builtin.file:
-    path: /var/lib/edpm-config
-    state: directory
-    setype: container_file_t
-    selevel: s0
-    mode: 0750
-
-- name: Check for previous run of NetworkConfig
-  become: true
-  ansible.builtin.stat:
-    path: /var/lib/edpm-config/os-net-config.returncode
-  register: os_net_config_returncode_stat
-
-- name: Check result of previous run of NetworkConfig
-  become: true
-  ansible.builtin.slurp:
-    path: /var/lib/edpm-config/os-net-config.returncode
-  when: os_net_config_returncode_stat.stat.exists
-  register: os_net_config_returncode_slurp
-
-- name: Ensure we get cloud-init
-  ansible.builtin.stat:
-    path: /etc/cloud/cloud.cfg.d
-  register: cloud_init_exists
-
-- name: NetworkConfig
-  become: true
-  # The conditions here are when we want to apply the
-  # NetworkConfig. They are:
-  # - If edpm_network_config_update is True
-  # - Or the previous run of NetworkConfig failed.
-  # - Or it has never run
-  # This will match the prior behavior of when a Heat
-  # SoftwareDeployment was used.
-  # It also ensures the script does exist as a sine qua non
-  # condition
-  when:
-    - (edpm_network_config_update) or
-      (os_net_config_returncode_stat.stat.exists and
-      ((os_net_config_returncode_slurp.content | b64decode | int) != 0)) or
-       (not os_net_config_returncode_stat.stat.exists)
+- name: Load network system role
   block:
-    - name: Create /etc/os-net-config directory
-      become: true
-      ansible.builtin.file:
-        path: /etc/os-net-config
-        state: directory
-        recurse: true
+    - name: Retrieve role name
+      ansible.builtin.set_fact:
+        systemrolename:
+          "{{ ansible_facts['distribution'] | lower }}.
+          {%- if ansible_facts['distribution'] == 'RedHat' -%}
+            rhel
+          {%- else -%}
+            linux
+          {%- endif -%}
+          _system_role.network"
+      delegate_to: localhost
+    - name: Configure network with nmstate
+      ansible.builtin.include_role:
+        name: "{{ systemrolename }}"
+  when: edpm_network_config_role == 'nmstate'
 
-    - name: Create os-net-config mappings from lookup data
-      edpm_os_net_config_mappings:
-        net_config_data_lookup:
-          "{{ edpm_network_config_os_net_config_mappings }}"
-      when: not ansible_check_mode|bool
-      register: os_net_config_mappings_result
-
-    - name: Write os-net-config mappings file /etc/os-net-config/mapping.yaml
-      ansible.builtin.copy:
-        content: "{{ os_net_config_mappings_result.mapping | to_nice_yaml }}"
-        dest: /etc/os-net-config/mapping.yaml
-        mode: 0644
-      when: os_net_config_mappings_result.changed|bool
-
-    - name: Manage NetworkConfig with edpm_os_net_config module
-      block:
-        - name: Remove /var/lib/edpm-config/scripts directory
-          ansible.builtin.file:
-            path: /var/lib/edpm-config/scripts
-            state: absent
-
-        - name: Run NetworkConfig with edpm_os_net_config
-          ansible.builtin.include_tasks: os_net_config.yml
-
-    - name: Write rc of NetworkConfig script
-      ansible.builtin.copy:
-        content: "{{ network_config_result.rc }}"
-        dest: /var/lib/edpm-config/os-net-config.returncode
-        mode: 0644
-      when:
-        - network_config_result.rc is defined
-
-    # LP Bug: https://bugs.launchpad.net/edpm/+bug/1958332
-    - name: Disable cloud-init network config
-      ansible.builtin.copy:
-        content: |
-          network:
-            config: disabled
-        dest: /etc/cloud/cloud.cfg.d/99-edpm-disable-network-config.cfg
-        mode: 0644
-      when:
-        - network_config_result.rc is defined
-        - network_config_result.rc == 0
-        - cloud_init_exists.stat.exists
-        - cloud_init_exists.stat.isdir
-
-    # os-net-config currently relies on the legacy network
-    # so we need to ensure it's enabled on boot. This should
-    # be removed when we switch to NetworkManager or replaced
-    # with something that ensures NetworkManager is enabled.
-    - name: Ensure network service is enabled
-      ansible.builtin.systemd:
-        name: network
-        enabled: true
-      when:
-        - edpm_network_config_manage_service
-        - not edpm_network_config_nmstate|bool
-        - not ansible_check_mode|bool
+- name: Load edpm_network_config tasks
+  ansible.builtin.include_tasks:
+    file: network_config.yml
+  when: edpm_network_config_role == 'os-net-config'

--- a/roles/edpm_network_config/tasks/network_config.yml
+++ b/roles/edpm_network_config/tasks/network_config.yml
@@ -50,7 +50,7 @@
     state: directory
     setype: container_file_t
     selevel: s0
-    mode: 0750
+    mode: '0750'
 
 - name: Check for previous run of NetworkConfig
   become: true

--- a/roles/edpm_network_config/tasks/network_config.yml
+++ b/roles/edpm_network_config/tasks/network_config.yml
@@ -122,7 +122,7 @@
       ansible.builtin.copy:
         content: "{{ network_config_result.rc }}"
         dest: /var/lib/edpm-config/os-net-config.returncode
-        mode: 0644
+        mode: '0644'
       when:
         - network_config_result.rc is defined
 
@@ -133,7 +133,7 @@
           network:
             config: disabled
         dest: /etc/cloud/cloud.cfg.d/99-edpm-disable-network-config.cfg
-        mode: 0644
+        mode: '0644'
       when:
         - network_config_result.rc is defined
         - network_config_result.rc == 0

--- a/roles/edpm_network_config/tasks/network_config.yml
+++ b/roles/edpm_network_config/tasks/network_config.yml
@@ -85,14 +85,14 @@
     - (edpm_network_config_update) or
       (os_net_config_returncode_stat.stat.exists and
       ((os_net_config_returncode_slurp.content | b64decode | int) != 0)) or
-       (not os_net_config_returncode_stat.stat.exists)
+      (not os_net_config_returncode_stat.stat.exists)
   block:
     - name: Create /etc/os-net-config directory
       become: true
       ansible.builtin.file:
         path: /etc/os-net-config
         state: directory
-        recurse: true
+        mode: '0755'
 
     - name: Create os-net-config mappings from lookup data
       edpm_os_net_config_mappings:
@@ -105,7 +105,7 @@
       ansible.builtin.copy:
         content: "{{ os_net_config_mappings_result.mapping | to_nice_yaml }}"
         dest: /etc/os-net-config/mapping.yaml
-        mode: 0644
+        mode: '0644'
       when: os_net_config_mappings_result.changed|bool
 
     - name: Manage NetworkConfig with edpm_os_net_config module
@@ -126,7 +126,7 @@
       when:
         - network_config_result.rc is defined
 
-    # LP Bug: https://bugs.launchpad.net/edpm/+bug/1958332
+    # LP Bug: https://bugs.launchpad.net/tripleo/+bug/1958332
     - name: Disable cloud-init network config
       ansible.builtin.copy:
         content: |

--- a/roles/edpm_network_config/tasks/network_config.yml
+++ b/roles/edpm_network_config/tasks/network_config.yml
@@ -38,6 +38,11 @@
     name: edpm_bootstrap
     tasks_from: packages.yml
 
+- name: Install os-net-config package
+  ansible.builtin.dnf:
+    name: os-net-config
+    state: latest
+
 - name: Ensure /var/lib/edpm-config directory exists
   become: true
   ansible.builtin.file:

--- a/roles/edpm_network_config/tasks/network_config.yml
+++ b/roles/edpm_network_config/tasks/network_config.yml
@@ -1,0 +1,149 @@
+---
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Gather SELinux fact if needed
+  when:
+    - ansible_facts.selinux is undefined
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - "!min"
+      - "selinux"
+
+- name: Create fcontext entry for edpmconfig
+  become: true
+  when:
+    - ansible_facts.selinux.status == "enabled"
+  sefcontext:
+    target: "/var/lib/edpm-config(/.*)?"
+    setype: container_file_t
+    selevel: s0
+    state: present
+
+- name: Ensure requirements are satisfied
+  ansible.builtin.include_role:
+    name: edpm_bootstrap
+    tasks_from: packages.yml
+
+- name: Ensure /var/lib/edpm-config directory exists
+  become: true
+  ansible.builtin.file:
+    path: /var/lib/edpm-config
+    state: directory
+    setype: container_file_t
+    selevel: s0
+    mode: 0750
+
+- name: Check for previous run of NetworkConfig
+  become: true
+  ansible.builtin.stat:
+    path: /var/lib/edpm-config/os-net-config.returncode
+  register: os_net_config_returncode_stat
+
+- name: Check result of previous run of NetworkConfig
+  become: true
+  ansible.builtin.slurp:
+    path: /var/lib/edpm-config/os-net-config.returncode
+  when: os_net_config_returncode_stat.stat.exists
+  register: os_net_config_returncode_slurp
+
+- name: Ensure we get cloud-init
+  ansible.builtin.stat:
+    path: /etc/cloud/cloud.cfg.d
+  register: cloud_init_exists
+
+- name: NetworkConfig
+  become: true
+  # The conditions here are when we want to apply the
+  # NetworkConfig. They are:
+  # - If edpm_network_config_update is True
+  # - Or the previous run of NetworkConfig failed.
+  # - Or it has never run
+  # This will match the prior behavior of when a Heat
+  # SoftwareDeployment was used.
+  # It also ensures the script does exist as a sine qua non
+  # condition
+  when:
+    - (edpm_network_config_update) or
+      (os_net_config_returncode_stat.stat.exists and
+      ((os_net_config_returncode_slurp.content | b64decode | int) != 0)) or
+       (not os_net_config_returncode_stat.stat.exists)
+  block:
+    - name: Create /etc/os-net-config directory
+      become: true
+      ansible.builtin.file:
+        path: /etc/os-net-config
+        state: directory
+        recurse: true
+
+    - name: Create os-net-config mappings from lookup data
+      edpm_os_net_config_mappings:
+        net_config_data_lookup:
+          "{{ edpm_network_config_os_net_config_mappings }}"
+      when: not ansible_check_mode|bool
+      register: os_net_config_mappings_result
+
+    - name: Write os-net-config mappings file /etc/os-net-config/mapping.yaml
+      ansible.builtin.copy:
+        content: "{{ os_net_config_mappings_result.mapping | to_nice_yaml }}"
+        dest: /etc/os-net-config/mapping.yaml
+        mode: 0644
+      when: os_net_config_mappings_result.changed|bool
+
+    - name: Manage NetworkConfig with edpm_os_net_config module
+      block:
+        - name: Remove /var/lib/edpm-config/scripts directory
+          ansible.builtin.file:
+            path: /var/lib/edpm-config/scripts
+            state: absent
+
+        - name: Run NetworkConfig with edpm_os_net_config
+          ansible.builtin.include_tasks: os_net_config.yml
+
+    - name: Write rc of NetworkConfig script
+      ansible.builtin.copy:
+        content: "{{ network_config_result.rc }}"
+        dest: /var/lib/edpm-config/os-net-config.returncode
+        mode: 0644
+      when:
+        - network_config_result.rc is defined
+
+    # LP Bug: https://bugs.launchpad.net/edpm/+bug/1958332
+    - name: Disable cloud-init network config
+      ansible.builtin.copy:
+        content: |
+          network:
+            config: disabled
+        dest: /etc/cloud/cloud.cfg.d/99-edpm-disable-network-config.cfg
+        mode: 0644
+      when:
+        - network_config_result.rc is defined
+        - network_config_result.rc == 0
+        - cloud_init_exists.stat.exists
+        - cloud_init_exists.stat.isdir
+
+    # os-net-config currently relies on the legacy network
+    # so we need to ensure it's enabled on boot. This should
+    # be removed when we switch to NetworkManager or replaced
+    # with something that ensures NetworkManager is enabled.
+    - name: Ensure network service is enabled
+      ansible.builtin.systemd:
+        name: network
+        enabled: true
+      when:
+        - edpm_network_config_manage_service
+        - not edpm_network_config_nmstate|bool
+        - not ansible_check_mode|bool

--- a/roles/edpm_network_config/tasks/os_net_config.yml
+++ b/roles/edpm_network_config/tasks/os_net_config.yml
@@ -28,7 +28,7 @@
       ansible.builtin.copy:
         content: "{{ edpm_network_config_override | to_yaml }}"
         dest: "{{ nic_config_file }}"
-        mode: 0644
+        mode: '0644'
         backup: true
       when:
         - edpm_network_config_override.keys()|length > 0
@@ -37,7 +37,7 @@
       ansible.builtin.template:
         src: "{{ edpm_network_config_template }}"
         dest: "{{ nic_config_file }}"
-        mode: 0644
+        mode: '0644'
         backup: true
       when:
         - edpm_network_config_override.keys()|length == 0


### PR DESCRIPTION
In the `edpm_config_network` role we have added the `edpm_network_config_role` variable that control the way how networking should be configured on edpm compute nodes.

The default value, `os-net-config`, will continue to configure the network with `os-net-config`.

Setting the value to `nmstate` the `network` role from linux-system-roles/rhel-system-roles will be used. This allow to configure interfaces using `nmstate` as its backend. See the [examples](https://nmstate.io/) on nmstate website to learn how to configure interfaces.

A short example is provided in molecule/nmstate scenario.