### PR TITLE
Add edpm_libvirt molecule test to assert correct NFT output

### DIFF
--- a/roles/edpm_libvirt/molecule/default/test-helpers/verify_firewall.yaml
+++ b/roles/edpm_libvirt/molecule/default/test-helpers/verify_firewall.yaml
@@ -28,3 +28,12 @@
         that:
           - rule_source_exists.stat.exists
         fail_msg: "vnc rule source file does not exist"
+    - name: Run nft list command and grep for VNC rule in EDPM_INPUT chain
+      become: true
+      ansible.builtin.shell: nft list table inet filter | awk '/chain EDPM_INPUT {/,/}/' | grep vnc
+      register: chain_exists
+    - name: Assert that output from greping for VNC contains the correct rule
+      assert:
+        that:
+          - item | regex_search('\s+tcp dport 5900-6923 ct state new counter packets \d+ bytes \d+ accept comment\s+')
+      loop: "{{ chain_exists.stdout_lines }}"


### PR DESCRIPTION
The edpm_libvirt molecule test runs on localhost and updates the NFT firewall. Add tasks to the verify firewall molecule test which get the output of the EDPM_INPUT chain from an `nft list` command and then assert that an expected VNC rule is present.

Follow up patch to bd56fbadc6185ddda39ab1c2c1fd226b65556e65 
Jira: OSP-27573
Signed-off-by: John Fulton <fulton@redhat.com>