### PR TITLE
relax nova config patteren

### DIFF
--- a/roles/edpm_nova/molecule/default/test-data/nova-cell1/01-nova.conf
+++ b/roles/edpm_nova/molecule/default/test-data/nova-cell1/01-nova.conf
@@ -2,7 +2,3 @@
 debug = True
 transport_url = fake:/
 compute_driver = libvirt.LibvirtDriver
-max_logfile_count=5
-max_logfile_size_mb=50
-log_rotation_type=size
-log_file = /var/log/containers/nova/nova-compute.log

--- a/roles/edpm_nova/molecule/default/test-data/nova-cell1/02-nova-log.conf
+++ b/roles/edpm_nova/molecule/default/test-data/nova-cell1/02-nova-log.conf
@@ -1,0 +1,5 @@
+[DEFAULT]
+max_logfile_count=5
+max_logfile_size_mb=50
+log_rotation_type=size
+log_file = /var/log/containers/nova/nova-compute.log

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -32,3 +32,11 @@
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_podman.yaml"
       with_items:
         - "nova_compute"
+    - name: ensure kolla_set_configs copied the expected files
+      become: true
+      ansible.builtin.shell: |
+        podman logs nova_compute 2>&1 | grep "{{item}}" > /dev/null
+      with_items:
+        - "Copying /var/lib/kolla/config_files/nova-blank.conf to /etc/nova/nova.conf"
+        - "Copying /var/lib/kolla/config_files/01-nova.conf to /etc/nova/nova.conf.d/01-nova.conf"
+        - "Copying /var/lib/kolla/config_files/02-nova-log.conf to /etc/nova/nova.conf.d/02-nova-log.conf"

--- a/roles/edpm_nova/templates/config.json.j2
+++ b/roles/edpm_nova/templates/config.json.j2
@@ -8,7 +8,7 @@
             "perm": "0600"
         },
         {
-            "source": "/var/lib/kolla/config_files/*nova.conf",
+            "source": "/var/lib/kolla/config_files/*nova*.conf",
             "dest": "/etc/nova/nova.conf.d/",
             "owner": "nova",
             "perm": "0600"


### PR DESCRIPTION
This change relaxes the shell glob used by kolla_set_configs
to match which files shoudl be copied to "/etc/nova/nova.conf.d".
The new pattern will match "*nova*.conf" instead of "*nova.conf".

The molecule tests are expanded to assert tht the expected files
are copied to verify this change.
