### PR TITLE
Setting regular expressions for zuul irrelevant-files list

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -38,15 +38,15 @@
           image_base: edpm
     irrelevant-files: &molecule_irrelevant_files
       - LICENSE
-      - OWNERS*
+      - OWNERS.*
       - README.md
-      - molecule/*
+      - molecule/.*
       - .github/workflows
-      - scripts/*
-      - docs/*
-      - contribute/*
+      - scripts/.*
+      - docs/.*
+      - contribute/.*
       - tests
-      - roles/*/molecule/*
+      - roles/.*/molecule/.*
 - job:
     name: edpm-ansible-crc-podified-edpm-deployment
     parent: cifmw-crc-podified-edpm-deployment


### PR DESCRIPTION
Zuul expects the list to consist of regular expressions. [0] The globs don't get rendered properly, leading to excessive job runs.

[0] https://zuul-ci.org/docs/zuul/latest/config/job.html#attr-job.irrelevant-files