### PR TITLE
Add a boolean variable to control if NetworkManager should control resolv.conf update

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -47,6 +47,11 @@ edpm_bootstrap_legacy_network_packages:
   - openstack-network-scripts
 edpm_bootstrap_network_service: NetworkManager
 
+# Control resolv.conf management by NetworkManager
+# false = disable NetworkManager resolv.conf update (default)
+# true = enable NetworkManager resolv.conf update
+edpm_bootstrap_network_resolvconf_update: false
+
 # String for SELinux state. One of: disabled, enforcing, permissive
 edpm_bootstrap_selinux_mode: enforcing
 

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -150,7 +150,7 @@
 
 - name: Stop NetworkManager from updating resolv.conf
   become: true
-  when: edpm_bootstrap_network_service == 'NetworkManager'
+  when: (edpm_bootstrap_network_service == 'NetworkManager') and (edpm_bootstrap_network_resolvconf_update == false)
   block:
     - name: Set 'dns=none' in /etc/NetworkManager/NetworkManager.conf
       community.general.ini_file:


### PR DESCRIPTION
When nmstate is used, resolv.conf should be updated by NetworkManager.

Using this variable allows us to control this behaviour.