### PR TITLE
Don't override the compute routing

### DIFF
--- a/roles/edpm_network_config/templates/ci/extracted_crc_nic2_vlans.j2
+++ b/roles/edpm_network_config/templates/ci/extracted_crc_nic2_vlans.j2
@@ -14,7 +14,6 @@ network_config:
   domain: {{ dns_search_domains }}
   addresses:
   - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
-  routes: {{ ctlplane_host_routes }}
   members:
   - type: interface
     name: nic2


### PR DESCRIPTION
This patch will ensure the compute is still reachable in the CI
ecosystem, since the default route should be on the public interface and
not touched.

Note: once we're able to switch to the multinode layout, we will refine
the job and leverage the proper networkConfig.template, allowing to
remove this file. But we can't run too many rabbits at the same time.
