### PR TITLE
Limiting pyyaml use in documentation build to stable versions

### DIFF
--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -9,3 +9,4 @@ ruamel.yaml
 antsibull-docs >= 2.0.0, < 3.0.0
 ansible-pygments >= 0.1.1
 sphinx-ansible-theme >= 0.9.0
+pyyaml!=6.0.0,!=5.4.0,!=5.4.1 # https://github.com/yaml/pyyaml/issues/601


### PR DESCRIPTION
[Regression ](https://github.com/yaml/pyyaml/issues/601) in the pyyaml build caused by switch to incompatible cythton can potentially cripple our doc build.
This PR excludes affected versions of the pyyaml library so they can't be loaded as n-th order dependencies


Regresssion: https://github.com/yaml/pyyaml/issues/601 
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/398