### PR TITLE
Refactoring collection playbooks to use static imports of roles

### DIFF
--- a/playbooks/ceph_client.yaml
+++ b/playbooks/ceph_client.yaml
@@ -3,9 +3,7 @@
   hosts: all
   strategy: linear
   become: true
-  tasks:
-    - name: "Configure EDPM as client of Ceph"
-      import_role:
-        name: osp.edpm.edpm_ceph_client_files
+  roles:
+    - role: osp.edpm.edpm_ceph_client_files
       tags:
         - edpm_ceph_client

--- a/playbooks/ceph_hci_pre.yaml
+++ b/playbooks/ceph_hci_pre.yaml
@@ -2,9 +2,7 @@
 - name: osp.edpm.edpm_ceph_hci_pre
   hosts: all
   strategy: linear
-  tasks:
-    - name: Prepare EDPM to Host Ceph
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_ceph_hci_pre
+  roles:
+    - role: osp.edpm.edpm_ceph_hci_pre
       tags:
         - edpm_ceph_hci_pre

--- a/playbooks/configure_network.yaml
+++ b/playbooks/configure_network.yaml
@@ -2,10 +2,8 @@
 - name: Deploy EDPM Network
   hosts: all
   strategy: linear
-  tasks:
-    - name: Grow volumes
-      import_role:
-        name: osp.edpm.edpm_growvols
+  roles:
+    - role: osp.edpm.edpm_growvols
       tags:
         - edpm_growvols
     - name: Install edpm_bootstrap
@@ -14,14 +12,10 @@
         tasks_from: bootstrap.yml
       tags:
         - edpm_bootstrap
-    - name: Install edpm_kernel
-      import_role:
-        name: osp.edpm.edpm_kernel
+    - role: osp.edpm.edpm_kernel
       tags:
         - edpm_kernel
-    - name: Import edpm_tuned
-      import_role:
-        name: osp.edpm.edpm_tuned
+    - role: osp.edpm.edpm_tuned
       tags:
         - edpm_tuned
     - name: Configure Kernel Args
@@ -30,8 +24,6 @@
         tasks_from: kernelargs.yml
       tags:
         - edpm_kernel
-    - name: import edpm_network_config
-      import_role:
-        name: osp.edpm.edpm_network_config
+    - role: osp.edpm.edpm_network_config
       tags:
         - edpm_network_config

--- a/playbooks/libvirt.yaml
+++ b/playbooks/libvirt.yaml
@@ -2,9 +2,7 @@
 - name: Deploy EDPM libvirt
   hosts: all
   strategy: linear
-  tasks:
-    - name: libvirt
-      import_role:
-        name: osp.edpm.edpm_libvirt
+  roles:
+    - role: osp.edpm.edpm_libvirt
       tags:
         - edpm_libvirt

--- a/playbooks/nova.yaml
+++ b/playbooks/nova.yaml
@@ -2,9 +2,7 @@
 - name: Deploy EDPM Nova
   hosts: all
   strategy: linear
-  tasks:
-    - name: nova
-      import_role:
-        name: osp.edpm.edpm_nova
+  roles:
+    - role: osp.edpm.edpm_nova
       tags:
         - edpm_nova

--- a/playbooks/ovn.yaml
+++ b/playbooks/ovn.yaml
@@ -3,9 +3,7 @@
   hosts: all
   strategy: linear
   become: true
-  tasks:
-    - name: ovn
-      import_role:
-        name: osp.edpm.edpm_ovn
+  roles:
+    - role: osp.edpm.edpm_ovn
       tags:
         - edpm_ovn

--- a/playbooks/validate_network.yaml
+++ b/playbooks/validate_network.yaml
@@ -2,9 +2,7 @@
 - name: osp.edpm.edpm_nodes_validation
   hosts: all
   strategy: linear
-  tasks:
-    - name: import edpm_nodes_validation
-      import_role:
-        name: osp.edpm.edpm_nodes_validation
+  roles:
+    - role: osp.edpm.edpm_nodes_validation
       tags:
         - edpm_nodes_validation


### PR DESCRIPTION
Telemetry playbooks are being handled by their own PR[0], owing to their specific lineage. 

[0] #275 