### PR TITLE
Introduce edpm_ceph_hci_pre role

### DIFF
--- a/docs/source/roles/role-edpm_ceph_hci_pre.rst
+++ b/docs/source/roles/role-edpm_ceph_hci_pre.rst
@@ -1,0 +1,6 @@
+================================
+Role - edpm_ceph_hci_pre
+================================
+
+.. include::
+   ../collections/osp/edpm/edpm_ceph_hci_pre_role.rst

--- a/playbooks/ceph_hci_pre.yaml
+++ b/playbooks/ceph_hci_pre.yaml
@@ -1,0 +1,10 @@
+---
+- name: osp.edpm.edpm_ceph_hci_pre
+  hosts: all
+  strategy: linear
+  tasks:
+    - name: Prepare EDPM to Host Ceph
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_ceph_hci_pre
+      tags:
+        - edpm_ceph_hci_pre

--- a/roles/edpm_ceph_hci_pre/defaults/main.yml
+++ b/roles/edpm_ceph_hci_pre/defaults/main.yml
@@ -1,0 +1,127 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of "edpm_ceph_hci_pre"
+
+# Firewall configuration
+edpm_ceph_hci_pre_configure_firewall: true
+
+# Only allow default storage network to access Ceph RBD/Mon
+edpm_ceph_hci_pre_storage_ranges:
+  - 172.18.0.0/24
+
+# What list of IP ranges should connect to RGW front end?
+# If the list is empty, no RGW frontend ports will be opened
+# append 0.0.0.0/0 to allow access from all IPs
+edpm_ceph_hci_pre_rgw_frontend_ranges: []
+
+# What list of IP ranges should connect to Ceph Grafana front end?
+# If the list is empty, no Grafana frontend ports will be opened
+edpm_ceph_hci_pre_grafana_frontend_ranges: []
+
+# What list of IP ranges should connect to RBD Mirror?
+# If the list is empty, no RBD Mirror ports will be opened
+edpm_ceph_hci_pre_rbd_mirror_ranges: []
+
+edpm_ceph_hci_pre_firewall_services:
+  - name: ceph_mon
+    num: 110
+    dport:
+      - 6789
+      - 3300
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_osd
+    num: 111
+    dport:
+      - 6800:7300
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_mgr
+    num: 113
+    dport:
+      - 6800:7300
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_mds
+    num: 112
+    dport:
+      - 6800:7300
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_nfs
+    num: 120
+    dport:
+      - 2049
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_rgw
+    num: 122
+    dport:
+      - 8080
+      - 13808
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_rgw_frontend
+    num: 100
+    dport:
+      - 8080
+    ranges: "{{ edpm_ceph_hci_pre_rgw_frontend_ranges | list }}"
+  - name: ceph_ssl_rgw_frontend
+    num: 100
+    dport:
+      - 13808
+    ranges: "{{ edpm_ceph_hci_pre_rgw_frontend_ranges | list }}"
+  - name: ceph_rbdmirror
+    num: 114
+    dport:
+      - 6800:7300
+    ranges: "{{ edpm_ceph_hci_pre_rbd_mirror_ranges | list }}"
+  - name: ceph_grafana
+    num: 123
+    dport:
+      - 3100
+      - 9100
+      - 9090
+      - 9092
+      - 9093
+      - 9094
+      - 9100
+      - 9283
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_dashboard
+    num: 100
+    dport:
+      - 8444
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_grafana_frontend
+    num: 100
+    dport:
+      - 3100
+    ranges: "{{ edpm_ceph_hci_pre_grafana_frontend_ranges | list }}"
+  - name: ceph_prometheus
+    num: 100
+    dport:
+      - 9092
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_alertmanager
+    num: 100
+    dport:
+      - 9093
+    ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+
+# only open ports for these services of the above
+edpm_ceph_hci_pre_enabled_services:
+  - ceph_mon
+  - ceph_mgr
+  - ceph_osd

