### PR TITLE
Revert "Removing MD5 from the list of approved algos"

### DIFF
--- a/roles/edpm_iscsid/defaults/main.yml
+++ b/roles/edpm_iscsid/defaults/main.yml
@@ -31,4 +31,4 @@ edpm_iscsid_volumes:
   - /etc/target:/etc/target:z
   - /var/lib/iscsi:/var/lib/iscsi:z
 
-edpm_iscsid_chap_algs: 'SHA3-256,SHA256,SHA1'
+edpm_iscsid_chap_algs: 'SHA3-256,SHA256,SHA1,MD5'

--- a/roles/edpm_iscsid/meta/argument_specs.yml
+++ b/roles/edpm_iscsid/meta/argument_specs.yml
@@ -29,5 +29,5 @@ argument_specs:
         description: List of iscsid volume mounts with permissions.
       edpm_iscsid_chap_algs:
         type: str
-        default: 'SHA3-256,SHA256,SHA1'
+        default: 'SHA3-256,SHA256,SHA1,MD5'
         description: List of allowed CHAP algorithms.


### PR DESCRIPTION
This reverts commit 6b75cd6c89e9661c039d141cd970eee1f4304d70.

It's true that MD5 is not compatible with FIPS, but MD5 is required in non-FIPS deployments with older storage hardware. Allowing MD5 by default is consistent with tripleo based deployments, and will give storage providers time to certify their product works in FIPS environments where MD5 is prohibited. In addition, removing MD5 by default will need to be coordinated with corresponding changes in the controlplane.