### PR TITLE
Do not require a source address for ceph_hci_pre firewall

### DIFF
--- a/roles/edpm_ceph_hci_pre/defaults/main.yml
+++ b/roles/edpm_ceph_hci_pre/defaults/main.yml
@@ -22,21 +22,23 @@
 # Firewall configuration
 edpm_ceph_hci_pre_configure_firewall: true
 
-# Only allow default storage network to access Ceph RBD/Mon
-edpm_ceph_hci_pre_storage_ranges:
-  - 172.18.0.0/24
+# Name of file to be created on EDPM nodes with ceph firewall rules
+edpm_ceph_hci_pre_firewall_yaml_file: /var/lib/edpm-config/firewall/ceph-networks.yaml
 
-# What list of IP ranges should connect to RGW front end?
-# If the list is empty, no RGW frontend ports will be opened
-# append 0.0.0.0/0 to allow access from all IPs
+# List of IP ranges which can connect to Ceph RBD/Mon ports
+# If list is empty, the firewall rule will not specify a source address
+edpm_ceph_hci_pre_storage_ranges: []
+
+# List of IP ranges which can connect to RGW front end
+# If list is empty, the firewall rule will not specify a source address
 edpm_ceph_hci_pre_rgw_frontend_ranges: []
 
-# What list of IP ranges should connect to Ceph Grafana front end?
-# If the list is empty, no Grafana frontend ports will be opened
+# List of IP ranges which can connect to Ceph Grafana front end
+# If list is empty, the firewall rule will not specify a source address
 edpm_ceph_hci_pre_grafana_frontend_ranges: []
 
-# What list of IP ranges should connect to RBD Mirror?
-# If the list is empty, no RBD Mirror ports will be opened
+# List of IP ranges which can connect to RBD Mirror
+# If list is empty, the firewall rule will not specify a source address
 edpm_ceph_hci_pre_rbd_mirror_ranges: []
 
 edpm_ceph_hci_pre_firewall_services:

--- a/roles/edpm_ceph_hci_pre/meta/argument_specs.yml
+++ b/roles/edpm_ceph_hci_pre/meta/argument_specs.yml
@@ -7,46 +7,40 @@ argument_specs:
       edpm_ceph_hci_pre_configure_firewall:
         default: true
         description: >-
-          Whether or not firewall ports should be opened
-          to allow access to Ceph services hosted on the node being
-          configured. No firewall configurations are made when `false`.
+          Whether or not firewall ports should be opened to allow access
+          to Ceph services hosted on the node being configured. No firewall
+          configurations are made when `false`.
         type: bool
       edpm_ceph_hci_pre_storage_ranges:
         type: list
         description: >-
-          List of IP address ranges in CIDR notation which
-          can access the Ceph `public_netowrk` firewall ports to be
-          opened. Defaults to a list with only the EDPM storage network
-          (`172.18.0.0/24`). If the list is empty, then no firewall ports
-          are opened. To allow access from all networks add `0.0.0.0/0`
-          to the list.
-        default: ['172.18.0.0/24']
+          List of IP address ranges in CIDR notation which can access the
+          Ceph services on the Ceph `public_network` and `cluster_network`.
+          When the firewall ports are opened, if the list is non-empty, then
+          when the firewall rule is created, it will specify the source
+          addresses. If the list is empty, then the firewall rule will not
+          specify a source address.
+        default: []
       edpm_ceph_hci_pre_rgw_frontend_ranges:
         type: list
         description: >-
-          List of IP address ranges in CIDR notation which
-          can access the frontend Ceph RGW firewall ports to be
-          opened. If the list is empty, then no firewall ports are
-          opened. To allow access from all networks add `0.0.0.0/0`
-          to the list.
+          List of IP address ranges in CIDR notation which can access the
+          frontend Ceph RGW firewall ports to be opened. If the list is
+          empty, the firewall rule will not specify a source address.
         default: []
       edpm_ceph_hci_pre_grafana_frontend_ranges:
         type: list
         description: >-
-          List of IP address ranges in CIDR notation which
-          can access the frontend Ceph Grafana firewall ports to be
-          opened. If the list is empty, then no firewall ports are
-          opened. To allow access from all networks add `0.0.0.0/0`
-          to the list.
+          List of IP address ranges in CIDR notation which can access the
+          frontend Ceph Grafana firewall ports to be opened. If the list is
+          empty, the firewall rule will not specify a source address.
         default: []
       edpm_ceph_hci_pre_rbd_mirror_ranges:
         type: list
         description: >-
-          List of IP address ranges in CIDR notation which
-          can access the frontend Ceph RBD mirror firewall ports to be
-          opened. If the list is empty, then no firewall ports are
-          opened. To allow access from all networks add `0.0.0.0/0`
-          to the list.
+          List of IP address ranges in CIDR notation which can access the
+          frontend Ceph RBD mirror firewall ports to be opened. If the list
+          is empty, the firewall rule will not specify a source address.
         default: []
       edpm_ceph_hci_pre_firewall_services:
         type: list
@@ -146,3 +140,10 @@ argument_specs:
           - ceph_mon
           - ceph_mgr
           - ceph_osd
+      edpm_ceph_hci_pre_firewall_yaml_file:
+        type: str
+        description: >-
+          The absolute path to a YAML file on the EDPM node which will be
+          created by the role. The file will be parsed by the edpm_nftables
+          role which creates the actual firewall rule.
+        default: /var/lib/edpm-config/firewall/ceph-networks.yaml

--- a/roles/edpm_ceph_hci_pre/molecule/default/converge.yml
+++ b/roles/edpm_ceph_hci_pre/molecule/default/converge.yml
@@ -15,7 +15,15 @@
 # under the License.
 
 
-- name: Converge
+- name: Converge defaults
   hosts: all
