### PR TITLE
Repurpose network_config_override variable

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -49,5 +49,5 @@ edpm_network_config_nmstate: false
 edpm_network_config_os_net_config_mappings: {}
 edpm_network_config_safe_defaults: true
 edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-edpm_network_config_override: {}
+edpm_network_config_override: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -67,9 +67,9 @@ argument_specs:
         description: "Which settings template should be rendered."
         default: templates/single_nic_vlans/single_nic_vlans.j2
       edpm_network_config_override:
-        type: dict
+        type: str
         description: "Optional template content overrides"
-        default: {}
+        default: ""
       edpm_bond_interface_ovs_options:
         type: str
         description: "Binding options to be rendered in a template"

--- a/roles/edpm_network_config/molecule/default/converge.yml
+++ b/roles/edpm_network_config/molecule/default/converge.yml
@@ -19,6 +19,39 @@
   hosts: all
   vars:
     edpm_network_config_template: templates/standalone.j2
+    edpm_network_config_override: |
+         ---
+         {% set control_virtual_ip = net_vip_map.ctlplane %}
+         {% set public_virtual_ip = vip_port_map.external.ip_address %}
+         {% if ':' in control_virtual_ip %}
+         {%   set control_virtual_cidr = 128 %}
+         {% else %}
+         {%   set control_virtual_cidr = 32 %}
+         {%   endif %}
+         {% if ':' in public_virtual_ip %}
+         {%   set public_virtual_cidr = 128 %}
+         {% else %}
+         {%   set public_virtual_cidr = 32 %}
+         {%   endif %}
+         network_config:
+         - type: ovs_bridge
+           name: br-ctlplane
+           use_dhcp: false
+           mtu: {{ ctlplane_mtu }}
+           ovs_extra:
+           - br-set-external-id br-ctlplane bridge-id br-ctlplane
+           addresses:
+           - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+           - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+           - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+           routes: {{ ctlplane_host_routes }}
+           dns_servers: {{ ctlplane_dns_nameservers }}
+           domain: {{ dns_search_domains }}
+           members:
+             - type: interface
+               name: {{ neutron_public_interface_name }}
+               primary: true
+               mtu: {{ ctlplane_mtu }}
     edpm_network_config_manage_service: false
     edpm_network_config_hide_sensitive_logs: false
     ctlplane_mtu: 1500

--- a/roles/edpm_network_config/tasks/os_net_config.yml
+++ b/roles/edpm_network_config/tasks/os_net_config.yml
@@ -26,12 +26,12 @@
     - name: Render overidden network config
       no_log: "{{ edpm_network_config_hide_sensitive_logs | bool }}"
       ansible.builtin.copy:
-        content: "{{ edpm_network_config_override | to_yaml }}"
+        content: "{{ edpm_network_config_override }}"
         dest: "{{ nic_config_file }}"
         mode: '0644'
         backup: true
       when:
-        - edpm_network_config_override.keys()|length > 0
+        - edpm_network_config_override != ""
     - name: Render network_config from template
       no_log: "{{ edpm_network_config_hide_sensitive_logs | bool }}"
       ansible.builtin.template:
@@ -40,7 +40,7 @@
         mode: '0644'
         backup: true
       when:
-        - edpm_network_config_override.keys()|length == 0
+        - edpm_network_config_override == ""
     - name: Run edpm_os_net_config_module with network_config
       edpm_os_net_config:
         config_file: "{{ nic_config_file }}"


### PR DESCRIPTION
This change repurposes the edpm_network_config_override variable to accept a Jinja2 formatted string that will be rendered. This change will enable us to eventually replace the edpm_network_config_template variable and remove this override one entirely.