### PR TITLE
Remove ovn role include from os setup

### DIFF
--- a/playbooks/configure_os.yaml
+++ b/playbooks/configure_os.yaml
@@ -40,12 +40,6 @@
         tasks_from: configure.yml
       tags:
         - edpm_timezone
-    - name: Configure edpm_ovn
-      import_role:
-        name: osp.edpm.edpm_ovn
-        tasks_from: configure.yml
-      tags:
-        - edpm_ovn
     - name: Configure edpm_ssh_known_hosts
       import_role:
         name: osp.edpm.edpm_ssh_known_hosts

--- a/playbooks/install_os.yaml
+++ b/playbooks/install_os.yaml
@@ -22,12 +22,6 @@
         tasks_from: install.yml
       tags:
         - edpm_chrony
-    - name: Install edpm_ovn
-      import_role:
-        name: osp.edpm.edpm_ovn
-        tasks_from: install.yml
-      tags:
-        - edpm_ovn
     - name: Install edpm_logrotate_crond
       import_role:
         name: osp.edpm.edpm_logrotate_crond

--- a/playbooks/run_os.yaml
+++ b/playbooks/run_os.yaml
@@ -34,12 +34,6 @@
         tasks_from: run.yml
       tags:
         - edpm_timezone
-    - name: Run edpm_ovn
-      import_role:
-        name: osp.edpm.edpm_ovn
-        tasks_from: run.yml
-      tags:
-        - edpm_ovn
     - name: Apply nftables configuration
       import_role:
         name: osp.edpm.edpm_nftables


### PR DESCRIPTION
ovn setup was split as part of [1], but missed as
part of playbook migration

[1] https://github.com/openstack-k8s-operators/dataplane-operator/commit/125ee8a99e