### PR TITLE
Refactor Ceph libvirt secret management code

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -25,3 +25,4 @@ edpm_libvirt_containers:
   - "libvirt_virtproxyd"
   - "libvirt_virtqemud"
   - "libvirt_virtsecretd"
+edpm_libvirt_ceph_path: /var/lib/openstack/config/ceph/

--- a/roles/edpm_libvirt/molecule/default/prepare.yml
+++ b/roles/edpm_libvirt/molecule/default/prepare.yml
@@ -30,12 +30,15 @@
         path: /etc/localtime
         src: /usr/share/zoneinfo/UTC
         state: link
+
     - name: set timezone
-      import_role:
+      ansible.builtin.import_role:
         name: "edpm_timezone"
+
     - name: install podman
-      import_role:
+      ansible.builtin.import_role:
         name: "edpm_podman"
+
     - name: Create firewall directory
       become: true
       ansible.builtin.file:
@@ -44,12 +47,63 @@
         owner: root
         group: root
         mode: 0750
+
     - name: open port 22 (edpm_nftables will active this later)
       become: true
-      copy:
+      ansible.builtin.copy:
         dest: /var/lib/edpm-config/firewall/sshd-networks.yaml
         content: |
           - rule_name: 003 Allow SSH
             rule:
               proto: tcp
               dport: 22
+
+    # edpm_nova molecule depends on edpm_libvirt so it tests
+    # the case where this directory does not exsit
+    - name: Create Ceph client file directory
+      become: true
+      ansible.builtin.file:
+        path: '/var/lib/openstack/config/ceph/'
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Create random mock Ceph FSID
+      ansible.builtin.command: uuidgen
+      register: fsid
+
+    - name: Create random mock Cephx key
+      ansible.builtin.shell:
+      args:
+        executable: /usr/bin/python
+        cmd: |
+          import os,struct,time,base64
+          key = os.urandom(16)
+          header = struct.pack("<hiih", 1, int(time.time()), 0, len(key))
+          print(base64.b64encode(header + key).decode())
+      register: cephx
+
+    - name: Create a mock Ceph conf file
+      become: true
+      ansible.builtin.copy:
+        dest: /var/lib/openstack/config/ceph/ceph.conf
+        content: |
+          [global]
+          fsid = {{ fsid.stdout }}
+          mon host = 192.168.42.6,192.168.42.7,192.168.42.8
+
+    - name: Create a mock Cephx keyring file
+      become: true
+      ansible.builtin.copy:
+        dest: /var/lib/openstack/config/ceph/ceph.client.openstack.keyring
+        content: |
+          [client.openstack]
+          key = {{ cephx.stdout }}
+          caps mgr = allow rw
+          caps mon = profile r
+          caps osd = allow class-read object_prefix rbd_children, {{
+                                    pools | map('regex_replace', '^(.*)$',
+                                    'allow rwx pool=\1') | join(', ') }}
+      vars:
+        pools: ['vms', 'volumes', 'images']

--- a/roles/edpm_libvirt/molecule/default/test-helpers/verify_ceph_secret.yaml
+++ b/roles/edpm_libvirt/molecule/default/test-helpers/verify_ceph_secret.yaml
@@ -1,0 +1,29 @@
+- name: Get the mock FSID from ceph conf file
+  become: true
+  ansible.builtin.shell: |
+    awk -F '=' '/fsid/ {print $2}' {{ conf_path }} | xargs
+  vars:
+    conf_path: /var/lib/openstack/config/ceph/ceph.conf
+  register: fsid
+
+- name: Get the mock cephx key from ceph keyring file
+  become: true
+  ansible.builtin.command: |
+    awk '$1 == "key" {print $3}' {{ key_path }}
+  vars:
+    key_path: /var/lib/openstack/config/ceph/ceph.client.openstack.keyring
+  register: cephx
+
+- name: Get cephx key from libvirt_virtsecretd container by passing FSID
+  become: true
+  ansible.builtin.command: |
+    podman exec libvirt_virtsecretd bash -c "virsh secret-get-value $FSID"
+  environment:
+    FSID: "{{ fsid.stdout }}"
+  register: virsh_secret
+
+- name: Assert that virsh secret-get-value returned the correct value
+  ansible.builtin.assert:
+    that:
+      - virsh_secret.stdout == cephx.stdout
+    fail_msg: "virsh secret-get-value {{ fsid.stdout }} return value is wrong"

