### PR TITLE
Added task to restart NM after plugin installation and improved `systemrolename` gathering

### DIFF
--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -20,14 +20,9 @@
       ansible.builtin.set_fact:
         systemrolename:
           "{%- if ansible_facts['distribution'] == 'RedHat' -%}
-            redhat
+            redhat.rhel
           {%- else -%}
-            fedora
-          {%- endif -%}.
-          {%- if ansible_facts['distribution'] == 'RedHat' -%}
-            rhel
-          {%- else -%}
-            linux
+            fedora.linux
           {%- endif -%}
           _system_roles.network"
       delegate_to: localhost
@@ -35,6 +30,10 @@
       ansible.builtin.dnf:
         name: NetworkManager-ovs
         state: latest
+    - name: Restart NetworkManager after plugin installation [nmstate]
+      ansible.builtin.systemd:
+        name: NetworkManager
+        state: restarted
     - name: Load system-roles.network tasks [nmstate]
       ansible.builtin.include_role:
         name: "{{ systemrolename }}"


### PR DESCRIPTION
The restart task is needed to avoid the error: 

```libnmstate.error.NmstateDependencyError: Manager(MissingPlugin):NetworkManager plugin for 'ovs-bridge' unavailable"```

despite the plugin is already installed.

The `systemrolename` fact gathering has been improved since an if/else conditional was redundant. 