### PR TITLE
Rework network_config_template to accept j2

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -48,6 +48,6 @@ edpm_network_config_manage_service: true
 edpm_network_config_nmstate: false
 edpm_network_config_os_net_config_mappings: {}
 edpm_network_config_safe_defaults: true
-edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
+edpm_network_config_template: ""
 edpm_network_config_override: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -63,9 +63,9 @@ argument_specs:
           case of failing while applying the provided net config.
         default: true
       edpm_network_config_template:
-        type: path
+        type: str
         description: "Which settings template should be rendered."
-        default: templates/single_nic_vlans/single_nic_vlans.j2
+        default: ""
       edpm_network_config_override:
         type: str
         description: "Optional template content overrides"

--- a/roles/edpm_network_config/molecule/default/converge.yml
+++ b/roles/edpm_network_config/molecule/default/converge.yml
@@ -18,7 +18,39 @@
 - name: Converge
   hosts: all
   vars:
-    edpm_network_config_template: templates/standalone.j2
+    edpm_network_config_template: |
+         ---
+         {% set control_virtual_ip = net_vip_map.ctlplane %}
+         {% set public_virtual_ip = vip_port_map.external.ip_address %}
+         {% if ':' in control_virtual_ip %}
+         {%   set control_virtual_cidr = 128 %}
+         {% else %}
+         {%   set control_virtual_cidr = 32 %}
+         {%   endif %}
+         {% if ':' in public_virtual_ip %}
+         {%   set public_virtual_cidr = 128 %}
+         {% else %}
+         {%   set public_virtual_cidr = 32 %}
+         {%   endif %}
+         network_config:
+         - type: ovs_bridge
+           name: br-ctlplane
+           use_dhcp: false
+           mtu: {{ ctlplane_mtu }}
+           ovs_extra:
+           - br-set-external-id br-ctlplane bridge-id br-ctlplane
+           addresses:
+           - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+           - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+           - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+           routes: {{ ctlplane_host_routes }}
+           dns_servers: {{ ctlplane_dns_nameservers }}
+           domain: {{ dns_search_domains }}
+           members:
+             - type: interface
+               name: {{ neutron_public_interface_name }}
+               primary: true
+               mtu: {{ ctlplane_mtu }}
     edpm_network_config_override: |
          ---
          {% set control_virtual_ip = net_vip_map.ctlplane %}

--- a/roles/edpm_network_config/tasks/os_net_config.yml
+++ b/roles/edpm_network_config/tasks/os_net_config.yml
@@ -31,16 +31,16 @@
         mode: '0644'
         backup: true
       when:
-        - edpm_network_config_override != ""
+        - edpm_network_config_template == ""
     - name: Render network_config from template
       no_log: "{{ edpm_network_config_hide_sensitive_logs | bool }}"
-      ansible.builtin.template:
-        src: "{{ edpm_network_config_template }}"
+      ansible.builtin.copy:
+        content: "{{ edpm_network_config_template }}"
         dest: "{{ nic_config_file }}"
         mode: '0644'
         backup: true
       when:
-        - edpm_network_config_override == ""
+        - edpm_network_config_template != ""
     - name: Run edpm_os_net_config_module with network_config
       edpm_os_net_config:
         config_file: "{{ nic_config_file }}"


### PR DESCRIPTION
In an effort to keep things backwards compatible, this change duplicates the edpm_network_config_override functionality using the edpm_network_config_template variable. This change is necessary to prepare for the removal of the edpm_network_config_override variable.

This change keeps things backwards compatible and allows time to fix all of the workflows relying on the `_override` variable. Once they have all been changed over to use the new format of the `_template` variable, we can go ahead and remove the `_override` one.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/581