### PR TITLE
Full documentation for edpm_network_config role endpoint

### DIFF
--- a/plugins/modules/edpm_os_net_config.py
+++ b/plugins/modules/edpm_os_net_config.py
@@ -64,7 +64,7 @@ options:
   safe_defaults:
     description:
       - If enabled, safe defaults (DHCP for all interfaces) will be applied in
-        case of failuring while applying the provided net config.
+        case of failing while applying the provided net config.
     type: bool
     default: false
   use_nmstate:

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -38,7 +38,6 @@ edpm_network_config_manage_service: true
 edpm_network_config_nmstate: false
 edpm_network_config_os_net_config_mappings: {}
 edpm_network_config_safe_defaults: true
-edpm_network_config_with_ansible: true
 edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
 edpm_network_config_override: {}
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -3,4 +3,69 @@ argument_specs:
   # ./roles/edpm_network_config/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_network_config role.
-    options: {}
+    options:
+      edpm_network_config_tool:
+        type: str
+        description: Which network config tool should be used
+        default: os-net-config
+        choices:
+          - os-net-config
+          - nmstate
+      edpm_network_config_update:
+        type: bool
+        description: Apply NetworkConfig or not
+        default: false
+      edpm_network_config_async_poll:
+        type: int
+        description: "How often will the edpm_os_net_config module be polled."
+        default: 3
+      edpm_network_config_async_timeout:
+        type: int
+        description: "Time before edpm_os_net_config call times out."
+        default: 300
+      edpm_network_config_debug:
+        type: bool
+        description: "Debugging output enabled"
+        default: false
+      edpm_network_config_hide_sensitive_logs:
+        type: bool
+        description: "Hide logs of potentially sensitive nature."
+        default: true
+      edpm_network_config_manage_service:
+        type: bool
+        description: "Enable the network service or not"
+        default: true
+      edpm_network_config_nmstate:
+        type: bool
+        description: "If enabled, use nmstate and network manager for network configuration."
+        default: false
+      edpm_network_config_os_net_config_mappings:
+        type: dict
+        description: "Per node and/or per node group configuration map. Used by the edpm_os_net_config_mappings module."
+        default: {}
+      edpm_network_config_safe_defaults:
+        type: bool
+        description: >
+          If enabled, safe defaults (DHCP for all interfaces) will be applied in
+          case of failing while applying the provided net config.
+        default: true
+      edpm_network_config_template:
+        type: path
+        description: "Which settings template should be rendered."
+        default: templates/single_nic_vlans/single_nic_vlans.j2
+      edpm_network_config_override:
+        type: dict
+        description: "Optional template content overrides"
+        default: {}
+      edpm_bond_interface_ovs_options:
+        type: str
+        description: "Binding options to be rendered in a template"
+        default: "bond_mode=active-backup"
+      neutron_physical_bridge_name:
+        type: str
+        description: "Name of the physical bridge"
+        default: br-ex
+      neutron_public_interface_name:
+        type: str
+        description: "Name of the public network interface"
+        default: nic1


### PR DESCRIPTION
Each variable now has a type, default value and basic info.

Several variables were removed, as they are not used by the role.

Namely:
 - edpm_network_config_with_ansible

Typo in the edpm_os_net_config module was fixed.