### PR TITLE
Exclude edpm_ddp_package molecule test from being executed locally

### DIFF
--- a/scripts/test_roles.py
+++ b/scripts/test_roles.py
@@ -13,6 +13,7 @@ SKIP_LIST = [
     "edpm_chrony",
     "edpm_podman",
     "edpm_ceph_client_files",
+    "edpm_ddp_package",
     "edpm_frr",
     "edpm_growvols",
     "edpm_kernel",


### PR DESCRIPTION
It's almost useless to execute this test:

* it needs linux-firmware package installed (we can install it in a container but still...)
* it needs to load that module (we can mock that, but, again...)

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/398

