### PR TITLE
Add firewall rules for ceph-nfs

### DIFF
--- a/roles/edpm_ceph_hci_pre/defaults/main.yml
+++ b/roles/edpm_ceph_hci_pre/defaults/main.yml
@@ -33,6 +33,10 @@ edpm_ceph_hci_pre_storage_ranges: []
 # If list is empty, the firewall rule will not specify a source address
 edpm_ceph_hci_pre_rgw_frontend_ranges: []
 
+# List of IP ranges which can connect to NFS front end
+# If list is empty, the firewall rule will not specify a source address
+edpm_ceph_hci_pre_nfs_frontend_ranges: []
+
 # List of IP ranges which can connect to Ceph Grafana front end
 # If list is empty, the firewall rule will not specify a source address
 edpm_ceph_hci_pre_grafana_frontend_ranges: []
@@ -66,8 +70,13 @@ edpm_ceph_hci_pre_firewall_services:
   - name: ceph_nfs
     num: 120
     dport:
-      - 2049
+      - 12049
     ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
+  - name: ceph_nfs_frontend
+    num: 121
+    dport:
+      - 2049
+    ranges: "{{ edpm_ceph_hci_pre_nfs_frontend_ranges | list }}"
   - name: ceph_rgw
     num: 122
     dport:
@@ -123,4 +132,6 @@ edpm_ceph_hci_pre_enabled_services:
   - ceph_mgr
   - ceph_osd
   - ceph_rgw
+  - ceph_nfs
   - ceph_rgw_frontend
+  - ceph_nfs_frontend


### PR DESCRIPTION
When `ceph-nfs` is deployed as part of `Ceph` with an associated `ingress` daemon, we should provide firewall rules to avoid unexpected behavior when the cluster is created and clients try to reach the `VIP` endpoint.
Required for https://github.com/openstack-k8s-operators/ci-framework/pull/557