### PR TITLE
Removing remnants of the edpm_nvdimm role

### DIFF
--- a/roles/edpm_nvdimm/meta/argument_specs.yml
+++ b/roles/edpm_nvdimm/meta/argument_specs.yml
@@ -1,6 +1,0 @@
----
-argument_specs:
-  # ./roles/edpm_nvdimm/tasks/main.yml entry point
-  main:
-    short_description: The main entry point for the edpm_nvdimm role.
-    options: {}

--- a/scripts/test_roles.py
+++ b/scripts/test_roles.py
@@ -17,7 +17,6 @@ SKIP_LIST = [
     "edpm_frr",
     "edpm_growvols",
     "edpm_kernel",
-    "edpm_nvdimm",
     "edpm_ovn_bgp_agent",
     "test_deps"
 ]


### PR DESCRIPTION
Due to an oversight during the argspec implementation, the edpm_nvdimm role wasn't entirely removed from the repo. This patch also removes the role from the list of roles locally tested with molecule.