### PR TITLE
Add new network template

### DIFF
--- a/roles/edpm_network_config/templates/ci/extracted_crc_nic2_vlans.j2
+++ b/roles/edpm_network_config/templates/ci/extracted_crc_nic2_vlans.j2
@@ -1,0 +1,32 @@
+---
+{# This template is for extracted CRC layout -#}
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}
+  mtu: {{ min_viable_mtu }}
+  use_dhcp: false
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ dns_search_domains }}
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+  routes: {{ ctlplane_host_routes }}
+  members:
+  - type: interface
+    name: nic2
+    mtu: {{ min_viable_mtu }}
+    # force the MAC address of the bridge to this interface
+    primary: true
+{% for network in role_networks %}
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask:
+        {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}


### PR DESCRIPTION
With the new CI layout, having a dedicated nodeset for CRC alongside a
dedicated Compute, we need to get a dedicated network template file in
order to consume the right interface - eth1, aka nic2.

That "nic2" interface is associated to a private, dedicated network in
order to allow network isolation to proceed, exactly like late OVB jobs
in TripleO CI ecosystem.

This patch therefore adds a new "ci" dedicated template we can then
consume from within the ci-framework, ensuring we're using the correct
interface.

Note: this is hopefully a temporary workaround - the ansibleVars we
should use is, for now, a string, and we can't edit it with kustomize.
There's a plan to change its type, allowing proper edition of the
mapping.

Signed-off-by: Cédric Jeanneret <cjeanner@redhat.com>