### PR TITLE
Argspecs for edpm_ceph_client_files

### DIFF
--- a/roles/edpm_ceph_client_files/defaults/main.yml
+++ b/roles/edpm_ceph_client_files/defaults/main.yml
@@ -18,6 +18,5 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_ceph_client_files"
-edpm_ceph_client_files_hide_sensitive_logs: true
 edpm_ceph_client_files_source: '/etc/ceph'
 edpm_ceph_client_files_config_home: "{{ edpm_ceph_client_config_home | default('/etc/ceph/') }}"

--- a/roles/edpm_ceph_client_files/meta/argument_specs.yml
+++ b/roles/edpm_ceph_client_files/meta/argument_specs.yml
@@ -3,4 +3,12 @@ argument_specs:
   # ./roles/edpm_ceph_client_files/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_ceph_client_files role.
-    options: {}
+    options:
+      edpm_ceph_client_files_config_home:
+        default: '{{ edpm_ceph_client_config_home | default(''/etc/ceph/'') }}'
+        description: Destination of ceph files on the remote machine.
+        type: str
+      edpm_ceph_client_files_source:
+        default: /etc/ceph
+        description: Location of the ceph files on `localhost`
+        type: str


### PR DESCRIPTION
The `edpm_ceph_client_files_hide_sensitive_logs` variable was removed as it wasn't used for anything.