### PR TITLE
Update ee runner image var using set_openstack_containers role

### DIFF
--- a/ci/playbooks/build_runner_image.yaml
+++ b/ci/playbooks/build_runner_image.yaml
@@ -34,5 +34,8 @@
       ansible.builtin.copy:
         mode: 0644
         content: |
-          cifmw_edpm_prepare_ansible_runner_image: "{{ ansibleee_runner_img }}"
+          cifmw_edpm_prepare_update_os_containers: true
+          cifmw_set_openstack_containers_operator_name: openstack-ansibleee
+          cifmw_set_openstack_containers_overrides:
+            ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
         dest: "{{ ansible_user_dir }}/ci-framework/edpm-ansible.yml"


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/319 adds a role to update the env variables in any service operator.

Let's use the same to update it.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/364