### PR TITLE
Switch to sha256 for config hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 TEST_ENV_REPOSITORY := https://github.com/openstack-k8s-operators/ci-framework.git
 IMAGE_TAG_BASE ?= quay.io/openstack-k8s-operators/openstack-ansibleee-runner
-IMG ?= $(IMAGE_TAG_BASE):latest
+IMAGE_TAG ?= latest
+IMG ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
 
 ifndef ENV_DIR
 override ENV_DIR := $(shell mktemp -d)/ci-framework

--- a/plugins/modules/container_config_hash.py
+++ b/plugins/modules/container_config_hash.py
@@ -155,7 +155,7 @@ class ContainerConfigHashManager:
         return r
 
     def _calculate_checksum(self, config_volume, exclusions=[]):
-        """Calculate an md5 hash from a list of files from the given folder
+        """Calculate an sha256 hash from a list of files from the given folder
            and if needed exclude files from that list.
 
         :param config_volume: string
@@ -163,7 +163,7 @@ class ContainerConfigHashManager:
         :returns: string
         """
 
-        total_hash = hashlib.new('md5')
+        total_hash = hashlib.new('sha256')
         for file in glob.glob(config_volume + '/**/*', recursive=True):
             file_relpath = '/' + os.path.relpath(file, config_volume)
             if os.path.isfile(file) and file_relpath not in exclusions:


### PR DESCRIPTION
Enabling FIPs enforces md5 never being used, so this module currently fails with FIPs.