### PR TITLE
Argspec for edpm_iscsid role

### DIFF
--- a/roles/edpm_iscsid/defaults/main.yml
+++ b/roles/edpm_iscsid/defaults/main.yml
@@ -32,4 +32,4 @@ edpm_iscsid_volumes:
   - /etc/target:/etc/target:z
   - /var/lib/iscsi:/var/lib/iscsi:z
 
-edpm_iscsid_chap_algs: 'SHA3-256,SHA256,SHA1,MD5'
+edpm_iscsid_chap_algs: 'SHA3-256,SHA256,SHA1'

--- a/roles/edpm_iscsid/defaults/main.yml
+++ b/roles/edpm_iscsid/defaults/main.yml
@@ -20,8 +20,6 @@
 # All variables within this role should have a prefix of "edpm_iscsid"
 edpm_iscsid_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 
-edpm_iscsid_hide_sensitive_logs: true
-
 edpm_iscsid_image: "quay.io/podified-antelope-centos9/openstack-iscsid:current-podified"
 edpm_iscsid_config_dir: /var/lib/config-data/ansible-generated/iscsid
 edpm_iscsid_volumes:

--- a/roles/edpm_iscsid/defaults/main.yml
+++ b/roles/edpm_iscsid/defaults/main.yml
@@ -21,7 +21,6 @@
 edpm_iscsid_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 
 edpm_iscsid_image: "quay.io/podified-antelope-centos9/openstack-iscsid:current-podified"
-edpm_iscsid_config_dir: /var/lib/config-data/ansible-generated/iscsid
 edpm_iscsid_volumes:
   - /var/lib/kolla/config_files/iscsid.json:/var/lib/kolla/config_files/config.json:ro
   - /dev:/dev

--- a/roles/edpm_iscsid/meta/argument_specs.yml
+++ b/roles/edpm_iscsid/meta/argument_specs.yml
@@ -32,5 +32,5 @@ argument_specs:
         description: List of iscsid volume mounts with permissions.
       edpm_iscsid_chap_algs:
         type: str
-        default: 'SHA3-256,SHA256,SHA1,MD5'
+        default: 'SHA3-256,SHA256,SHA1'
         description: List of allowed CHAP algorithms.

--- a/roles/edpm_iscsid/meta/argument_specs.yml
+++ b/roles/edpm_iscsid/meta/argument_specs.yml
@@ -15,9 +15,6 @@ argument_specs:
         type: str
         default: "quay.io/podified-antelope-centos9/openstack-iscsid:current-podified"
         description: URL of the iscsid container image.
-      edpm_iscsid_config_dir:
-        type: path
-        default: /var/lib/config-data/ansible-generated/iscsid
       edpm_iscsid_volumes:
         type: list
         default:

--- a/roles/edpm_iscsid/meta/argument_specs.yml
+++ b/roles/edpm_iscsid/meta/argument_specs.yml
@@ -3,4 +3,34 @@ argument_specs:
   # ./roles/edpm_iscsid/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_iscsid role.
-    options: {}
+    options:
+      edpm_iscsid_debug:
+        type: bool
+        default: false
+        description: |
+          Produce additional text messages describing role operation.
+          Set to false by default using following template:
+          {{ (ansible_verbosity | int) >= 2 | bool }}
+      edpm_iscsid_image:
+        type: str
+        default: "quay.io/podified-antelope-centos9/openstack-iscsid:current-podified"
+        description: URL of the iscsid container image.
+      edpm_iscsid_config_dir:
+        type: path
+        default: /var/lib/config-data/ansible-generated/iscsid
+      edpm_iscsid_volumes:
+        type: list
+        default:
+        - /var/lib/kolla/config_files/iscsid.json:/var/lib/kolla/config_files/config.json:ro
+        - /dev:/dev
+        - /run:/run
+        - /sys:/sys
+        - /lib/modules:/lib/modules:ro
+        - /etc/iscsi:/etc/iscsi:z
+        - /etc/target:/etc/target:z
+        - /var/lib/iscsi:/var/lib/iscsi:z
+        description: List of iscsid volume mounts with permissions.
+      edpm_iscsid_chap_algs:
+        type: str
+        default: 'SHA3-256,SHA256,SHA1,MD5'
+        description: List of allowed CHAP algorithms.


### PR DESCRIPTION
Patch also removes unused `edpm_iscsid_hide_sensitive_logs` variable.

The PR also removes MD5 from the list of approved hash algorithms.