### PR TITLE
Restart NetworkManager only when needed and renamed task

### DIFF
--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -26,14 +26,16 @@
           {%- endif -%}
           _system_roles.network"
       delegate_to: localhost
-    - name: Install required package [nmstate]
+    - name: Install OVS NetworkManager plugin [nmstate]
       ansible.builtin.dnf:
         name: NetworkManager-ovs
         state: latest
+      register: nm_ovs_status
     - name: Restart NetworkManager after plugin installation [nmstate]
       ansible.builtin.systemd:
         name: NetworkManager
         state: restarted
+      when: nm_ovs_status.changed
     - name: Load system-roles.network tasks [nmstate]
       ansible.builtin.include_role:
         name: "{{ systemrolename }}"


### PR DESCRIPTION
It's not necessary and potentially dangerous to restart NetworkManager if it's not needed, so we will check the state of the dnf task to monitor if it's changed.

Also, the task name now explains what is going to be installed.