### PR TITLE
mova edpm-ansible-crc-podified-edpm-baremetal to github-manual

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -12,6 +12,11 @@
         - edpm-ansible-crc-podified-edpm-deployment:
             dependencies:
               - edpm-ansible-content-provider
+    github-manual:
+      jobs:
+        # Note: the baremetal job is very unstable as such
+        # it is moved to the manual pipeline until that can
+        # be fixed. comment "check-github" to run this job.
         - edpm-ansible-crc-podified-edpm-baremetal:
             dependencies:
               - edpm-ansible-content-provider


### PR DESCRIPTION
This change moves the edpm-ansible-crc-podified-edpm-baremetal
job to the manual pipeline until it can be fixed.
