### PR TITLE
Replace `package` module with `dnf` in `edpm_sshd` role

### DIFF
--- a/roles/edpm_sshd/tasks/install.yml
+++ b/roles/edpm_sshd/tasks/install.yml
@@ -19,7 +19,7 @@
   become: true
   block:
     - name: Install the OpenSSH server
-      ansible.builtin.package:
+      ansible.builtin.dnf:
         name: "{{ edpm_sshd_packages }}"
         state: present
       register: _sshd_install_result


### PR DESCRIPTION
This PR is a followup of https://github.com/openstack-k8s-operators/edpm-ansible/pull/331 since I missed `package` usage... :man_facepalming: 