### PR TITLE
Use new content provider and standalone crc based edpm job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -39,14 +39,8 @@
 
 # EDPM jobs
 - job:
-    name: edpm-ansible-content-provider
-    parent: content-provider-base
-    vars:
-      cifmw_operator_build_org: openstack-k8s-operators
-      cifmw_operator_build_operators:
-        - name: "openstack-operator"
-          src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
-          image_base: edpm
+    name: edpm-ansible-crc-podified-edpm-baremetal
+    parent: cifmw-crc-podified-edpm-baremetal
     irrelevant-files: &molecule_irrelevant_files
       - LICENSE
       - OWNERS.*
@@ -59,13 +53,3 @@
       - contribute/.*
       - tests
       - roles/.*/molecule/.*
-
-- job:
-    name: edpm-ansible-crc-podified-edpm-deployment
-    parent: cifmw-crc-podified-edpm-deployment
-    irrelevant-files: *molecule_irrelevant_files
-
-- job:
-    name: edpm-ansible-crc-podified-edpm-baremetal
-    parent: cifmw-crc-podified-edpm-baremetal
-    irrelevant-files: *molecule_irrelevant_files

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,10 +8,10 @@
         - edpm-ansible-molecule-edpm_kernel
         - edpm-ansible-molecule-edpm_libvirt
         - edpm-ansible-molecule-edpm_nova
-        - edpm-ansible-content-provider
-        - edpm-ansible-crc-podified-edpm-deployment:
+        - openstack-k8s-operators-content-provider
+        - podified-multinode-edpm-deployment-crc:
             dependencies:
-              - edpm-ansible-content-provider
+              - openstack-k8s-operators-content-provider
         - edpm-ansible-crc-podified-edpm-baremetal:
             dependencies:
-              - edpm-ansible-content-provider
+              - openstack-k8s-operators-content-provider


### PR DESCRIPTION
This pr removes the old content provider and edpm job and uses the new content provider and standalone crc based edpm job.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/379