### PR TITLE
remove O(n*m) loop from edpm_kernel

### DIFF
--- a/roles/edpm_kernel/tasks/main.yml
+++ b/roles/edpm_kernel/tasks/main.yml
@@ -58,7 +58,7 @@
       when:
         - _install_packages_result.changed or _modprobe_result.changed
 
-    - name: Set default sysctl options
+    - name: Render sysctl options
       ansible.builtin.template:
         src: "edpm-sysctl.conf.j2"
         dest: "/etc/sysctl.d/99-edpm.conf"
@@ -66,25 +66,11 @@
         owner: root
         group: root
         setype: etc_t
-      register: _default_sysctl_result
-
-    - name: Set extra sysctl options
-      ansible.posix.sysctl:
-        name: "{{ setting.key }}"
-        value: "{{ setting.opt.value }}"
-        sysctl_set: "{{ setting.opt.set | default(true) }}"
-        state: "{{ setting.opt.state | default('present') }}"
-        sysctl_file: "/etc/sysctl.d/99-edpm.conf"
-        reload: false
-      loop: "{{ edpm_kernel_sysctl_settings | combine(edpm_kernel_sysctl_extra_settings) | dict2items(key_name='key', value_name='opt') }}"
-      loop_control:
-        label: "{{ setting.key }}"
-        loop_var: setting
-      register: _extra_sysctl_result
+      register: _sysctl_result
 
     - name: Sysctl reload
       ansible.builtin.systemd:
         name: systemd-sysctl.service
         state: restarted
       when:
-        - _extra_sysctl_result.changed or _default_sysctl_result.changed
+        - _sysctl_result.changed


### PR DESCRIPTION
the orginal commit of edpm_kernel used the ansible.posix.sysctl modules
to set extra sysctl options in a loop. later pr #157
added the extra sysctl arg to the template and too the loop.

By adding edpm_kernel_sysctl_extra_settings to the template, pr #157
removed the need for the loop and usage of the ansible.posix.sysctl
module entirely. This change simply removes it and relys on the
exisitng systemd service restart to pick up the cahnge when the file
is updated.

Depends-On: #269 
Closes: #254 
