### PR TITLE
Add edpm role to deploy Neutron SRIOV agent

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -25,6 +25,7 @@ jobs:
         - edpm_container_standalone
         - edpm_logrotate_crond
         - edpm_network_config
+        - edpm_neutron_sriov
         - edpm_nftables
         - edpm_nodes_validation
         - edpm_nova_compute

--- a/playbooks/neutron_sriov.yaml
+++ b/playbooks/neutron_sriov.yaml
@@ -1,0 +1,11 @@
+---
+- name: Deploy EDPM Neutron SR-IOV agent
+  hosts: all
+  strategy: linear
+  become: true
+  tasks:
+    - name: Neutron SR-IOV agent
+      import_role:
+        name: osp.edpm.edpm_neutron_sriov
+      tags:
+        - edpm_neutron_sriov

--- a/roles/edpm_neutron_sriov/OWNERS
+++ b/roles/edpm_neutron_sriov/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+  - slawqo
+  - network-approvers
+
+reviewers:
+  - slawqo
+  - network-approvers

--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -1,0 +1,71 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of "edpm_neutron_sriov_agent"
+edpm_neutron_sriov_agent_config_dir: "/var/lib/config-data/ansible-generated/neutron-sriov-agent"
+edpm_neutron_sriov_image: "quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent:current-podified"
+
+edpm_neutron_sriov_common_volumes:
+  - /lib/modules:/lib/modules:ro
+  - /dev:/dev
+  - "{{ edpm_neutron_sriov_agent_config_dir }}:/etc/neutron:z"
+  - /var/lib/neutron:/var/lib/neutron:shared,z
+  - /var/lib/kolla/config_files/neutron_sriov_agent.json:/var/lib/kolla/config_files/config.json:ro
+  - /var/log/containers/neutron:/var/log/neutron:z
+
+# neutron.conf
+# DEFAULT
+edpm_neutron_sriov_DEFAULT_debug: false
+edpm_neutron_sriov_DEFAULT_rpc_response_timeout: 60
+edpm_neutron_sriov_DEFAULT_transport_url: ''
+edpm_neutron_sriov_DEFAULT_host: '{{ ansible_facts["nodename"] }}'
+# oslo_concurrency
+edpm_neutron_sriov_oslo_concurrency_lock_patch: '$state_path/lock'
+# oslo_messaging_rabbit
+edpm_neutron_sriov_oslo_messaging_rabbit_heartbeat_timeout_threshold: 60
+# oslo_middleware
+edpm_neutron_sriov_oslo_middleware_enable_proxy_headers_parsing: 60
+
+# rootwrap.conf
+# DEFAULT
+edpm_neutron_sriov_rootwrap_DEFAULT_filters_path: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+edpm_neutron_sriov_rootwrap_DEFAULT_exec_dirs: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
+edpm_neutron_sriov_rootwrap_DEFAULT_use_syslog: 'False'
+edpm_neutron_sriov_rootwrap_DEFAULT_syslog_log_facility: 'syslog'
+edpm_neutron_sriov_rootwrap_DEFAULT_syslog_log_level: 'ERROR'
+edpm_neutron_sriov_rootwrap_DEFAULT_daemon_timeout: 600
+edpm_neutron_sriov_rootwrap_DEFAULT_rlimit_nofile: 1024
+
+# neutron-sriov-agent.ini
+# DEFAULT
+edpm_neutron_sriov_agent_DEFAULT_state_path: '/var/lib/neutron'
+# AGENT
+edpm_neutron_sriov_agent_AGENT_root_helper: 'sudo neutron-rootwrap /etc/neutron/rootwrap.conf'
+edpm_neutron_sriov_agent_AGENT_report_interval: 300
+edpm_neutron_sriov_agent_AGENT_extensions: 'qos'
+edpm_neutron_sriov_agent_AGENT_polling_interval: 2
+# SRIOV_NIC
+edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings: ''
+edpm_neutron_sriov_agent_SRIOV_NIC_exclude_devices: ''
+edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_bandwidths: ''
+edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_hypervisors: ''
+edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_default_hypervisor: ''
+edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_inventory_defaults: 'allocation_ratio:1.0,min_unit:1,step_size:1,reserved:0'
+# SRIOV_DRIVER
+edpm_neutron_sriov_agent_SRIOV_DRIVER_vnic_type_prohibit_list: ''

