### PR TITLE
SR-IOV is not configured when the provider is not set

### DIFF
--- a/plugins/modules/edpm_os_net_config.py
+++ b/plugins/modules/edpm_os_net_config.py
@@ -115,6 +115,8 @@ def _run_os_net_config(config_file, cleanup=False, debug=False,
         argv.append('--noop')
     if use_nmstate:
         argv.append('--provider nmstate')
+    else:
+        argv.append('--provider ifcfg')
     cmd = " ".join(argv)
 
     # Apply the provided network configuration


### PR DESCRIPTION
The default provider still remains as 'ifcfg' and when its not specified, the SR-IOV PF configuration is skipped. Adding the changes to support the same.