+  roles:
+    - role: "edpm_ceph_hci_pre"
+
+- name: Converge overrides
+  hosts: all
+  vars:
+    edpm_ceph_hci_pre_firewall_yaml_file: /var/lib/edpm-config/firewall/ceph-networks-overrides.yaml
+    edpm_ceph_hci_pre_storage_ranges: [172.18.0.0/24]
   roles:
     - role: "edpm_ceph_hci_pre"

--- a/roles/edpm_ceph_hci_pre/molecule/default/prepare.yml
+++ b/roles/edpm_ceph_hci_pre/molecule/default/prepare.yml
@@ -18,5 +18,4 @@
 - name: Prepare
   hosts: all
   roles:
-    - role: test_deps
     - role: env_data

--- a/roles/edpm_ceph_hci_pre/molecule/default/verify.yml
+++ b/roles/edpm_ceph_hci_pre/molecule/default/verify.yml
@@ -17,11 +17,24 @@
 - name: Verify
   hosts: all
   tasks:
-    - name: Read generated file
+    - name: Read generated file from defaults
       command: cat /var/lib/edpm-config/firewall/ceph-networks.yaml
       register: ceph_networks
 
-    - name: Assert that generated file is correct
+    - name: Assert that default generated file is correct
+      assert:
+        that:
+          - item.rule.proto == 'tcp'
+          - item.rule_name | regex_search('^[0-9]{3} allow ceph_.*$')
+          - item.rule.dport | list
+          - item.rule.dport[0] | regex_search('^([0-9]{4})$|^([0-9]{4}:[0-9]{4})$')
+      loop: "{{ ceph_networks.stdout | from_yaml }}"
+
+    - name: Read generated file from overrides
+      command: cat /var/lib/edpm-config/firewall/ceph-networks-overrides.yaml
+      register: ceph_networks_overrides
+
+    - name: Assert that overridden generated file is correct
       assert:
         that:
           - item.rule.proto == 'tcp'
@@ -29,4 +42,4 @@
           - item.rule_name | regex_search('^[0-9]{3} allow ceph_.* from 172.18.0.0/24$')
           - item.rule.dport | list
           - item.rule.dport[0] | regex_search('^([0-9]{4})$|^([0-9]{4}:[0-9]{4})$')
-      loop: "{{ ceph_networks.stdout | from_yaml }}"
+      loop: "{{ ceph_networks_overrides.stdout | from_yaml }}"

--- a/roles/edpm_ceph_hci_pre/tasks/firewall.yml
+++ b/roles/edpm_ceph_hci_pre/tasks/firewall.yml
@@ -16,7 +16,7 @@
 
 - name: Ensure firewall directory is present
   ansible.builtin.file:
-    path: '/var/lib/edpm-config/firewall'
+    path: "{{ edpm_ceph_hci_pre_firewall_yaml_file | dirname }}"
     state: directory
     owner: root
     group: root
@@ -24,6 +24,6 @@
 
 - name: Inject firewall configuration for Ceph Server
   ansible.builtin.template:
-    dest: '/var/lib/edpm-config/firewall/ceph-networks.yaml'
+    dest: "{{ edpm_ceph_hci_pre_firewall_yaml_file }}"
     src: 'firewall.yaml.j2'
     mode: '0644'

--- a/roles/edpm_ceph_hci_pre/templates/firewall.yaml.j2
+++ b/roles/edpm_ceph_hci_pre/templates/firewall.yaml.j2
@@ -1,13 +1,21 @@
 ---
 # Generated via edpm_ceph_hci_pre
-{% for rule in edpm_ceph_hci_pre_firewall_services -%}
-{% for range in rule.ranges -%}
-{% if rule.name in edpm_ceph_hci_pre_enabled_services -%}
+{%- for rule in edpm_ceph_hci_pre_firewall_services -%}
+    {%- if rule.name in edpm_ceph_hci_pre_enabled_services -%}
+        {%- if rule.ranges | length == 0 +%}
+- rule_name: "{{ rule.num }} allow {{ rule.name }}"
+  rule:
+    proto: tcp
+    dport: {{ rule.dport }}
+        {%- endif -%}
+        {%- if rule.ranges | length > 0 -%}
+            {%- for range in rule.ranges +%}
 - rule_name: "{{ rule.num }} allow {{ rule.name }} from {{ range }}"
   rule:
     proto: tcp
     dport: {{ rule.dport }}
     source: {{ range }}
-{% endif %}
-{% endfor %}
-{% endfor %}
+            {%- endfor -%}
+        {%- endif -%}
+   {%- endif -%}
+{%- endfor -%}


### PR DESCRIPTION
If variables matching edpm_ceph_hci_pre_*_ranges are set to an empty list, then do not specify a source address in the NFT rule. For example the rule will look like this:
```
  tcp dport { 3300, 6789 } ...
```
If the source address is specified, then the rule will look like this:
```
  ip saddr 172.18.0.0/24 tcp dport { 3300, 6789 } ...
```
Prior to this patch, if someone wanted to not pass a source address they would need to add 0.0.0.0/0 to the list which is unintuitive. It is better to handle when there is no source address by not creating a rule with a source address.

TripleO does not specify a source IP address when defining Ceph rules in iptables. A line from /etc/sysconfig/iptables in Wallaby TripleO CI is below.
```
-A INPUT -p tcp -m tcp --dport 3300 -m conntrack \
  --ctstate NEW -m comment --comment "110 ceph_mon ipv4" \
  -j ACCEPT
```
The default firewall rules in the edpm_ceph_hci_pre role are being updated in this patch to have the functional equivalent of the above in nftables. The option remains to override the defaults and pass a list of source addresses. It is assumed the storage and storage management networks will be isolated.