### PR TITLE
update /var/lib/libvirt to 755

### DIFF
--- a/roles/edpm_libvirt/tasks/install.yml
+++ b/roles/edpm_libvirt/tasks/install.yml
@@ -27,7 +27,9 @@
     group: "{{ item.group | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
   with_items:
-  - { "path": "/var/lib/libvirt", "mode": "0750" }
+  # qemu is not in the libvirt group in the container images so use
+  # mode 755 to make /var/lib/libvirt traversable.
+  - { "path": "/var/lib/libvirt", "mode": "0755" }
   - { "path": "/var/log/containers/libvirt", "mode": "0750" }
   - { "path": "/var/log/containers/qemu", "mode": "0750" }
   # dont set owner/group or mode on these, as they are managed


### PR DESCRIPTION
the periodic-podified-edpm-deployment-antelope-ocp-crc-1cs9 zuul job
is failing with

"""
qemu-kvm: Unable to read /var/lib/libvirt/qemu/domain-1-instance-00000001/master-key.aes:
Failed to open file “/var/lib/libvirt/qemu/domain-1-instance-00000001/master-key.aes”: Permission denied
"""

we belive this is caused by a change in the permission of /var/lib/libvirt form 755 to 750

libvirts dynmaic ownership feature will change the permission on any files qemu should be able
to access in /var/lib/libvirt when it is booting a vm however it will not change
the permissions on the directory. since the qemu user is not in the libvirt group it is
relying on the global traversablity of /var/lib/libivrt enabled by 755 to be able to access
that dir and the files with in. As a result of the tightening of permission to 750 this
is now failing.