--- a/roles/edpm_libvirt/molecule/default/verify.yml
+++ b/roles/edpm_libvirt/molecule/default/verify.yml
@@ -24,6 +24,8 @@
         - "/var/log/containers/libvirt"
     - name: ensure firewall is configured
       ansible.builtin.include_tasks: "test-helpers/verify_firewall.yaml"
+    - name: ensure ceph secret is configured
+      ansible.builtin.include_tasks: "test-helpers/verify_ceph_secret.yaml"
     - name: ensure systemd services are defined and functional
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_systemd_service.yaml"
       with_items:

--- a/roles/edpm_libvirt/tasks/post-install.yml
+++ b/roles/edpm_libvirt/tasks/post-install.yml
@@ -1,32 +1,57 @@
 ---
-- name: update ceph libvirt secret
+- name: Gather Ceph configuration files
   tags:
     - install
     - post-libvirt
+    - ceph
   become: true
-  changed_when: true
-  shell: |
-    CLUSTERS=( $(ls /var/lib/openstack/config/ceph/*.conf | xargs -I {} basename  -s .conf {} ) )
-    declare -A CLUSTER_USER_MAP=()
-    for cluster in ${CLUSTERS[@]}; do CLUSTER_USER_MAP[${cluster}]=$(ls /var/lib/openstack/config/ceph/${cluster}.client.*.keyring | grep -v admin | awk -F . '{print $3}'); done
-    declare -A CLUSTER_FSID_MAP=()
-    for cluster in ${CLUSTERS[@]}; do CLUSTER_FSID_MAP[${cluster}]=$(awk -F '=' '/fsid/ {print $2}' /var/lib/openstack/config/ceph/${cluster}.conf| xargs); done
-    for cluster in ${CLUSTERS[@]}; do
-    cat <<EOF | tee secret.xml>/dev/null
-    <secret ephemeral='no' private='no'>
-    <uuid>${CLUSTER_FSID_MAP[${cluster}]}</uuid>
-    <usage type='ceph'>
-        <name>${cluster}.client.${CLUSTER_USER_MAP[$cluster]} secret</name>
-    </usage>
-    </secret>
-    EOF
-    podman cp secret.xml libvirt_virtqemud:/tmp/secret.xml
-    rm -f secret.xml
-    podman exec libvirt_virtqemud bash -c "virsh secret-undefine ${CLUSTER_FSID_MAP[${cluster}]}"
-    podman exec libvirt_virtqemud bash -c "virsh secret-define --file /tmp/secret.xml; rm -f /tmp/secret.xml"
-    keyring=$(awk '$1 == "key" {print $3}' /var/lib/openstack/config/ceph/${cluster}.client.${CLUSTER_USER_MAP[$cluster]}.keyring)
-    podman exec libvirt_virtqemud bash -c "virsh secret-set-value ${CLUSTER_FSID_MAP[${cluster}]} --base64 ${keyring}"
-    done
+  ansible.builtin.find:
+    paths: "{{ edpm_libvirt_ceph_path }}"
+    patterns: "*.conf"
+  register: found_confs
+
+- name: Update Ceph Libvirt secret if Ceph files were found
+  tags:
+    - install
+    - post-libvirt
+    - ceph
+  become: true
+  when:
+    - found_confs.files is defined
+    - found_confs.files | length > 0
+  block:
+    - name: Extract FSIDs from Ceph configuration files
+      ansible.builtin.shell: |
+        echo {{ (item | basename).split('.')[0] }}
+        awk -F '=' '/fsid/ {print $2}' {{ item }} | xargs
+      register: fsids
+      loop: "{{ found_confs.files | map(attribute='path') }}"
+
+    - name: Map Ceph clusters to FSIDs
+      ansible.builtin.set_fact:
+        cluster_fsid_map: "{{ cluster_fsid_map | default({}) |\
+          combine({item.stdout_lines[0] : item.stdout_lines[1] }) }}"
+      loop: "{{ fsids.results }}"
+
+    - name: Gather Ceph keyring files
+      ansible.builtin.find:
+        paths: "{{ edpm_libvirt_ceph_path }}"
+        patterns: "*.keyring"
+      register: found_keys
+
+    - name: Map Ceph clusters to cephx users
+      ansible.builtin.set_fact:
+        cluster_user_map: "{{ cluster_user_map | default({}) |\
+          combine({item.split('.')[0] : item.split('.')[2] }) }}"
+      loop: "{{ found_keys.files | map(attribute='path') | map('basename') }}"
+
+    - name: Use maps to create libvirt secrets
+      ansible.builtin.include_tasks: virsh-secret.yml
+      vars:
+        cluster: "{{ item }}"
+        fsid: "{{ cluster_fsid_map[item] }}"
+        user: "{{ cluster_user_map[item] }}"
+      loop: "{{ cluster_fsid_map.keys() | list }}"
 
 - name: Copy qemu vnc firewall config
   tags:

--- a/roles/edpm_libvirt/tasks/virsh-secret.yml
+++ b/roles/edpm_libvirt/tasks/virsh-secret.yml
@@ -1,0 +1,41 @@
+---
+- name: Create XML file for virsh secret on container host
+  ansible.builtin.template:
+    src: libvirt_virtqemud/secret.xml.j2
+    dest: /tmp/secret.xml
+    mode: "0600"
+
+- name: Copy XML file into libvirt_virtqemud container
+  ansible.builtin.command: podman cp /tmp/secret.xml libvirt_virtqemud:/tmp/secret.xml
+
+- name: Delete XML secret file on host
+  ansible.builtin.file:
+    path: /tmp/secret.xml
+    state: absent
+
+- name: Run virsh secret-define inside the libvirt_virtqemud container
+  changed_when: true
+  ansible.builtin.shell: "podman exec libvirt_virtqemud bash -c '{{ '; '.join(cmds) }}'"
+  vars:
+    cmds:
+      - "virsh secret-undefine {{ fsid }}"
+      - "virsh secret-define --file /tmp/secret.xml"
+      - "rm -f /tmp/secret.xml"
+
+- name: Register cephx_key
+  ansible.builtin.command: "awk '$1 == \"key\" {print $3}' {{ key_path }}"
+  no_log: true
+  register: cephx_key
+  vars:
+    key_path: "{{ edpm_libvirt_ceph_path }}/{{ cluster }}.client.{{ user }}.keyring"
+
+- name: Run virsh secret-set-value inside the libvirt_virtqemud container if the cephx_key is valid
+  no_log: true
+  changed_when: true
+  ansible.builtin.command: "podman exec libvirt_virtqemud bash -c 'virsh secret-set-value $FSID --base64 $KEY'"
+  environment:
+    FSID: "{{ fsid }}"
+    KEY: "{{ cephx_key.stdout }}"
+  when:
+    - cephx_key.stdout is defined
+    - cephx_key.stdout | regex_search('^[a-zA-Z0-9+/]{38}==$')

--- a/roles/edpm_libvirt/templates/libvirt_virtqemud/secret.xml.j2
+++ b/roles/edpm_libvirt/templates/libvirt_virtqemud/secret.xml.j2
@@ -1,0 +1,6 @@
+<secret ephemeral='no' private='no'>
+<uuid>{{ fsid }}</uuid>
+<usage type='ceph'>
+    <name>{{ cluster }}.client.{{ user }} secret</name>
+</usage>
+</secret>


### PR DESCRIPTION
Replace shell script with Ansible tasks. The shell script creates data structures, has an XML template, and executes commands. Bulild data structures in Ansible, use the template module, add a validation on cephx key value but also run commands where necessary. Aim is to make the Ansible logs easier to debug in the field.

Update edpm_libvirt molecule to test the new Ansible tasks. This includes generating mock data during prepare and confirming libvirt outputs the correct data during verify. Also, add whitespace to prepare.yml for readability.

Jira: [OSP-27777](https://issues.redhat.com//browse/OSP-27777)