### PR TITLE
extract host user,group and dir creation to edpm_users role

### DIFF
--- a/playbooks/configure_network.yaml
+++ b/playbooks/configure_network.yaml
@@ -14,6 +14,15 @@
         tasks_from: bootstrap.yml
       tags:
         - edpm_bootstrap
+    # This should be done very early in the bootstrap process
+    # to ensure that the created users and groups are available
+    # before any packages are installed or services are started
+    # that may need them.
+    - name: Configure host users and groups
+      tags:
+        - edpm_users
+      ansible.builtin.import_role:
+        name:  edpm_users
     - name: Install edpm_kernel
       import_role:
         name: osp.edpm.edpm_kernel

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -125,9 +125,3 @@
 
 - name: Configure swap
   ansible.builtin.import_tasks: swap.yml
-
-- name: Set GID hugetlbfs user to match kolla pre-set
-  ansible.builtin.group:
-    name: hugetlbfs
-    gid: 42477
-  become: true

--- a/roles/edpm_nova_libvirt/defaults/main.yml
+++ b/roles/edpm_nova_libvirt/defaults/main.yml
@@ -60,7 +60,6 @@ edpm_nova_libvirt_qemu_client_certificate_key_size_real: "{{
     default(edpm_certificate_key_size |
       default('2048', true)
     ) }}"
-edpm_nova_libvirt_vhostuser_socket_group: qemu  # role specific
 edpm_nova_libvirt_qemu_memory_backing_dir: ""  # role specific
 edpm_nova_libvirt_nova_compute_libvirt_type: kvm
 edpm_nova_libvirt_enabled_perf_events: []

--- a/roles/edpm_nova_libvirt/meta/argument_specs.yml
+++ b/roles/edpm_nova_libvirt/meta/argument_specs.yml
@@ -301,10 +301,6 @@ argument_specs:
         default: true
         description: ''
         type: bool
-      edpm_nova_libvirt_vhostuser_socket_group:
-        default: qemu
-        description: ''
-        type: str
       edpm_nova_libvirt_virtlogd_log_filters:
         default: 1:logging 4:object 4:json 4:event 1:util
         description: ''

--- a/roles/edpm_nova_libvirt/tasks/install.yml
+++ b/roles/edpm_nova_libvirt/tasks/install.yml
@@ -44,32 +44,6 @@
     content: ""
     dest: /etc/ssh/ssh_known_hosts
     force: false
-# qemu user on host will be cretaed by libvirt package install, ensure
-# the qemu user created with same uid/gid as like libvirt package.
-# These specific values are required since ovs is running on host.
-# Once ovs with DPDK is containerized, we could modify this uid/gid
-# to match with kolla config values.
-- name: Ensure qemu group is present on the host
-  ansible.builtin.group:
-    name: qemu
-    gid: 107
-    state: present
-- name: Ensure qemu user is present on the host
-  ansible.builtin.user:
-    name: qemu
-    uid: 107
-    group: qemu
-    state: present
-    shell: /sbin/nologin
-    comment: qemu user
-- name: Create directory for vhost-user sockets with qemu ownership
-  ansible.builtin.file:
-    path: /var/lib/vhost_sockets
-    state: directory
-    owner: qemu
-    group: "{{ edpm_nova_libvirt_vhostuser_socket_group }}"
-    setype: virt_cache_t
-    seuser: system_u
 - name: Ensure ceph configurations exist
   ansible.builtin.file:
     path: "{{ edpm_nova_libvirt_ceph_config_path }}"

--- a/roles/edpm_users/defaults/main.yml
+++ b/roles/edpm_users/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of "edpm_users"
+edpm_users_users:
+  - { "name": "qemu", "uid": "107", "gid": "107", "shell": "/sbin/nologin", "comment": "qemu user" }
+  - { "name": "hugetlbfs", "gid": "42477", "group_only": true }
+edpm_users_extra_dirs:
+  - { "path": "/var/lib/vhost_sockets", "owner": "qemu", "group": "qemu", "setype": "virt_cache_t", "seuser": "system_u", "mode": "0755" }