--- a/roles/edpm_neutron_sriov/handlers/main.yml
+++ b/roles/edpm_neutron_sriov/handlers/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: restart neutron-sriov-agent container
+  become: true
+  ansible.builtin.systemd:
+    state: restarted
+    name: "edpm_neutron_sriov_agent.service"
+  listen: "restart neutron-sriov-agent"

--- a/roles/edpm_neutron_sriov/meta/argument_specs.yml
+++ b/roles/edpm_neutron_sriov/meta/argument_specs.yml
@@ -1,0 +1,126 @@
+---
+argument_specs:
+  # ./roles/edpm_neutron_sriov/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_neutron_sriov role.
+    options:
+      edpm_neutron_sriov_agent_config_dir:
+        default: "/var/lib/config-data/ansible-generated/neutron-sriov-agent"
+        description: |
+          The path to the directory containing Neutron SRIOV NIC agent config
+          files.
+        type: str
+      edpm_neutron_sriov_image:
+        default: "quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent:current-podified"
+        description: Neutron SRIOV NIC agent container image.
+        type: str
+      edpm_neutron_sriov_common_volumes:
+        default:
+          - /lib/modules:/lib/modules:ro
+          - /dev:/dev
+          - "{{ edpm_neutron_sriov_agent_config_dir }}:/etc/neutron:z"
+          - /var/lib/neutron:/var/lib/neutron:shared,z
+          - /var/lib/kolla/config_files/neutron_sriov_agent.json:/var/lib/kolla/config_files/config.json:ro
+          - /var/log/containers/neutron:/var/log/neutron:z
+        description: List of volumes in a mount point form.
+        type: list
+      edpm_neutron_sriov_DEFAULT_debug:
+        default: false
+        description: "Enable or disable DEBUG mode in the Neutron agent"
+        type: bool
+      edpm_neutron_sriov_DEFAULT_rpc_response_timeout:
+        default: 60
+        description: ''
+        type: int
+      edpm_neutron_sriov_DEFAULT_transport_url:
+        default: ''
+        description: ''
+        type: str
+      edpm_neutron_sriov_DEFAULT_host:
+        default: '{{ ansible_facts["nodename"] }}'
+        description: ''
+        type: str
+      edpm_neutron_sriov_oslo_concurrency_lock_patch:
+        default: '$state_path/lock'
+        description: ''
+        type: str
+      edpm_neutron_sriov_oslo_messaging_rabbit_heartbeat_timeout_threshold:
+        default: 60
+        description: ''
+        type: int
+      edpm_neutron_sriov_oslo_middleware_enable_proxy_headers_parsing:
+        default: 60
+        description: ''
+        type: int
+      edpm_neutron_sriov_rootwrap_DEFAULT_filters_path:
+        default: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+      edpm_neutron_sriov_rootwrap_DEFAULT_exec_dirs:
+        default: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
+      edpm_neutron_sriov_rootwrap_DEFAULT_use_syslog:
+        default: false
+        description: ''
+        type: bool
+      edpm_neutron_sriov_rootwrap_DEFAULT_syslog_log_facility:
+        default: 'syslog'
+        description: ''
+        type: str
+      edpm_neutron_sriov_rootwrap_DEFAULT_syslog_log_level:
+        default: 'ERROR'
+        description: ''
+        type: str
+      edpm_neutron_sriov_rootwrap_DEFAULT_daemon_timeout:
+        default: 600
+        description: ''
+        type: int
+      edpm_neutron_sriov_rootwrap_DEFAULT_rlimit_nofile:
+        default: 1024
+        description: ''
+        type: int
+      edpm_neutron_sriov_agent_DEFAULT_state_path:
+        default: '/var/lib/neutron'
+        description: ''
+        type: str
+      edpm_neutron_sriov_agent_AGENT_root_helper:
+        default: 'sudo neutron-rootwrap /etc/neutron/rootwrap.conf'
+        description: ''
+        type: str
+      edpm_neutron_sriov_agent_AGENT_report_interval:
+        default: 300
+        description: ''
+        type: int
+      edpm_neutron_sriov_agent_AGENT_extensions:
+        default: 'qos'
+        description: ''
+        type: str
+      edpm_neutron_sriov_agent_AGENT_polling_interval:
+        default: 2
+        description: ''
+        type: int
+      edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings:
+        default: ''
+        description: ''
+        type: str
+      edpm_neutron_sriov_agent_SRIOV_NIC_exclude_devices:
+        default: ''
+        description: ''
+        type: str
+      edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_bandwidths:
+        default: ''
+        description: ''
+        type: str
+      edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_hypervisors:
+        default: ''
+        description: ''
+        type: str
+      edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_default_hypervisor:
+        default: ''
+        description: ''
+        type: str
+      edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_inventory_defaults:
+        default: 'allocation_ratio:1.0,min_unit:1,step_size:1,reserved:0'
+        description: ''
+        type: str
+      edpm_neutron_sriov_agent_SRIOV_DRIVER_vnic_type_prohibit_list:
+        default: ''
+        description: ''
+        type: str

