### PR TITLE
edpm_libvirt role should handle quoted cephx keys

### DIFF
--- a/roles/edpm_libvirt/tasks/virsh-secret.yml
+++ b/roles/edpm_libvirt/tasks/virsh-secret.yml
@@ -35,7 +35,7 @@
   ansible.builtin.command: "podman exec libvirt_virtqemud bash -c 'virsh secret-set-value $FSID --base64 $KEY'"
   environment:
     FSID: "{{ fsid }}"
-    KEY: "{{ cephx_key.stdout }}"
+    KEY: "{{ cephx_key.stdout | regex_replace('\"', '') }}"
   when:
     - cephx_key.stdout is defined
-    - cephx_key.stdout | regex_search('^[a-zA-Z0-9+/]{38}==$')
+    - cephx_key.stdout | regex_replace('\"', '') | regex_search('^[a-zA-Z0-9+/]{38}==$')


### PR DESCRIPTION
It's valid for the key inside a ceph keyring file to be either quoted or not quoted. Before this patch, if the key was quoted, then it was not passed to the "virsh secret-set-value" command because it did not satisfy the regex check because of the quotes. This change strips the quotes from the key value before it is checked and passed to the virsh command.