### PR TITLE
Removing ununsed debug args

### DIFF
--- a/roles/edpm_ceph_client_files/defaults/main.yml
+++ b/roles/edpm_ceph_client_files/defaults/main.yml
@@ -18,7 +18,6 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_ceph_client_files"
-edpm_ceph_client_files_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 edpm_ceph_client_files_hide_sensitive_logs: true
 edpm_ceph_client_files_source: '/etc/ceph'
 edpm_ceph_client_files_config_home: "{{ edpm_ceph_client_config_home | default('/etc/ceph/') }}"

--- a/roles/edpm_chrony/README.rst
+++ b/roles/edpm_chrony/README.rst
@@ -13,9 +13,6 @@ Role Variables
    * - Name
      - Default Value
      - Description
-   * - `edpm_chrony_debug`
-     - `False`
-     - Enable debug option in chrony
    * - `edpm_chrony_role_action`
      - `all`
      - Ansible action when including the role. Should be one of: [all|install|config|upgrade|online]

--- a/roles/edpm_chrony/defaults/main.yml
+++ b/roles/edpm_chrony/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-edpm_chrony_debug: false
 edpm_chrony_role_action: all
 edpm_chrony_global_server_settings: iburst minpoll 6 maxpoll 10
 edpm_chrony_global_pool_settings: iburst minpoll 6 maxpoll 10

--- a/roles/edpm_container_manage/defaults/main.yml
+++ b/roles/edpm_container_manage/defaults/main.yml
@@ -17,7 +17,6 @@
 
 # All variables intended for modification should place placed in this file.
 edpm_container_manage_hide_sensitive_logs: "{{ hide_sensitive_logs | default(true) }}"
-edpm_container_manage_debug: "{{ ((ansible_verbosity | int) >= 2) | bool }}"
 edpm_container_manage_clean_orphans: true
 
 # All variables within this role should have a prefix of "edpm_container_manage"

--- a/roles/edpm_container_manage/meta/argument_specs.yml
+++ b/roles/edpm_container_manage/meta/argument_specs.yml
@@ -7,9 +7,6 @@ argument_specs:
       edpm_container_manage_hide_sensitive_logs:
         type: str
         default: "{{ hide_sensitive_logs | default(true) }}"
-      edpm_container_manage_debug:
-        type: str
-        default: "{{ ((ansible_verbosity | int) >= 2) | bool }}"
       edpm_container_manage_clean_orphans:
         type: bool
         default: true

--- a/roles/edpm_container_manage/molecule/default/converge.yml
+++ b/roles/edpm_container_manage/molecule/default/converge.yml
@@ -20,7 +20,6 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_debug: true
     edpm_container_manage_config_patterns: '*.json'
   tasks:
     - include_role:
@@ -86,7 +85,6 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_debug: true
     edpm_container_manage_config_patterns: '*.json'
   tasks:
     - name: Gather facts about centos container before new run
@@ -119,7 +117,6 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_debug: true
     edpm_container_manage_config_patterns: '*.json'
   tasks:
     - name: Stop systemd service for edpm_centos in a manual stop
@@ -151,7 +148,6 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_debug: true
     edpm_container_manage_config_patterns: 'centos.json'
     edpm_container_manage_clean_orphans: false
     edpm_container_manage_config_overrides:
@@ -197,7 +193,6 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_debug: true
     edpm_container_manage_config_patterns: 'centos.json'
     edpm_container_manage_clean_orphans: false
   tasks:
@@ -234,7 +229,6 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_debug: true
     edpm_container_manage_config_patterns: 'centos_*.json'
   tasks:
     - name: Remove centos container config
@@ -267,7 +261,6 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_debug: true
     edpm_container_manage_config_patterns: 'centos_*.json'
   tasks:
     - name: Modify the centos_bis container config
@@ -309,7 +302,6 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_debug: true
     edpm_container_manage_config_patterns: 'centos_*.json'
     edpm_container_manage_config_overrides:
       centos_bis:

--- a/roles/edpm_container_manage/tasks/create.yml
+++ b/roles/edpm_container_manage/tasks/create.yml
@@ -38,7 +38,6 @@
   become: true
   container_systemd:
     container_config: "{{ container_config }}"
-    debug: "{{ edpm_container_manage_debug | bool }}"
     systemd_healthchecks: "{{ (not edpm_container_manage_healthcheck_disabled | bool) }}"
   vars:
     container_config: "{{ all_containers_hash | osp.edpm.dict_to_list | osp.edpm.haskey(attribute='restart', value=['always','unless-stopped'], any=True) | default([]) }}"

