### PR TITLE
Removing json_query calls

### DIFF
--- a/plugins/filter/jump_chain_targets.yml
+++ b/plugins/filter/jump_chain_targets.yml
@@ -1,0 +1,16 @@
+DOCUMENTATION:
+  name: jump_chain_targets
+  author: "EDPM team"
+  version_added: 2.9
+  short_description: Retrieve existing jump chain targets
+  description: |
+    Filters valid chain target rules satisfying conditions based on
+    `table`, `family` and `chain` attributes.
+    Used by the osp.edpm.nftables role.
+EXAMPLES: |
+    '{{ edpm_nftables_chains_prefix }}_'~rule.get('chain', 'INPUT')
+     not in ( existing | osp.edpm.jump_chain_targets(rule=rule) )
+RETURN:
+  _value:
+    description: list of jump chain targets
+    type: list

--- a/roles/edpm_nftables/templates/jump-chain.j2
+++ b/roles/edpm_nftables/templates/jump-chain.j2
@@ -6,10 +6,9 @@
 {%   set existing = (current_nft['stdout']|from_json)['nftables']|map(attribute='rule', default={})|list %}
 {%   for ruleset in edpm_nftables_rules %}
 {%     set rule=ruleset['rule'] %}
-{%     set query="[? table==`"~rule.get('table', 'filter')~"` && family==`inet` && chain==`"~rule.get('chain', 'INPUT')~"`].expr[*].jump.target" %}
 {%     set chain_key = rule.get('chain', 'INPUT') ~ rule.get('table', 'filter') %}
 {%     if chain_key not in chains.chains %}
-{%       if '{{ edpm_nftables_chains_prefix }}_'~rule.get('chain', 'INPUT') not in (existing|json_query(query)|flatten) %}
+{%       if '{{ edpm_nftables_chains_prefix }}_'~rule.get('chain', 'INPUT') not in ( existing | osp.edpm.jump_chain_targets(rule=rule) ) %}
 insert rule inet {{ rule.get('table', 'filter') }} {{ rule.get('chain', 'INPUT') }} position 0 jump {{ edpm_nftables_chains_prefix }}_{{ rule.get('chain', 'INPUT') }}
 {%       endif %}
 {%       set _ = chains.chains.append(chain_key) %}

--- a/roles/edpm_podman/templates/podman_network_config.j2
+++ b/roles/edpm_podman/templates/podman_network_config.j2
@@ -1,9 +1,9 @@
 {
-  "name": "{{ podman_network_inspect.stdout | from_json | first | json_query('name') }}",
-  "id": "{{ podman_network_inspect.stdout | from_json | first | json_query('id') }}",
-  "driver": "{{ podman_network_inspect.stdout | from_json | first | json_query('driver') }}",
-  "network_interface": "{{ podman_network_inspect.stdout | from_json | first | json_query('network_interface') }}",
-  "created": "{{ podman_network_inspect.stdout | from_json | first | json_query('created') }}",
+  "name": "{{ (podman_network_inspect.stdout | from_json | first)['name'] }}",
+  "id": "{{ (podman_network_inspect.stdout | from_json | first)['id'] }}",
+  "driver": "{{ (podman_network_inspect.stdout | from_json | first)['driver'] }}",
+  "network_interface": "{{ (podman_network_inspect.stdout | from_json | first)['network_interface'] }}",
+  "created": "{{ (podman_network_inspect.stdout | from_json | first)['created'] }}",
   "subnets": [
     {
       "subnet": "10.255.255.0/24",
@@ -15,7 +15,7 @@
     }
   ],
   "ipv6_enabled": true,
-  "internal": {{ podman_network_inspect.stdout | from_json | first | json_query('internal') | to_json }},
-  "dns_enabled": {{ podman_network_inspect.stdout | from_json | first | json_query('dns_enabled') | to_json }},
-  "ipam_options": {{ podman_network_inspect.stdout | from_json | first | json_query('ipam_options') | to_json }}
+  "internal": {{ (podman_network_inspect.stdout | from_json | first)['internal'] | to_json }},
+  "dns_enabled": {{ (podman_network_inspect.stdout | from_json | first)['dns_enabled'] | to_json }},
+  "ipam_options": {{ (podman_network_inspect.stdout | from_json | first)['ipam_options'] | to_json }}
 }

--- a/roles/env_data/tasks/main.yml
+++ b/roles/env_data/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Output installed packages
   ansible.builtin.debug:
-    msg: "{{ ansible_facts.packages | community.general.json_query('*') | flatten | join('\n') }}"
+    msg: "{{ ansible_facts.packages | flatten }}"
 
 - name: Output installed repositories
   ansible.builtin.debug:


### PR DESCRIPTION
We aren't going to be shipping required package, so we need to work around this. In most cases the query wasn't necessary in the first place. The exception being the jump targets template, in which case it was replaced by a specialized filter.

Note that the filter isn't general, it can not be, otherwise we would have to reimplement json query, or get another dependency. Neither of which is something we need or should pursue. Therefore, if there comes a time when the template is adjusted, the filter will need some changes as well.