--- a/roles/edpm_ceph_hci_pre/handlers/main.yml
+++ b/roles/edpm_ceph_hci_pre/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/roles/edpm_ceph_hci_pre/meta/argument_specs.yml
+++ b/roles/edpm_ceph_hci_pre/meta/argument_specs.yml
@@ -1,0 +1,148 @@
+---
+argument_specs:
+  # ./roles/edpm_ceph_hci_pre/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_ceph_hci_pre role.
+    options:
+      edpm_ceph_hci_pre_configure_firewall:
+        default: true
+        description: >-
+          Whether or not firewall ports should be opened
+          to allow access to Ceph services hosted on the node being
+          configured. No firewall configurations are made when `false`.
+        type: bool
+      edpm_ceph_hci_pre_storage_ranges:
+        type: list
+        description: >-
+          List of IP address ranges in CIDR notation which
+          can access the Ceph `public_netowrk` firewall ports to be
+          opened. Defaults to a list with only the EDPM storage network
+          (`172.18.0.0/24`). If the list is empty, then no firewall ports
+          are opened. To allow access from all networks add `0.0.0.0/0`
+          to the list.
+        default: ['172.18.0.0/24']
+      edpm_ceph_hci_pre_rgw_frontend_ranges:
+        type: list
+        description: >-
+          List of IP address ranges in CIDR notation which
+          can access the frontend Ceph RGW firewall ports to be
+          opened. If the list is empty, then no firewall ports are
+          opened. To allow access from all networks add `0.0.0.0/0`
+          to the list.
+        default: []
+      edpm_ceph_hci_pre_grafana_frontend_ranges:
+        type: list
+        description: >-
+          List of IP address ranges in CIDR notation which
+          can access the frontend Ceph Grafana firewall ports to be
+          opened. If the list is empty, then no firewall ports are
+          opened. To allow access from all networks add `0.0.0.0/0`
+          to the list.
+        default: []
+      edpm_ceph_hci_pre_rbd_mirror_ranges:
+        type: list
+        description: >-
+          List of IP address ranges in CIDR notation which
+          can access the frontend Ceph RBD mirror firewall ports to be
+          opened. If the list is empty, then no firewall ports are
+          opened. To allow access from all networks add `0.0.0.0/0`
+          to the list.
+        default: []
+      edpm_ceph_hci_pre_firewall_services:
+        type: list
+        description: >-
+          List of dictionaries describing each Ceph service name (`name`),
+          firewall rule order number (`num`), ranges based on the different
+          ranges defined above (for all variables above matching
+          `edpm_ceph_hci_pre_*_ranges`), and destination port list (`dport`).
+          If the `dport` list contains an interval, e.g. `mix:max`, then all
+          ports between (and including) `min` and `max` will be opened.
+        default:
+          - name: ceph_mon
+            num: 110
+            dport:
+              - 6789
+              - 3300
+            ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+          - name: ceph_osd
+            num: 111
+            dport:
+              - 6800:7300
+            ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+          - name: ceph_mgr
+            num: 113
+            dport:
+              - 6800:7300
+            ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+          - name: ceph_mds
+            num: 112
+            dport:
+              - 6800:7300
+            ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+          - name: ceph_nfs
+            num: 120
+            dport:
+              - 2049
+            ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+          - name: ceph_rgw
+            num: 122
+            dport:
+              - 8080
+              - 13808
+            ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+          - name: ceph_rgw_frontend
+            num: 100
+            dport:
+              - 8080
+            ranges: "{{ edpm_ceph_hci_pre_rgw_frontend_ranges | list }}"
+          - name: ceph_ssl_rgw_frontend
+            num: 100
+            dport:
+              - 13808
+            ranges: "{{ edpm_ceph_hci_pre_rgw_frontend_ranges | list }}"
+          - name: ceph_rbdmirror
+            num: 114
+            dport:
+              - 6800:7300
+            ranges: "{{ edpm_ceph_hci_pre_rbd_mirror_ranges | list }}"
+          - name: ceph_grafana
+            num: 123
+            dport:
+              - 3100
+              - 9100
+              - 9090
+              - 9092
+              - 9093
+              - 9094
+              - 9100
+              - 9283
+            ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+          - name: ceph_grafana_frontend
+            num: 100
+            dport:
+              - 3100
+            ranges: "{{ edpm_ceph_hci_pre_grafana_frontend_ranges | list }}"
+          - name: ceph_prometheus
+            num: 100
+            dport:
+              - 9092
+            ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+          - name: ceph_alertmanager
+            num: 100
+            dport:
+              - 9093
+            ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+      edpm_ceph_hci_pre_enabled_services:
+        type: list
+        description: >-
+          List of names matching each `name` in the
+          `edpm_ceph_hci_pre_firewall_services` which should have their
+          firewall ports opened. By default only the Ceph RBD (block)
+          service is configured with it's supporting services. If EDPM
+          nodes will host a Ceph cluster with more than just block
+          service, then extend this list. If this list is empty, then
+          no firewall ports for Ceph will be opened.
+        default:
+          - ceph_mon
+          - ceph_mgr
+          - ceph_osd

