### PR TITLE
Add tc command

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -32,6 +32,7 @@ edpm_bootstrap_packages_bootstrap:
   - rsync
   - tmpwatch
   - sysstat
+  - iproute-tc
 
 edpm_bootstrap_release_version_package:
   - rhosp-release

--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -20,6 +20,7 @@ argument_specs:
           - rsync
           - tmpwatch
           - sysstat
+          - iproute-tc
         description: "List of packages that are requred to bootstrap EDPM."
 
       edpm_bootstrap_release_version_package:


### PR DESCRIPTION
The command allows us to capture qdisc drop counter, which is useful for debugging packet loss problems.