### PR TITLE
ovn: remove rootwrap.d from the list of filters_path

### DIFF
--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -60,7 +60,7 @@ edpm_neutron_dhcp_oslo_middleware_enable_proxy_headers_parsing: 60
 
 # rootwrap.conf
 # DEFAULT
-edpm_neutron_dhcp_rootwrap_DEFAULT_filters_path: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+edpm_neutron_dhcp_rootwrap_DEFAULT_filters_path: '/usr/share/neutron/rootwrap'
 edpm_neutron_dhcp_rootwrap_DEFAULT_exec_dirs: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
 edpm_neutron_dhcp_rootwrap_DEFAULT_use_syslog: false
 edpm_neutron_dhcp_rootwrap_DEFAULT_syslog_log_facility: 'syslog'

--- a/roles/edpm_neutron_dhcp/meta/argument_specs.yml
+++ b/roles/edpm_neutron_dhcp/meta/argument_specs.yml
@@ -84,7 +84,7 @@ argument_specs:
         description: ''
         type: int
       edpm_neutron_dhcp_rootwrap_DEFAULT_filters_path:
-        default: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+        default: '/usr/share/neutron/rootwrap'
       edpm_neutron_dhcp_rootwrap_DEFAULT_exec_dirs:
         default: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
       edpm_neutron_dhcp_rootwrap_DEFAULT_use_syslog:

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -38,7 +38,7 @@ edpm_neutron_metadata_agent_oslo_concurrency_lock_patch: '$state_path/lock'
 edpm_neutron_metadata_agent_agent_report_interval: '300'
 
 # rootwrap.conf
-edpm_neutron_metadata_agent_rootwrap_DEFAULT_filters_path: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+edpm_neutron_metadata_agent_rootwrap_DEFAULT_filters_path: '/usr/share/neutron/rootwrap'
 edpm_neutron_metadata_agent_rootwrap_DEFAULT_exec_dirs: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
 edpm_neutron_metadata_agent_rootwrap_DEFAULT_use_syslog: 'False'
 edpm_neutron_metadata_agent_rootwrap_DEFAULT_syslog_log_facility: 'syslog'

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -87,7 +87,7 @@ argument_specs:
         description: ''
         type: str
       edpm_neutron_metadata_agent_rootwrap_DEFAULT_filters_path:
-        default: /etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap
+        default: /usr/share/neutron/rootwrap
         description: ''
         type: str
       edpm_neutron_metadata_agent_rootwrap_DEFAULT_rlimit_nofile:

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -24,7 +24,7 @@ edpm_neutron_ovn_common_volumes:
 edpm_neutron_ovn_agent_DEFAULT_host: '{{ ansible_facts["nodename"] }}'  # also in missing vars
 
 # rootwrap.conf
-edpm_neutron_ovn_agent_rootwrap_DEFAULT_filters_path: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+edpm_neutron_ovn_agent_rootwrap_DEFAULT_filters_path: '/usr/share/neutron/rootwrap'
 edpm_neutron_ovn_agent_rootwrap_DEFAULT_exec_dirs: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin'
 edpm_neutron_ovn_agent_rootwrap_DEFAULT_use_syslog: 'False'
 edpm_neutron_ovn_agent_rootwrap_DEFAULT_syslog_log_facility: 'syslog'

--- a/roles/edpm_neutron_ovn/meta/argument_specs.yml
+++ b/roles/edpm_neutron_ovn/meta/argument_specs.yml
@@ -61,7 +61,7 @@ argument_specs:
         description: List of directories to search executables in
         type: str
       edpm_neutron_ovn_agent_rootwrap_DEFAULT_filters_path:
-        default: /etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap
+        default: /usr/share/neutron/rootwrap
         description: List of directories to load filter definitions from
         type: str
       edpm_neutron_ovn_agent_rootwrap_DEFAULT_rlimit_nofile:

--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -51,7 +51,7 @@ edpm_neutron_sriov_oslo_middleware_enable_proxy_headers_parsing: 60
 
 # rootwrap.conf
 # DEFAULT
-edpm_neutron_sriov_rootwrap_DEFAULT_filters_path: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+edpm_neutron_sriov_rootwrap_DEFAULT_filters_path: '/usr/share/neutron/rootwrap'
 edpm_neutron_sriov_rootwrap_DEFAULT_exec_dirs: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
 edpm_neutron_sriov_rootwrap_DEFAULT_use_syslog: 'False'
 edpm_neutron_sriov_rootwrap_DEFAULT_syslog_log_facility: 'syslog'

--- a/roles/edpm_neutron_sriov/meta/argument_specs.yml
+++ b/roles/edpm_neutron_sriov/meta/argument_specs.yml
@@ -67,7 +67,7 @@ argument_specs:
         description: ''
         type: int
       edpm_neutron_sriov_rootwrap_DEFAULT_filters_path:
-        default: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+        default: '/usr/share/neutron/rootwrap'
       edpm_neutron_sriov_rootwrap_DEFAULT_exec_dirs:
         default: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
       edpm_neutron_sriov_rootwrap_DEFAULT_use_syslog:


### PR DESCRIPTION
The directory doesn't exist, and we move the filter files under /usr/share/neutron/rootwrap in rpms. See:

https://github.com/rdo-packages/neutron-distgit/blob/antelope-rdo/openstack-neutron.spec#L499