### PR TITLE
Replace edpm_network_config_template with existing _override

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -38,6 +38,5 @@ edpm_network_config_manage_service: true
 edpm_network_config_nmstate: false
 edpm_network_config_os_net_config_mappings: {}
 edpm_network_config_safe_defaults: true
-edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-edpm_network_config_override: {}
+edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"

--- a/roles/edpm_network_config/molecule/default/converge.yml
+++ b/roles/edpm_network_config/molecule/default/converge.yml
@@ -18,7 +18,39 @@
 - name: Converge
   hosts: all
   vars:
-    edpm_network_config_template: templates/standalone.j2
+    edpm_network_config_template: |
+            ---
+            {% set control_virtual_ip = net_vip_map.ctlplane %}
+            {% set public_virtual_ip = vip_port_map.external.ip_address %}
+            {% if ':' in control_virtual_ip %}
+            {%   set control_virtual_cidr = 128 %}
+            {% else %}
+            {%   set control_virtual_cidr = 32 %}
+            {%   endif %}
+            {% if ':' in public_virtual_ip %}
+            {%   set public_virtual_cidr = 128 %}
+            {% else %}
+            {%   set public_virtual_cidr = 32 %}
+            {%   endif %}
+            network_config:
+            - type: ovs_bridge
+              name: br-ctlplane
+              use_dhcp: false
+              mtu: {{ ctlplane_mtu }}
+              ovs_extra:
+              - br-set-external-id br-ctlplane bridge-id br-ctlplane
+              addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+              - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+              - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+              routes: {{ ctlplane_host_routes }}
+              dns_servers: {{ ctlplane_dns_nameservers }}
+              domain: {{ dns_search_domains }}
+              members:
+                - type: interface
+                  name: {{ neutron_public_interface_name }}
+                  primary: true
+                  mtu: {{ ctlplane_mtu }}
     edpm_network_config_manage_service: false
     edpm_network_config_hide_sensitive_logs: false
     ctlplane_mtu: 1500

--- a/roles/edpm_network_config/tasks/os_net_config.yml
+++ b/roles/edpm_network_config/tasks/os_net_config.yml
@@ -23,24 +23,14 @@
     - name: Set nic_config_file fact
       ansible.builtin.set_fact:
         nic_config_file: "/etc/os-net-config/config.yaml"
-    - name: Render overidden network config
+    - name: Render network config
       no_log: "{{ edpm_network_config_hide_sensitive_logs | bool }}"
       ansible.builtin.copy:
-        content: "{{ edpm_network_config_override | to_yaml }}"
+        content: "{{ edpm_network_config_template }}"
         dest: "{{ nic_config_file }}"
         mode: '0644'
         backup: true
-      when:
-        - edpm_network_config_override.keys()|length > 0
-    - name: Render network_config from template
-      no_log: "{{ edpm_network_config_hide_sensitive_logs | bool }}"
-      ansible.builtin.template:
-        src: "{{ edpm_network_config_template }}"
-        dest: "{{ nic_config_file }}"
-        mode: '0644'
-        backup: true
-      when:
-        - edpm_network_config_override.keys()|length == 0
+
     - name: Run edpm_os_net_config_module with network_config
       edpm_os_net_config:
         config_file: "{{ nic_config_file }}"


### PR DESCRIPTION
Given the way this interface is leveraged via the dataplane-operator, it
doesn't make sense to define a file path. Instead, this change moves the
existing edpm_network_config_override to be the primary interface. It
has subsequently been renamed to edpm_network_config_template.
This allows users to define jinja2 strings for the variable, and they are
rendered out to compute nodes using the copy module.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/451