--- a/roles/edpm_ceph_hci_pre/meta/main.yml
+++ b/roles/edpm_ceph_hci_pre/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_ceph_hci_pre
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_ceph_hci_pre/molecule/default/converge.yml
+++ b/roles/edpm_ceph_hci_pre/molecule/default/converge.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "edpm_ceph_hci_pre"

--- a/roles/edpm_ceph_hci_pre/molecule/default/molecule.yml
+++ b/roles/edpm_ceph_hci_pre/molecule/default/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+    registry:
+      url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+    command: /sbin/init
+    dockerfile: ../../../../molecule/common/Containerfile.j2
+    privileged: true
+    ulimits: &ulimit
+      - host
+provisioner:
+  name: ansible
+  log: true
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/roles/edpm_ceph_hci_pre/molecule/default/prepare.yml
+++ b/roles/edpm_ceph_hci_pre/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+    - role: env_data

--- a/roles/edpm_ceph_hci_pre/molecule/default/verify.yml
+++ b/roles/edpm_ceph_hci_pre/molecule/default/verify.yml
@@ -1,0 +1,32 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Read generated file
+      command: cat /var/lib/edpm-config/firewall/ceph-networks.yaml
+      register: ceph_networks
+
+    - name: Assert that generated file is correct
+      assert:
+        that:
+          - item.rule.proto == 'tcp'
+          - item.rule.source == '172.18.0.0/24'
+          - item.rule_name | regex_search('^[0-9]{3} allow ceph_.* from 172.18.0.0/24$')
+          - item.rule.dport | list
+          - item.rule.dport[0] | regex_search('^([0-9]{4})$|^([0-9]{4}:[0-9]{4})$')
+      loop: "{{ ceph_networks.stdout | from_yaml }}"

--- a/roles/edpm_ceph_hci_pre/tasks/firewall.yml
+++ b/roles/edpm_ceph_hci_pre/tasks/firewall.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure firewall directory is present
+  ansible.builtin.file:
+    path: '/var/lib/edpm-config/firewall'
+    state: directory
+    owner: root
+    group: root
+    mode: '0750'
+
+- name: Inject firewall configuration for Ceph Server
+  ansible.builtin.template:
+    dest: '/var/lib/edpm-config/firewall/ceph-networks.yaml'
+    src: 'firewall.yaml.j2'
+    mode: '0644'

--- a/roles/edpm_ceph_hci_pre/tasks/main.yml
+++ b/roles/edpm_ceph_hci_pre/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Configure Firewall for Ceph
+  ansible.builtin.include_tasks: firewall.yml
+  when: edpm_ceph_hci_pre_configure_firewall | bool

--- a/roles/edpm_ceph_hci_pre/templates/firewall.yaml.j2
+++ b/roles/edpm_ceph_hci_pre/templates/firewall.yaml.j2
@@ -1,0 +1,13 @@
+---
+# Generated via edpm_ceph_hci_pre
+{% for rule in edpm_ceph_hci_pre_firewall_services -%}
+{% for range in rule.ranges -%}
+{% if rule.name in edpm_ceph_hci_pre_enabled_services -%}
+- rule_name: "{{ rule.num }} allow {{ rule.name }} from {{ range }}"
+  rule:
+    proto: tcp
+    dport: {{ rule.dport }}
+    source: {{ range }}
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/roles/edpm_ceph_hci_pre/vars/main.yml
+++ b/roles/edpm_ceph_hci_pre/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "edpm_ceph_hci_pre"


### PR DESCRIPTION
The edpm_ceph_hci_pre role configures EDPM hosts so that they are ready for Ceph to be installed. For now this includes opening the firewall ports but the role has been named so that any other prerequisite configuration could be done.

Jira: [OSP-25827](https://issues.redhat.com//browse/OSP-25827)