### PR TITLE
Optimized the dependencies needed by molecule

### DIFF
--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -1,23 +1,5 @@
-# this is required for the molecule jobs
-ansi2html
-dogpile.cache>=0.9.2
-openstacksdk
-pytest
-pytest-cov
-pytest-html
-pytest-testinfra
-pytest-xdist
-mock
-molecule>=3.3.4
-molecule-plugins[podman]
-ruamel.yaml
-netaddr
-jinja2
+ansible-core==2.14.6
 jmespath
-ansible-core
-ansible-compat<4 # https://github.com/ansible-community/molecule/issues/3903
-
-# Upstream requirements from constraints.txt
-os-net-config  # Apache-2.0
-# Allows to unpin cryptography
-pyOpenSSL>=22.1.0
+molecule>=5.1.0
+molecule-plugins[podman]>=23.4.0
+pytest-testinfra


### PR DESCRIPTION
Probably most of them were residues from the initial import.

The only packages required now are:
* `ansible-core` pinned to the version that we are using both on upstream and downstream
* `molecule` (last version compatibile with ansible version)
* `molecule-plugins` (last version compatible with molecule version)
* `jmespath` (required by molecule tests)
* `pytest-testinfra` (required by molecule tests)