### PR TITLE
Role edpm_ceph_hci_pre needs become to update firewall

### DIFF
--- a/roles/edpm_ceph_hci_pre/tasks/firewall.yml
+++ b/roles/edpm_ceph_hci_pre/tasks/firewall.yml
@@ -15,6 +15,7 @@
 # under the License.
 
 - name: Ensure firewall directory is present
+  become: true
   ansible.builtin.file:
     path: "{{ edpm_ceph_hci_pre_firewall_yaml_file | dirname }}"
     state: directory
@@ -23,6 +24,7 @@
     mode: '0750'
 
 - name: Inject firewall configuration for Ceph Server
+  become: true
   ansible.builtin.template:
     dest: "{{ edpm_ceph_hci_pre_firewall_yaml_file }}"
     src: 'firewall.yaml.j2'


### PR DESCRIPTION
Add `become: true` to tasks in firewall.yml from the role edpm_ceph_hci_pre since the move to using cloud-admin [1] exposed that we were relying on the role being run as root. When run as cloud-admin without become these tasks failed: [Errno 13] Permission denied: b'/var/lib/edpm-config/firewall'

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/531