### PR TITLE
edpm_container_manage treat override as regex

### DIFF
--- a/plugins/modules/edpm_container_manage.py
+++ b/plugins/modules/edpm_container_manage.py
@@ -20,6 +20,7 @@ from ansible.module_utils.parsing.convert_bool import boolean
 
 import glob
 import os
+import re
 import time
 import yaml
 import json
@@ -153,12 +154,15 @@ class EdpmContainerManage:
         # handle overrides similar to container_config_data
         if self.config_overrides:
             for k in self.config_overrides.keys():
-                if k in configs:
+                r = re.compile(k)
+                overrides = list(filter(r.match, configs))
+                if overrides:
                     for mk, mv in self.config_overrides[k].items():
                         if self.debug:
                             self.module.debug(f'Override found for {k}: {mk} '
                                               f'will be set to {mv}')
-                        configs[k][mk] = mv
+                        for override_config in overrides:
+                            configs[override_config][mk] = mv
         return configs
 
     def _get_version(self):


### PR DESCRIPTION
If we pattern match the config file we should also use config_override as an regexp so we will match the config from the pattern.

Change-Id: I33a5b4d9b6335ae07f84c4f9f0c7629ed6bd6180