### PR TITLE
Pinning molecule to avoid testinfra removal

### DIFF
--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -1,6 +1,6 @@
 ansible-core==2.14.6
 jmespath
-molecule>=5.1.0
+molecule>=5.1.0,<6.0.0
 molecule-plugins[podman]>=23.4.0
 pytest-testinfra
 # this is required for the molecule jobs


### PR DESCRIPTION
Should prevent https://github.com/ansible/molecule/issues/4011 