### PR TITLE
Fix run_ovn_bgp_agent playbook definition

### DIFF
--- a/playbooks/run_ovn_bgp_agent.yaml
+++ b/playbooks/run_ovn_bgp_agent.yaml
@@ -3,8 +3,10 @@
   hosts: all
   strategy: linear
   become: True
-  roles:
-    - role: osp.edpm.edpm_ovn_bgp_agent
-      tasks_from: run.yml
+  tasks:
+    - name: Run edpm_ovn_bgp_agent
+      import_role:
+        name: osp.edpm.edpm_ovn_bgp_agent
+        tasks_from: run.yml
       tags:
         - edpm_ovn_bgp_agent


### PR DESCRIPTION
Ensure the tasks is defined and imports the run role, instead of defining a role as this fails with:
    Validating arguments against arg spec 'main' - The main entry point for
    the edpm_ovn_bgp_agent role.] ***