### PR TITLE
Add tripleo-repos package to Containerfile.j2 template

### DIFF
--- a/molecule/common/Containerfile.j2
+++ b/molecule/common/Containerfile.j2
@@ -5,8 +5,10 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN dnf upgrade -y && \
+RUN curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos9-wallaby/current/delorean.repo && \
+    dnf upgrade -y && \
     dnf -y install sudo python3-libselinux selinux-policy {{ item.pkg_extras | default('') }} && \
+    dnf install -y python*tripleo-repos && \
     dnf clean all -y
 
 CMD [ '/sbin/init' ]


### PR DESCRIPTION
The tripleo-repos are now installed in container generally, in contrary with the test_deps role. Template was generated and successfully tested in local CentOS9 container, and the installation of required repos was successfull.