### PR TITLE
edpm_libivirt should reload NFT ruleset after configuring it

### DIFF
--- a/roles/edpm_libvirt/molecule/default/prepare.yml
+++ b/roles/edpm_libvirt/molecule/default/prepare.yml
@@ -36,3 +36,20 @@
     - name: install podman
       import_role:
         name: "edpm_podman"
+    - name: Create firewall directory
+      become: true
+      ansible.builtin.file:
+        path: '/var/lib/edpm-config/firewall'
+        state: directory
+        owner: root
+        group: root
+        mode: 0750
+    - name: open port 22 (edpm_nftables will active this later)
+      become: true
+      copy:
+        dest: /var/lib/edpm-config/firewall/sshd-networks.yaml
+        content: |
+          - rule_name: 003 Allow SSH
+            rule:
+              proto: tcp
+              dport: 22

--- a/roles/edpm_libvirt/tasks/post-install.yml
+++ b/roles/edpm_libvirt/tasks/post-install.yml
@@ -44,3 +44,10 @@
   ansible.builtin.include_role:
       name: osp.edpm.edpm_nftables
       tasks_from: "configure.yml"
+- name: Reload firewall for new vnc rule
+  tags:
+    - install
+    - post-libvirt
+  ansible.builtin.include_role:
+      name: osp.edpm.edpm_nftables
+      tasks_from: "run.yml"

--- a/roles/edpm_nova/molecule/default/prepare.yml
+++ b/roles/edpm_nova/molecule/default/prepare.yml
@@ -47,6 +47,23 @@
     - name: install podman
       import_role:
         name: "edpm_podman"
+    - name: Create firewall directory
+      become: true
+      ansible.builtin.file:
+        path: '/var/lib/edpm-config/firewall'
+        state: directory
+        owner: root
+        group: root
+        mode: 0750
+    - name: open port 22 (edpm_nftables will active this later)
+      become: true
+      copy:
+        dest: /var/lib/edpm-config/firewall/sshd-networks.yaml
+        content: |
+          - rule_name: 003 Allow SSH
+            rule:
+              proto: tcp
+              dport: 22
     - name: install libvirt
       import_role:
         name: "edpm_libvirt"


### PR DESCRIPTION
The post-install tasks file was calling the configure tasks in the edpm_nftables role to update the rules file in the /etc/nftables/ directory, but was not calling the run tasks to make the firewall reload the ruleset. This caused the output of `nft list ruleset` to not include the VNC rule which the edpm_libivirt role adds. Fix this by calling the run tasks file.

Jira: [OSP-27573](https://issues.redhat.com//browse/OSP-27573)