### PR TITLE
Run EDPM job from podified-multinode-edpm-pipeline job template

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -36,20 +36,3 @@
     parent: edpm-ansible-molecule-base
     vars:
       TEST_RUN: edpm_nova
-
-# EDPM jobs
-- job:
-    name: edpm-ansible-crc-podified-edpm-baremetal
-    parent: cifmw-crc-podified-edpm-baremetal
-    irrelevant-files: &molecule_irrelevant_files
-      - LICENSE
-      - OWNERS.*
-      - README.md
-      - molecule/.*
-      - molecule-requirements.txt
-      - .github/workflows
-      - scripts/.*
-      - docs/.*
-      - contribute/.*
-      - tests
-      - roles/.*/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,6 +1,8 @@
 ---
 - project:
     name: openstack-k8s-operators/edpm-ansible
+    templates:
+      - podified-multinode-edpm-baremetal-pipeline
     github-check:
       jobs:
         - edpm-ansible-molecule-edpm_podman
@@ -8,10 +10,3 @@
         - edpm-ansible-molecule-edpm_kernel
         - edpm-ansible-molecule-edpm_libvirt
         - edpm-ansible-molecule-edpm_nova
-        - openstack-k8s-operators-content-provider
-        - podified-multinode-edpm-deployment-crc:
-            dependencies:
-              - openstack-k8s-operators-content-provider
-        - edpm-ansible-crc-podified-edpm-baremetal:
-            dependencies:
-              - openstack-k8s-operators-content-provider


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/534 adds the Zuul Project template for running content provider and edpm/baremetal jobs.

It will allow devs to update the job at one place and test anywhere. edpm-ansible-crc-podified-edpm-baremetal is the similar job of ci-framework-crc-podified-edpm-baremetal but different name.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/326