### PR TITLE
Skip edpm jobs when molecule-requirements.txt is modified

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -52,12 +52,14 @@
       - OWNERS.*
       - README.md
       - molecule/.*
+      - molecule-requirements.txt
       - .github/workflows
       - scripts/.*
       - docs/.*
       - contribute/.*
       - tests
       - roles/.*/molecule/.*
+
 - job:
     name: edpm-ansible-crc-podified-edpm-deployment
     parent: cifmw-crc-podified-edpm-deployment


### PR DESCRIPTION
The file affects only molecule job so we don't have to run the whole deployment scenario.