### PR TITLE
Refactored `edpm_download_cache` role

### DIFF
--- a/roles/edpm_download_cache/defaults/main.yml
+++ b/roles/edpm_download_cache/defaults/main.yml
@@ -18,3 +18,6 @@
 # All variables intended for modification should be placed in this file.
 
 # All variables within this role should have a prefix of "edpm_download_cache"
+edpm_download_cache_packages: true
+
+edpm_download_cache_container_images: true

--- a/roles/edpm_download_cache/meta/argument_specs.yml
+++ b/roles/edpm_download_cache/meta/argument_specs.yml
@@ -3,4 +3,12 @@ argument_specs:
   # ./roles/edpm_download_cache/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_download_cache role.
-    options: {}
+    options:
+      edpm_download_cache_packages:
+        type: bool
+        default: true
+        description: Enable caching of packages
+      edpm_download_cache_container_images:
+        type: bool
+        default: true
+        description: Enable caching of container images

--- a/roles/edpm_download_cache/tasks/container_images.yml
+++ b/roles/edpm_download_cache/tasks/container_images.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Install podman
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_podman
+    tasks_from: install.yml
+  tags:
+    - edpm_podman
+    - download_cache
+
+- name: Login to container registries if needed
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_podman
+    tasks_from: login.yml
+  tags:
+    - edpm_podman
+    - download_cache

--- a/roles/edpm_download_cache/tasks/main.yml
+++ b/roles/edpm_download_cache/tasks/main.yml
@@ -14,43 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Download packages
+  ansible.builtin.include_tasks: packages.yml
+  when: edpm_download_cache_packages | bool
 
-- name: Download packages for edpm_bootstrap role
-  ansible.builtin.include_role:
-    name: osp.edpm.edpm_bootstrap
-    tasks_from: download_cache.yml
-
-- name: Download packages for edpm_podman role
-  ansible.builtin.include_role:
-    name: osp.edpm.edpm_podman
-    tasks_from: download_cache.yml
-
-- name: Download packages for edpm_tuned role
-  ansible.builtin.include_role:
-    name: osp.edpm.edpm_tuned
-    tasks_from: download_cache.yml
-
-- name: Download packages for edpm_kernel role
-  ansible.builtin.include_role:
-    name: osp.edpm.edpm_kernel
-    tasks_from: download_cache.yml
-
-- name: Download packages for edpm_network_config role
-  ansible.builtin.include_role:
-    name: osp.edpm.edpm_network_config
-    tasks_from: download_cache.yml
-
-- name: Download packages for edpm_logrotate_crond role
-  ansible.builtin.include_role:
-    name: osp.edpm.edpm_logrotate_crond
-    tasks_from: download_cache.yml
-
-- name: Download packages for edpm_chrony role
-  ansible.builtin.include_role:
-    name: osp.edpm.edpm_chrony
-    tasks_from: download_cache.yml
-
-- name: Download packages for edpm_sshd role
-  ansible.builtin.include_role:
-    name: osp.edpm.edpm_sshd
-    tasks_from: download_cache.yml
+- name: Download container images
+  ansible.builtin.include_tasks: container_images.yml
+  when: edpm_download_cache_container_images | bool

--- a/roles/edpm_download_cache/tasks/packages.yml
+++ b/roles/edpm_download_cache/tasks/packages.yml
@@ -1,0 +1,65 @@
+---
+
+- name: Download packages for edpm_bootstrap role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_bootstrap
+    tasks_from: download_cache.yml
+  tags:
+    - edpm_kernel
+    - download_cache
+
+- name: Download packages for edpm_podman role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_podman
+    tasks_from: download_cache.yml
+  tags:
+  - edpm_podman
+  - download_cache
+
+- name: Download packages for edpm_tuned role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_tuned
+    tasks_from: download_cache.yml
+  tags:
+    - edpm_tuned
+    - download_cache
+
+- name: Download packages for edpm_kernel role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_kernel
+    tasks_from: download_cache.yml
+  tags:
+    - edpm_kernel
+    - download_cache
+
+- name: Download packages for edpm_network_config role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_network_config
+    tasks_from: download_cache.yml
+  tags:
+    - edpm_network_config
+    - download_cache
+
+- name: Download packages for edpm_logrotate_crond role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_logrotate_crond
+    tasks_from: download_cache.yml
+  tags:
+    - edpm_logrotate_crond
+    - download_cache
+
+- name: Download packages for edpm_chrony role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_chrony
+    tasks_from: download_cache.yml
+  tags:
+    - edpm_chrony
+    - download_cache
+
+- name: Download packages for edpm_sshd role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_sshd
+    tasks_from: download_cache.yml
+  tags:
+    - edpm_sshd
+    - download_cache


### PR DESCRIPTION
* splitted packages and container images downloads in two different files
* added `edpm_download_cache_packages` and `edpm_download_cache_container_images` variables to enable/disable download of packages and container images
* enabled the installation of `podman` via `edpm_podman` role since it's a requirement for `podman_image` module
* added tags in the tasks