### PR TITLE
Add ceph_rgw and ceph_rgw_frontend in te list of enabled_services

### DIFF
--- a/roles/edpm_ceph_hci_pre/defaults/main.yml
+++ b/roles/edpm_ceph_hci_pre/defaults/main.yml
@@ -72,17 +72,12 @@ edpm_ceph_hci_pre_firewall_services:
     num: 122
     dport:
       - 8080
-      - 13808
+      - 8082
     ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
   - name: ceph_rgw_frontend
     num: 100
     dport:
       - 8080
-    ranges: "{{ edpm_ceph_hci_pre_rgw_frontend_ranges | list }}"
-  - name: ceph_ssl_rgw_frontend
-    num: 100
-    dport:
-      - 13808
     ranges: "{{ edpm_ceph_hci_pre_rgw_frontend_ranges | list }}"
   - name: ceph_rbdmirror
     num: 114
@@ -127,3 +122,5 @@ edpm_ceph_hci_pre_enabled_services:
   - ceph_mon
   - ceph_mgr
   - ceph_osd
+  - ceph_rgw
+  - ceph_rgw_frontend


### PR DESCRIPTION
When `Ceph` `HCI` is deployed and the `Ceph` firewall rules are applied, we need to make sure that if `RGW` is deployed by the `orchestrator`, both backends and the related frontend are able to communicate.
`RGW` can be deployed at `day1` or as part of `day2` operations, and eventually it can be updated to use `TLS`.
By adding `radosgw` among the `enabled_services` list by default, we can make sure to not hit firewall related issues.
In `CI` we use the `Storage` network to reserve a `VIP` for this service, however, in a production environment, an administrator can choose to expose `RGW` using a `public network`. 
For this reason both 'ceph_rgw' and 'ceph_rgw_frontend' are added to the default list.