### PR TITLE
Do not attempt to manage collocated Ceph containers

### DIFF
--- a/docs/source/roles/role-edpm_container_manage.rst
+++ b/docs/source/roles/role-edpm_container_manage.rst
@@ -29,6 +29,9 @@ This Ansible role allows to do the following tasks:
 
   * The container config_id doesn't match with the one in input.
 
+  * The container's name starts with "ceph". Ceph containers are not
+    managed by this role.
+
   Once the previous conditions checked, then these reasons will make the
   containers deleted:
 

--- a/roles/edpm_container_manage/tasks/delete_orphan.yml
+++ b/roles/edpm_container_manage/tasks/delete_orphan.yml
@@ -20,6 +20,13 @@
   when:
     - edpm_container_manage_cli == 'podman'
 
+- name: Exclude Ceph containers from podman container list
+  ansible.builtin.set_fact:
+    filtered_containers: "{{ filtered_containers | default([]) + [item] }}"
+  when:
+    - not (item['Name'] | regex_search('^ceph.*'))
+  loop: "{{ podman_containers.containers }}"
+
 - name: "Delete orphan containers managed by Podman for {{ edpm_container_manage_config }}"
   when:
     - edpm_container_manage_systemd_teardown | bool
@@ -28,6 +35,7 @@
   vars:
     edpm_container_cli: "{{ edpm_container_manage_cli }}"
     edpm_containers_to_rm: >-
-      {{ podman_containers.containers | osp.edpm.needs_delete(config=all_containers_hash,
+      {{ filtered_containers | default([]) |
+      osp.edpm.needs_delete(config=all_containers_hash,
       config_id=edpm_container_manage_config_id, check_config=False,
       clean_orphans=True) }}


### PR DESCRIPTION
If an HCI EDPM node has Ceph containers, then they should not be be manged by the edpm_container_manage role. Add a new task to exclude Ceph containers from the list of containers built by the call to
containers.podman.podman_container_info.

Without this new task, the edpm_container_manage role delete_orphan.yml tasks file attempts to process Ceph containers but it cannot handle them so it fails with an AttributeError: 'NoneType' object has no attribute 'get'.