### PR TITLE
Add edpm_bootstrap_command

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -49,3 +49,7 @@ edpm_bootstrap_network_service: NetworkManager
 
 # String for SELinux state. One of: disabled, enforcing, permissive
 edpm_bootstrap_selinux_mode: enforcing
+
+# Shell command that is executed before any packages are installed by the role.
+# Can be used to register systems using any arbitrary registration command(s).
+edpm_bootstrap_command: ""

--- a/roles/edpm_bootstrap/molecule/default/converge.yml
+++ b/roles/edpm_bootstrap/molecule/default/converge.yml
@@ -6,3 +6,7 @@
     - name: "Include edpm_bootstrap"
       ansible.builtin.include_role:
         name: "osp.edpm.edpm_bootstrap"
+      vars:
+        edpm_bootstrap_command: |
+          touch /tmp/edpm_bootstrap_command
+          ls -l /tmp

--- a/roles/edpm_bootstrap/molecule/default/molecule.yml
+++ b/roles/edpm_bootstrap/molecule/default/molecule.yml
@@ -27,4 +27,5 @@ scenario:
     - create
     - prepare
     - converge
+    - verify
     - destroy

--- a/roles/edpm_bootstrap/molecule/default/verify.yml
+++ b/roles/edpm_bootstrap/molecule/default/verify.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Verify
+  hosts: all
+  tasks:
+
+    - name: Verify bootstrap command created expected file
+      stat:
+        path: /tmp/edpm_bootstrap_command
+      register: bootstrap_stat
+      failed_when: not bootstrap_stat.stat.exists

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -72,6 +72,22 @@
   tags:
     - always
 
+- name: Bootstrap command
+  become: true
+  when: edpm_bootstrap_command != ""
+  block:
+    - name: Bootstrap command
+      shell: "{{ edpm_bootstrap_command }}"
+      register: bootstrap_cmd
+      failed_when: false
+
+    - name: Bootstrap command output
+      debug:
+        msg:
+          stdout: "{{ bootstrap_cmd.stdout_lines }}"
+          stderr: "{{ bootstrap_cmd.stderr_lines }}"
+      failed_when: bootstrap_cmd.rc != 0
+
 # Currently only supported on RHEL as edpm does not have a version package
 - name: Release version package
   when:


### PR DESCRIPTION
edpm_bootstrap_command is a variable for a shell command that will be
run early in the edpm_boostrap role tasks, before any package installs.
It can be used to register systems in order to enable package
repositories.

Signed-off-by: James Slagle <jslagle@redhat.com>
