### PR TITLE
Use ansible_hostname rather than fqdn for hostname

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -66,7 +66,7 @@ edpm_ovn_controller_tls_volumes:
 
 # Set external_id data from provided variables
 edpm_ovn_ovs_external_ids:
-  hostname: "{{ ansible_facts['fqdn'] }}"
+  hostname: "{{ ansible_hostname }}"
   ovn-bridge: "{{ edpm_ovn_bridge }}"
   ovn-bridge-mappings: "{{ edpm_ovn_bridge_mappings | join(',') }}"
   ovn-chassis-mac-mappings:


### PR DESCRIPTION
I think it should be the nodeName[1] and not fqdn. 
$$echo $(oc get pod ovn-controller-6l7t2 -o "jsonpath={.spec.nodeName}")
crc-8cf2w-master-0

[1] https://github.com/openstack-k8s-operators/ovn-operator/blob/main/pkg/ovncontroller/configjob.go#L68