### PR TITLE
Store Ceph client files in /var/lib/openstack/config/ceph

### DIFF
--- a/roles/edpm_ceph_client_files/defaults/main.yml
+++ b/roles/edpm_ceph_client_files/defaults/main.yml
@@ -18,5 +18,9 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_ceph_client_files"
+
+# Where files are copied from inside the AEE Pod
 edpm_ceph_client_files_source: '/etc/ceph'
-edpm_ceph_client_files_config_home: "{{ edpm_ceph_client_config_home | default('/etc/ceph/') }}"
+
+# Where files are copied to on the EDPM node
+edpm_ceph_client_files_config_home: "{{ edpm_ceph_client_config_home | default('/var/lib/openstack/config/ceph') }}"

--- a/roles/edpm_ceph_client_files/meta/argument_specs.yml
+++ b/roles/edpm_ceph_client_files/meta/argument_specs.yml
@@ -5,7 +5,7 @@ argument_specs:
     short_description: The main entry point for the edpm_ceph_client_files role.
     options:
       edpm_ceph_client_files_config_home:
-        default: '{{ edpm_ceph_client_config_home | default(''/etc/ceph/'') }}'
+        default: '{{ edpm_ceph_client_config_home | default(''/var/lib/openstack/config/ceph'') }}'
         description: Destination of ceph files on the remote machine.
         type: str
       edpm_ceph_client_files_source:

--- a/roles/edpm_libvirt/tasks/post-install.yml
+++ b/roles/edpm_libvirt/tasks/post-install.yml
@@ -6,11 +6,11 @@
   become: true
   changed_when: true
   shell: |
-    CLUSTERS=( $(ls /etc/ceph/*.conf | xargs -I {} basename  -s .conf {} ) )
+    CLUSTERS=( $(ls /var/lib/openstack/config/ceph/*.conf | xargs -I {} basename  -s .conf {} ) )
     declare -A CLUSTER_USER_MAP=()
-    for cluster in ${CLUSTERS[@]}; do CLUSTER_USER_MAP[${cluster}]=$(ls /etc/ceph/${cluster}.client.*.keyring | grep -v admin | awk -F . '{print $3}'); done
+    for cluster in ${CLUSTERS[@]}; do CLUSTER_USER_MAP[${cluster}]=$(ls /var/lib/openstack/config/ceph/${cluster}.client.*.keyring | grep -v admin | awk -F . '{print $3}'); done
     declare -A CLUSTER_FSID_MAP=()
-    for cluster in ${CLUSTERS[@]}; do CLUSTER_FSID_MAP[${cluster}]=$(awk -F '=' '/fsid/ {print $2}' /etc/ceph/${cluster}.conf| xargs); done
+    for cluster in ${CLUSTERS[@]}; do CLUSTER_FSID_MAP[${cluster}]=$(awk -F '=' '/fsid/ {print $2}' /var/lib/openstack/config/ceph/${cluster}.conf| xargs); done
     for cluster in ${CLUSTERS[@]}; do
     cat <<EOF | tee secret.xml>/dev/null
     <secret ephemeral='no' private='no'>
@@ -24,9 +24,10 @@
     rm -f secret.xml
     podman exec libvirt_virtqemud bash -c "virsh secret-undefine ${CLUSTER_FSID_MAP[${cluster}]}"
     podman exec libvirt_virtqemud bash -c "virsh secret-define --file /tmp/secret.xml; rm -f /tmp/secret.xml"
-    keyring=$(awk '$1 == "key" {print $3}' /etc/ceph/${cluster}.client.${CLUSTER_USER_MAP[$cluster]}.keyring)
+    keyring=$(awk '$1 == "key" {print $3}' /var/lib/openstack/config/ceph/${cluster}.client.${CLUSTER_USER_MAP[$cluster]}.keyring)
     podman exec libvirt_virtqemud bash -c "virsh secret-set-value ${CLUSTER_FSID_MAP[${cluster}]} --base64 ${keyring}"
     done
+
 - name: Copy qemu vnc firewall config
   tags:
     - install


### PR DESCRIPTION
On EDPM nodes Ceph client files were being stored in /etc/ceph. In an HCI scenario /etc/ceph could also host Ceph server files. To prevent any possible conflict store the client files in /var/lib/openstack/config/ceph. Inside the continers the path will remain /etc/ceph even though it changed on the host.

Jira: [OSP-27777](https://issues.redhat.com//browse/OSP-27777)