### PR TITLE
edpm_kernel: Fix Reboot Task

### DIFF
--- a/roles/edpm_kernel/tasks/reboot.yaml
+++ b/roles/edpm_kernel/tasks/reboot.yaml
@@ -71,6 +71,7 @@
 
 # Reboot the node
 - name: Reboot after kernel args update
+  become: true
   ansible.builtin.reboot:
     post_reboot_delay: "{{ edpm_kernel_post_reboot_delay }}"
     reboot_timeout: "{{ edpm_kernel_reboot_timeout }}"


### PR DESCRIPTION
Reboot task may fail due to the remote user being an unprivileged user
(non root) which is not able to perform a reboot.
By escalating the permissions in the task, the reboot task should pass.
