### PR TITLE
Changed root size in growvols defaults

### DIFF
--- a/roles/edpm_growvols/defaults/main.yml
+++ b/roles/edpm_growvols/defaults/main.yml
@@ -16,7 +16,7 @@
 
 
 growvols_args: >
-  /=8GB
+  /=15GB
   /tmp=1GB
   /var/log=10GB
   /var/log/audit=2GB


### PR DESCRIPTION
Since we're creating a swapfile when a swap partition isn't present due to https://github.com/openstack-k8s-operators/edpm-ansible/pull/156, let's extend the root partition size to reserve some space for the swapfile itself.