### PR TITLE
Use ansible_nodename for ovn chassis hostname

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -66,7 +66,7 @@ edpm_ovn_controller_tls_volumes:
 
 # Set external_id data from provided variables
 edpm_ovn_ovs_external_ids:
-  hostname: "{{ ansible_hostname }}"
+  hostname: "{{ ansible_nodename }}"
   ovn-bridge: "{{ edpm_ovn_bridge }}"
   ovn-bridge-mappings: "{{ edpm_ovn_bridge_mappings | join(',') }}"
   ovn-chassis-mac-mappings:

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -600,7 +600,7 @@ argument_specs:
         type: int
       edpm_ovn_ovs_external_ids:
         default:
-          hostname: '{{ ansible_hostname }}'
+          hostname: '{{ ansible_nodename }}'
           ovn-bridge: '{{ edpm_ovn_bridge }}'
           ovn-bridge-mappings: '{{ edpm_ovn_bridge_mappings | join('','') }}'
           ovn-chassis-mac-mappings: '{%- set chassis_mac_mappings = [] -%} {%- for physnet,


### PR DESCRIPTION
It was originally changed from ansible_fqdn
to ansible_hostname as part of [1] but that caused issues in environments where a fqdn is set as hostname.

We need to keep the ovn chassis hostname in sync with how nova-compute "host" config is set.
Nova "host" defaults to socket.gethostname() and to sync with it we need to use ansible_nodename as
ansible_hostname strips out domain part.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/211