--- a/roles/edpm_container_manage/tasks/delete_orphan.yml
+++ b/roles/edpm_container_manage/tasks/delete_orphan.yml
@@ -17,7 +17,6 @@
 - name: Gather podman infos
   containers.podman.podman_container_info: {}
   register: podman_containers
-  no_log: "{{ not (edpm_container_manage_debug | bool) }}"
   when:
     - edpm_container_manage_cli == 'podman'
 

--- a/roles/edpm_container_manage/tasks/main.yml
+++ b/roles/edpm_container_manage/tasks/main.yml
@@ -42,14 +42,12 @@
   become: true
 
 - name: Generate containers configs data
-  no_log: "{{ not edpm_container_manage_debug }}"
   block:
     - name: "Find all matching configs configs for in {{ edpm_container_manage_config }}"
       container_config_data:
         config_path: "{{ edpm_container_manage_config }}"
         config_pattern: "{{ edpm_container_manage_config_patterns }}"
         config_overrides: "{{ edpm_container_manage_config_overrides }}"
-        debug: "{{ edpm_container_manage_debug }}"
       register: container_config_data
     - name: Finalise hashes for all containers
       ansible.builtin.set_fact:

--- a/roles/edpm_container_standalone/defaults/main.yml
+++ b/roles/edpm_container_standalone/defaults/main.yml
@@ -18,8 +18,6 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_container_standalone"
-edpm_container_standalone_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
-
 edpm_container_standalone_hide_sensitive_logs: true
 
 # Service name. Use for creating directories, container labels, etc

--- a/roles/edpm_hosts_entries/defaults/main.yml
+++ b/roles/edpm_hosts_entries/defaults/main.yml
@@ -18,7 +18,6 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_hosts_entries"
-edpm_hosts_entries_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 edpm_hosts_entries_hosts_path: /etc/hosts
 edpm_hosts_entries_undercloud_hosts_entries: ""
 edpm_hosts_entries_extra_hosts_entries: ""

--- a/roles/edpm_logrotate_crond/defaults/main.yml
+++ b/roles/edpm_logrotate_crond/defaults/main.yml
@@ -18,7 +18,6 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_logrotate_crond"
-edpm_logrotate_crond_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 
 edpm_logrotate_crond_hide_sensitive_logs: true
 

--- a/roles/edpm_logrotate_crond/molecule/default/converge.yml
+++ b/roles/edpm_logrotate_crond/molecule/default/converge.yml
@@ -18,7 +18,6 @@
 - name: Converge
   hosts: all
   vars:
-    edpm_container_manage_debug: true
   tasks:
 
     - name: install edpm_logrotate_crond

--- a/roles/edpm_nodes_validation/defaults/main.yml
+++ b/roles/edpm_nodes_validation/defaults/main.yml
@@ -18,7 +18,6 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_nodes_validation"
-edpm_nodes_validation_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 edpm_nodes_validation_hide_sensitive_logs: true
 edpm_nodes_validation_ping_test_ips: []
 edpm_nodes_validation_edpm_role_name: true

--- a/roles/edpm_podman/defaults/main.yml
+++ b/roles/edpm_podman/defaults/main.yml
@@ -17,7 +17,6 @@
 
 # All variables intended for modification should be placed in this file.
 edpm_podman_hide_sensitive_logs: "{{ hide_sensitive_logs | default(true) }}"
-edpm_podman_debug: "{{ ((ansible_verbosity | int) >= 2) | bool }}"
 
 edpm_podman_buildah_login: false
 edpm_container_registry_insecure_registries: []

--- a/roles/edpm_telemetry/tasks/deploy_ceilometer.yml
+++ b/roles/edpm_telemetry/tasks/deploy_ceilometer.yml
@@ -65,7 +65,6 @@
   vars:
     edpm_container_manage_config: '/var/lib/openstack/config/containers'
     edpm_container_manage_healthcheck_disabled: true
-    edpm_container_manage_debug: true
     edpm_container_manage_config_patterns: 'ceilometer_agent_compute.json'
     edpm_container_manage_clean_orphans: false
   tags:


### PR DESCRIPTION
Many of our roles have debug arguments with no effect on the role behavior. These arguments are often set by referring to the ansible runtime verbosity level. In cases when these arguments are not used anywhere else in edpm_ansible collection or in the wider codebase, I believe it's safe to remove them.