### PR TITLE
Add templating support for nmstate defined networking configuration

### DIFF
--- a/roles/edpm_network_config/molecule/default/prepare.yml
+++ b/roles/edpm_network_config/molecule/default/prepare.yml
@@ -15,6 +15,7 @@
 # under the License.
 - name: Prepare test_deps
   hosts: all
+  become: true
   roles:
     - role: ../../../../molecule/common/test_deps
       test_deps_setup_edpm: true
@@ -27,12 +28,13 @@
 
   tasks:
     - name: Ensure legacy scripts installed
-      become: true
       ansible.builtin.package:
         name: network-scripts
         state: present
       when:
         - ansible_facts['distribution_major_version'] is version('8', '==')
     - name: Create a dummy network interface
-      become: true
       ansible.builtin.command: "ip link add dummy0 type dummy"
+      register: ip_command_output
+      changed_when: ip_command_output.rc == 0
+      failed_when: ip_command_output.rc != 0

--- a/roles/edpm_network_config/molecule/nmstate/converge.yml
+++ b/roles/edpm_network_config/molecule/nmstate/converge.yml
@@ -18,14 +18,19 @@
 - name: Converge
   hosts: all
   vars:
-    edpm_network_config_tool: nmstate
-    network_provider: nm
-    network_state:
+    # edpm_network_config - nmstate
+    edpm_network_config_tool: 'nmstate'
+    edpm_network_config_template: |
+      ---
       interfaces:
-      - name: dummy0
-        type: dummy
-        state: down
-        ipv4:
-          enabled: false
+        - name: dummy0
+          type: dummy
+          state: up
+          ipv4:
+            address:
+            - ip: 192.168.180.2
+              prefix-length: 24
+            dhcp: false
+            enabled: true
   roles:
-    - role: "osp.edpm.edpm_network_config"
+    - role: osp.edpm.edpm_network_config

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -38,6 +38,9 @@
         name: NetworkManager
         state: restarted
       when: nm_ovs_status.changed  # noqa: no-handler
+    - name: Render network_state variable
+      ansible.builtin.set_fact:
+        network_state: "{{ edpm_network_config_template | from_yaml }}"
     - name: Load system-roles.network tasks [nmstate]
       ansible.builtin.include_role:
         name: "{{ systemrolename }}"


### PR DESCRIPTION
* Fixed `nmstate` molecule scenario for `edpm_network_config` role