--- a/roles/edpm_neutron_sriov/meta/main.yml
+++ b/roles/edpm_neutron_sriov/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_neutron_sriov
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_neutron_sriov/molecule/default/collections.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+- name: community.general

--- a/roles/edpm_neutron_sriov/molecule/default/converge.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/converge.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "edpm_neutron_sriov"
+      vars:
+        edpm_neutron_sriov_DEFAULT_transport_url: "fake:/"

--- a/roles/edpm_neutron_sriov/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: fake-sriov-compute-1
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - verify
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_neutron_sriov/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+- name: Prepare test_deps
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+      test_deps_extra_packages:
+        - iproute
+        - podman

--- a/roles/edpm_neutron_sriov/molecule/default/verify.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/verify.yml
@@ -1,0 +1,39 @@
+---
+- name: Verify neutron-sriov-agent
+  gather_facts: false
+  hosts: all
+  vars:
+    test_helper_dir: "../../../../molecule/test-helpers"
+  tasks:
+    - name: ensure expected directories exist
+      ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_dir.yaml"
+      with_items:
+        - "/var/lib/neutron"
+        - "/var/lib/openstack/config/containers"
+        - "/var/lib/kolla/config_files/neutron_sriov_agent.json"
+        - "/var/lib/config-data/ansible-generated/neutron-sriov-agent"
+        - "/var/log/containers/neutron"
+        - "/var/log/containers/stdouts"
+
+    - name: ensure systemd services are defined and functional
+      ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_systemd_service.yaml"
+      with_items:
+        - "edpm_neutron_sriov_agent"
+
+    - name: ensure podman container exists and are running
+      ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_podman.yaml"
+      with_items:
+        - "neutron_sriov_agent"
+
+    - name: ensure that log file for neutron-sriov-agent exist
+      become: true
+      block:
+        - name: Check if file /var/log/containers/neutron/neutron-sriov-nic-agent.log exist
+          ansible.builtin.stat:
+            path: /var/log/containers/neutron/neutron-sriov-nic-agent.log
+          register: log_file
+        - name: Assert file /var/log/containers/neutron/neutron-sriov-nic-agent.log exist
+          ansible.builtin.assert:
+            that:
+              - log_file.stat.exists
+            fail_msg: "File /var/log/containers/neutron/neutron-sriov-nic-agent.log does not exist"

