### PR TITLE
Replace package module with dnf module

### DIFF
--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -100,7 +100,7 @@
       failed_when: false
     - name: Deploy release version package
       become: true
-      ansible.builtin.package:
+      ansible.builtin.dnf:
         name: "{{ edpm_bootstrap_release_version_package }}"
         state: present
       when:
@@ -137,7 +137,7 @@
       failed_when: false
 
     - name: Deploy network-scripts required for deprecated network service
-      ansible.builtin.package:
+      ansible.builtin.dnf:
         name: "{{ edpm_bootstrap_legacy_network_packages }}"
         state: present
       when:

--- a/roles/edpm_bootstrap/tasks/packages.yml
+++ b/roles/edpm_bootstrap/tasks/packages.yml
@@ -43,7 +43,7 @@
 
 - name: Deploy required packages to bootstrap EDPM
   become: true
-  ansible.builtin.package:
+  ansible.builtin.dnf:
     name: "{{ edpm_bootstrap_packages_bootstrap }}"
     state: present
   # When a node is deployed with overcloud-minimal, OVS isn't required so let's


### PR DESCRIPTION
It's pointless to continue to use the `package` module (which itself rely on an action plugin to be executed) since edpm-ansible only supports EL 8/9 targets.