### PR TITLE
Set ansible runner image var for edpm_prepare role

### DIFF
--- a/ci/playbooks/build_runner_image.yaml
+++ b/ci/playbooks/build_runner_image.yaml
@@ -34,8 +34,5 @@
       ansible.builtin.copy:
         mode: 0644
         content: |
-          make_edpm_deploy_env:
-            DATAPLANE_RUNNER_IMG: "{{ ansibleee_runner_img }}"
-          make_edpm_compute_baremetal_params:
-            ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
+          cifmw_edpm_prepare_ansible_runner_image: "{{ ansibleee_runner_img }}"
         dest: "{{ ansible_user_dir }}/ci-framework/edpm-ansible.yml"


### PR DESCRIPTION
With this commit, we set ansible runner image var for edpm_prepare role, so that in edpm_prepare we can Patch openstack-ansibleee-operator CSV with the correct image which we build in job.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/339
Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/203
Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/232