--- a/roles/edpm_neutron_sriov/tasks/configure.yml
+++ b/roles/edpm_neutron_sriov/tasks/configure.yml
@@ -1,0 +1,31 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Render neutron configuration files
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ edpm_neutron_sriov_agent_config_dir }}/{{ item.dest }}"
+    setype: "container_file_t"
+    mode: "0644"
+  with_items:
+    - {"src": "neutron.conf.j2", "dest": "neutron.conf"}
+    - {"src": "rootwrap.conf.j2", "dest": "rootwrap.conf"}
+    - {"src": "neutron-sriov-agent.ini.j2", "dest": "neutron-sriov-agent.ini"}
+  tags:
+    - configure
+    - neutron
+  notify:
+  - restart neutron-sriov-agent

--- a/roles/edpm_neutron_sriov/tasks/install.yml
+++ b/roles/edpm_neutron_sriov/tasks/install.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create neutron-sriov-agent directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    setype: "container_file_t"
+    state: directory
+    mode: "{{ item.mode | default(omit) }}"
+  with_items:
+    - {'path': "/var/lib/openstack/config/containers", "mode": "0750" }
+    - {'path': "/var/lib/neutron", "mode": "0750" }
+    - {'path': "{{ edpm_neutron_sriov_agent_config_dir }}", 'mode': '0755'}
+    - {'path': "/var/log/containers/stdouts"}
+    - {'path': "/var/log/containers/neutron"}
+  tags:
+    - install
+    - neutron
+
+- name: render neutron-sriov-agent container
+  become: true
+  ansible.builtin.template:
+    src: "neutron_sriov_agent.yaml.j2"
+    dest: "/var/lib/openstack/config/containers/neutron_sriov_agent.yaml"
+    setype: "container_file_t"
+    mode: 0644
+  notify:
+  - restart neutron-sriov-agent
+  tags:
+    - install
+    - neutron

--- a/roles/edpm_neutron_sriov/tasks/main.yml
+++ b/roles/edpm_neutron_sriov/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Install neutron-sriov-agent
+  ansible.builtin.import_tasks: install.yml
+
+- name: Configure neutron-sriov-agent
+  ansible.builtin.import_tasks: configure.yml
+
+- name: Ensure neutron-sriov-agent is running
+  ansible.builtin.import_tasks: run.yml

--- a/roles/edpm_neutron_sriov/tasks/run.yml
+++ b/roles/edpm_neutron_sriov/tasks/run.yml
@@ -1,0 +1,32 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure /usr/libexec/edpm-start-podman-container exists
+  ansible.builtin.import_role:
+    name: edpm_container_manage
+    tasks_from: shutdown.yml
+
+- name: Run neutron-sriov-agent container
+  debugger: on_failed
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_debug: true
+    edpm_container_standalone_service: neutron_sriov_agent
+    edpm_container_standalone_container_defs:
+      neutron_sriov_agent: "{{ lookup('template', 'neutron_sriov_agent.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      neutron_sriov_agent: "{{ lookup('template', 'kolla_config/neutron_sriov_agent.yaml.j2') | from_yaml }}"

--- a/roles/edpm_neutron_sriov/templates/kolla_config/neutron_sriov_agent.yaml.j2
+++ b/roles/edpm_neutron_sriov/templates/kolla_config/neutron_sriov_agent.yaml.j2
@@ -1,0 +1,16 @@
+command: "/usr/bin/neutron-sriov-nic-agent"
+permissions:
+  - owner: neutron:neutron
+    path: /var/log/neutron
+    recurse: true
+  - owner: neutron:neutron
+    path: /var/lib/neutron
+    recurse: true
+  - optional: true
+    owner: neutron:neutron
+    path: /etc/pki/tls/certs/neutron_sriov_agent.crt
+    perm: 0644
+  - optional: true
+    owner: neutron:neutron
+    path: /etc/pki/tls/private/neutron_sriov_agent.key
+    perm: 0644

