### PR TITLE
Check if we have required python version available before running tests

### DIFF
--- a/scripts/molecule_venv.sh
+++ b/scripts/molecule_venv.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 LOCAL_MOLECULE_ENV=$(mktemp -d)/molecule
-python -m venv $LOCAL_MOLECULE_ENV
+if which python3.9 2>/dev/null; then
+    python3.9 -m venv $LOCAL_MOLECULE_ENV
+else
+    echo WARNING: python3.9 binary is not in path. Tests will run with system python: $(python --version) at $(which python)
+    python -m venv $LOCAL_MOLECULE_ENV
+fi
+
 source $LOCAL_MOLECULE_ENV/bin/activate
 pip install -r molecule-requirements.txt
 ./scripts/test_roles.py


### PR DESCRIPTION
Collection was built with python 3.9 in mind, however it is possible that when molecule tests are executed on a local machine other python versions may be used to create the venv.

This patch introduces a mechanism, which checks if the appropriate python version is present on the system, and if not prints a warning indicating that the default will be used instead.