--- a/roles/edpm_users/handlers/main.yml
+++ b/roles/edpm_users/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/roles/edpm_users/meta/argument_specs.yml
+++ b/roles/edpm_users/meta/argument_specs.yml
@@ -1,0 +1,32 @@
+---
+argument_specs:
+  # ./roles/edpm_users/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_users role.
+    description:
+     - |
+        This role will create the users and groups listed in this variable and is intended to be used
+        whenever we required users and or groups to be created on the host that match the users and or groups
+        of the containers running on the host. it can also create directories and set their ownership and permissions.
+        This is useful for example when we want to create a directory on the host that will be used by a container
+        to share content with a process running on the host like ovs-dpdk. ovs-dpdk requires a directory to be created
+        to share vhost-user unix socket between qemu executing in the libvirt_virtqemd container and ovs-vswitchd
+        executing in the host. that directory and the user and group of the vhost-user unix socket must share the
+        same uid and gid when accessed form both the container and the host.
+    options:
+      edpm_users_users:
+        type: list
+        default:
+          - { "name": "qemu", "uid": "107", "gid": "107", "shell": "/sbin/nologin", "comment": "qemu user" }
+          - { "name": "hugetlbfs", "gid": "42477", "group_only": true }
+        description: |
+          The list of users and or groups to create on the compute node.
+      edpm_users_extra_dirs:
+        type: list
+        default:
+          - { "path": "/var/lib/vhost_sockets", "owner": "qemu", "group": "qemu", "setype": "virt_cache_t", "seuser": "system_u", "mode": "0755" }
+        description: |
+          The list of directories to create on the compute node for communication with host processes.
+          This shoudl only be used for directories that are required to be shared between containers and host processes.
+          Where the host directories are created solely for the purpose of sharing content between containers or
+          to persist data this should not be used.

--- a/roles/edpm_users/meta/main.yml
+++ b/roles/edpm_users/meta/main.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_users
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '9'
+  galaxy_tags:
+    - edpm
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_users/molecule/default/converge.yml
+++ b/roles/edpm_users/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include edpm_users"
+      ansible.builtin.include_role:
+        name: "osp.edpm.edpm_users"

--- a/roles/edpm_users/molecule/default/molecule.yml
+++ b/roles/edpm_users/molecule/default/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+- name: instance
+  command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - verify
+    - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_users/molecule/default/verify.yml
+++ b/roles/edpm_users/molecule/default/verify.yml
@@ -1,0 +1,40 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  vars:
+    test_helper_dir: "../../../../molecule/test-helpers"
+  tasks:
+    - name: lookup all host_users
+      ansible.builtin.shell: "getent passwd | awk -F':' '{print $1}'"
+      register: host_users
+      changed_when: false
+      failed_when: false
+      check_mode: false
+    - name: assert expected host_users exist
+      ansible.builtin.assert:
+        that:
+          - item in host_users.stdout_lines
+        fail_msg: "User {{ item }} does not exist"
+      loop:
+        - "qemu"
+    - name: lookup all host_groups
+      ansible.builtin.shell: "getent group | awk -F':' '{print $1}'"
+      register: host_groups
+      changed_when: false
+      failed_when: false
+      check_mode: false
+    - name: assert expected host_groups exist
+      ansible.builtin.assert:
+        that:
+          - item in host_groups.stdout_lines
+        fail_msg: "group {{ item }} does not exist"
+      loop:
+        - "qemu"
+        - "hugetlbfs"
+    - name: ensure expected directories exist
+      ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_dir.yaml"
+      with_items:
+        - /var/lib/vhost_sockets

--- a/roles/edpm_users/tasks/create_users_and_groups.yml
+++ b/roles/edpm_users/tasks/create_users_and_groups.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: create host user and group
+  become: true
+  tags:
+    - edpm_users
+  block:
+    - name: Ensure {{ item.name }} group is present on the host
+      ansible.builtin.group:
+        name: "{{ item.name }}"
+        gid: "{{ item.gid }}"
+        state: present
+    - name: Ensure {{ item.name }} user is present on the host
+      when: not (item.group_only | default(false))
+      ansible.builtin.user:
+        name: "{{ item.name }}"
+        uid: "{{ item.uid }}"
+        group: "{{ item.name }}"
+        state: present
+        shell: "{{ item.shell }}"
+        comment: "{{ item.comment }}"

--- a/roles/edpm_users/tasks/main.yml
+++ b/roles/edpm_users/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: create host users and groups
+  ansible.builtin.include_tasks: create_users_and_groups.yml
+  with_items: "{{ edpm_users_users }}"
+
+- name: create host directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    setype: "{{ item.setype | default(omit) }}"
+    seuser: "{{item.seuser | default(omit) }}"
+    mode: "{{ item.mode | default(omit) }}"
+  loop: "{{ edpm_users_extra_dirs }}"

--- a/roles/edpm_users/vars/main.yml
+++ b/roles/edpm_users/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "edpm_users"


### PR DESCRIPTION
This change factors out the code to create users/groups that must
map to the same uid/gid within or outside of a container.

This is required to supprot ovs-dpdk where the hugepage and
vhost user socket permission must align to enabel ovs-dpdk
running on the host to comunciate with qemu running in a container.

Thsi work enabled the future removal of the edpm_nova_compute
and edpm_nova_libvirt roles.
