### PR TITLE
Set make_edpm_compute_baremetal var

### DIFF
--- a/ci/playbooks/build_runner_image.yaml
+++ b/ci/playbooks/build_runner_image.yaml
@@ -35,7 +35,7 @@
         mode: 0644
         content: |
           make_edpm_deploy_env:
-            ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
-          make_edpm_compute_baremetal:
+            DATAPLANE_RUNNER_IMG: "{{ ansibleee_runner_img }}"
+          make_edpm_compute_baremetal_params:
             ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
         dest: "{{ ansible_user_dir }}/ci-framework/edpm-ansible.yml"

--- a/ci/playbooks/build_runner_image.yaml
+++ b/ci/playbooks/build_runner_image.yaml
@@ -35,7 +35,7 @@
         mode: 0644
         content: |
           make_edpm_deploy_env:
-            DATAPLANE_RUNNER_IMG: "{{ ansibleee_runner_img }}"
+            ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
           make_edpm_compute_baremetal:
-            DATAPLANE_RUNNER_IMG: "{{ ansibleee_runner_img }}"
+            ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
         dest: "{{ ansible_user_dir }}/ci-framework/edpm-ansible.yml"

--- a/ci/playbooks/build_runner_image.yaml
+++ b/ci/playbooks/build_runner_image.yaml
@@ -36,4 +36,6 @@
         content: |
           make_edpm_deploy_env:
             DATAPLANE_RUNNER_IMG: "{{ ansibleee_runner_img }}"
+          make_edpm_compute_baremetal:
+            DATAPLANE_RUNNER_IMG: "{{ ansibleee_runner_img }}"
         dest: "{{ ansible_user_dir }}/ci-framework/edpm-ansible.yml"


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/install_yamls/pull/320 sets the openstack_runner_img for baremetal edpm deployment.

edpm-ansible baremetal edpm job builds the runner image. we can reuse the built runner image via make_edpm_compute_baremetal var.

It will help to test proper code in the CI.
