### PR TITLE
Update docs on testing roles with molecule

### DIFF
--- a/docs/source/contributing_roles.rst
+++ b/docs/source/contributing_roles.rst
@@ -35,7 +35,17 @@ Roles can be tested individually using the *molecule-venv* created by running
     % python3 -m venv molecule-venv
     % source molecule-venv/bin/activate
     (molecule-venv) % pip install --upgrade pip
-    (molecule-venv) % pip install molecule molecule-podman jmespath
+    (molecule-venv) % pip install -r ../../molecule-requirements.txt
+
+The `edpm_timezone` role molecule directory is a working example to
+borrow from when configuring the molecule directory for a new role.
+Copying the default `molecule.yml` file from `edpm_timezone` should
+be sufficient for the `molecule test` command to work.
+
+.. code-block:: console
+
+    $ cd roles/${NEWROLENAME}/molecule/default
+    $ cp ../../../edpm_timezone/molecule/default/molecule.yml molecule.yml
 
 Use the *molecule-venv* to test a specific role.
 


### PR DESCRIPTION
If someone follows our current docs to create a new role the `molecule test` command doesn't work the first time. After asking around for a working example I learned that The `edpm_timezone` role has a working `molecule.yaml` file and that I should pass `molecule-requirements.txt` to `pip install`. After I did that my hello_world skeleton role worked with molecule. I'm committing this docs patch to save the next person the trouble.