### PR TITLE
Drop baremetal job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,7 +2,7 @@
 - project:
     name: openstack-k8s-operators/edpm-ansible
     templates:
-      - podified-multinode-edpm-baremetal-pipeline
+      - podified-multinode-edpm-pipeline
     github-check:
       jobs:
         - edpm-ansible-molecule-edpm_podman


### PR DESCRIPTION
We don't always need to run the baremetal job with edpm-ansible changes. Removing it as there too many jobs here.