--- a/roles/edpm_neutron_sriov/templates/neutron-sriov-agent.ini.j2
+++ b/roles/edpm_neutron_sriov/templates/neutron-sriov-agent.ini.j2
@@ -1,0 +1,19 @@
+[DEFAULT]
+state_path = {{ edpm_neutron_sriov_agent_DEFAULT_state_path }}
+
+[AGENT]
+extensions = {{ edpm_neutron_sriov_agent_AGENT_extensions }}
+polling_interval = {{ edpm_neutron_sriov_agent_AGENT_polling_interval }}
+root_helper = {{ edpm_neutron_sriov_agent_AGENT_root_helper }}
+report_interval = {{ edpm_neutron_sriov_agent_AGENT_report_interval }}
+
+[SRIOV_NIC]
+physical_device_mappings = {{ edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings }}
+exclude_devices = {{ edpm_neutron_sriov_agent_SRIOV_NIC_exclude_devices }}
+resource_provider_bandwidths = {{ edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_bandwidths }}
+resource_provider_hypervisors = {{ edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_hypervisors }}
+resource_provider_default_hypervisor = {{ edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_default_hypervisor }}
+resource_provider_inventory_defaults = {{ edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_inventory_defaults }}
+
+[SRIOV_DRIVER]
+vnic_type_prohibit_list = {{ edpm_neutron_sriov_agent_SRIOV_DRIVER_vnic_type_prohibit_list }}

--- a/roles/edpm_neutron_sriov/templates/neutron.conf.j2
+++ b/roles/edpm_neutron_sriov/templates/neutron.conf.j2
@@ -1,0 +1,14 @@
+[DEFAULT]
+log_file = /var/log/neutron/neutron-sriov-nic-agent.log
+debug = {{ edpm_neutron_sriov_DEFAULT_debug }}
+rpc_response_timeout = {{ edpm_neutron_sriov_DEFAULT_rpc_response_timeout }}
+transport_url = {{ edpm_neutron_sriov_DEFAULT_transport_url }}
+
+[oslo_concurrency]
+lock_path = {{ edpm_neutron_sriov_oslo_concurrency_lock_patch }}
+
+[oslo_messaging_rabbit]
+heartbeat_timeout_threshold = {{ edpm_neutron_sriov_oslo_messaging_rabbit_heartbeat_timeout_threshold }}
+
+[oslo_middleware]
+enable_proxy_headers_parsing = {{ edpm_neutron_sriov_oslo_middleware_enable_proxy_headers_parsing }}

--- a/roles/edpm_neutron_sriov/templates/neutron_sriov_agent.yaml.j2
+++ b/roles/edpm_neutron_sriov/templates/neutron_sriov_agent.yaml.j2
@@ -1,0 +1,14 @@
+start_order: 1
+image: "{{ edpm_neutron_sriov_image }}"
+net: host
+privileged: true
+user: neutron
+restart: always
+volumes:
+  {% set edpm_neutron_sriov_volumes = [] %}
+  {%- set edpm_neutron_sriov_volumes =
+          edpm_neutron_sriov_volumes +
+          edpm_neutron_sriov_common_volumes %}
+  {{ edpm_neutron_sriov_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_neutron_sriov/templates/rootwrap.conf.j2
+++ b/roles/edpm_neutron_sriov/templates/rootwrap.conf.j2
@@ -1,0 +1,8 @@
+[DEFAULT]
+filters_path = {{ edpm_neutron_sriov_rootwrap_DEFAULT_filters_path }}
+exec_dirs = {{ edpm_neutron_sriov_rootwrap_DEFAULT_exec_dirs }}
+use_syslog = {{ edpm_neutron_sriov_rootwrap_DEFAULT_use_syslog }}
+syslog_log_facility = {{ edpm_neutron_sriov_rootwrap_DEFAULT_syslog_log_facility }}
+syslog_log_level = {{ edpm_neutron_sriov_rootwrap_DEFAULT_syslog_log_level }}
+daemon_timeout = {{ edpm_neutron_sriov_rootwrap_DEFAULT_daemon_timeout }}
+rlimit_nofile = {{ edpm_neutron_sriov_rootwrap_DEFAULT_rlimit_nofile }}

--- a/roles/edpm_neutron_sriov/vars/main.yml
+++ b/roles/edpm_neutron_sriov/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "edpm_neutron_sriov"


### PR DESCRIPTION
This new roles deploys, configures and runs neutron-sriov-agent on the EDPM node if needed.