### PR TITLE
Add edpm role to deploy Neutron DHCP agent

### DIFF
--- a/playbooks/neutron_dhcp.yaml
+++ b/playbooks/neutron_dhcp.yaml
@@ -1,0 +1,11 @@
+---
+- name: Deploy EDPM Neutron DHCP agent
+  hosts: all
+  strategy: linear
+  become: true
+  tasks:
+    - name: Neutron DHCP agent
+      import_role:
+        name: osp.edpm.edpm_neutron_dhcp
+      tags:
+        - edpm_neutron_dhcp

--- a/roles/edpm_download_cache/tasks/container_images.yml
+++ b/roles/edpm_download_cache/tasks/container_images.yml
@@ -63,3 +63,8 @@
   tags:
     - edpm_neutron_sriov
     - download_cache
+
+- name: Download images for edpm_neutron_dhcp role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_dhcp
+    tasks_from: download_cache.yml

--- a/roles/edpm_neutron_dhcp/OWNERS
+++ b/roles/edpm_neutron_dhcp/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+  - slawqo
+  - network-approvers
+
+reviewers:
+  - slawqo
+  - network-approvers

--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -1,0 +1,83 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "edpm_neutron_dhcp"
+
+# seconds between retries for download tasks
+edpm_neutron_dhcp_images_download_delay: 5
+
+# number of retries for download tasks
+edpm_neutron_dhcp_images_download_retries: 5
+
+edpm_neutron_dhcp_agent_config_src: "/var/lib/openstack/configs/neutron-dhcp"
+edpm_neutron_dhcp_agent_config_dir: "/var/lib/config-data/ansible-generated/neutron-dhcp-agent"
+edpm_neutron_dhcp_image: "quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent:current-podified"
+
+edpm_neutron_dhcp_common_volumes:
+  - /run/netns:/run/netns:shared
+  - "{{ edpm_neutron_dhcp_agent_config_dir }}:/etc/neutron.conf.d:z"
+  - /var/lib/neutron:/var/lib/neutron:shared,z
+  - /var/lib/kolla/config_files/neutron_dhcp_agent.json:/var/lib/kolla/config_files/config.json:ro
+  - /var/log/containers/neutron:/var/log/neutron:z
+  - /run/openvswitch:/run/openvswitch:shared,z
+
+# neutron.conf
+# DEFAULT
+edpm_neutron_dhcp_DEFAULT_debug: false
+edpm_neutron_dhcp_DEFAULT_rpc_response_timeout: 60
+edpm_neutron_dhcp_DEFAULT_transport_url: ''
+
+# oslo_concurrency
+edpm_neutron_dhcp_oslo_concurrency_lock_patch: '$state_path/lock'
+# oslo_messaging_rabbit
+edpm_neutron_dhcp_oslo_messaging_rabbit_heartbeat_timeout_threshold: 60
+# oslo_middleware
+edpm_neutron_dhcp_oslo_middleware_enable_proxy_headers_parsing: 60
+
+# rootwrap.conf
+# DEFAULT
+edpm_neutron_dhcp_rootwrap_DEFAULT_filters_path: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+edpm_neutron_dhcp_rootwrap_DEFAULT_exec_dirs: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
+edpm_neutron_dhcp_rootwrap_DEFAULT_use_syslog: False
+edpm_neutron_dhcp_rootwrap_DEFAULT_syslog_log_facility: 'syslog'
+edpm_neutron_dhcp_rootwrap_DEFAULT_syslog_log_level: 'ERROR'
+edpm_neutron_dhcp_rootwrap_DEFAULT_daemon_timeout: 600
+edpm_neutron_dhcp_rootwrap_DEFAULT_rlimit_nofile: 1024
+
+# neutron-dhcp-agent.conf
+# DEFAULT
+edpm_neutron_dhcp_agent_DEFAULT_state_path: '/var/lib/neutron'
+edpm_neutron_dhcp_agent_DEFAULT_host: '{{ ansible_facts["nodename"] }}'
+edpm_neutron_dhcp_agent_DEFAULT_resync_interval: 5
+edpm_neutron_dhcp_agent_DEFAULT_resync_throttle: 1
+edpm_neutron_dhcp_agent_DEFAULT_dhcp_driver: 'neutron.agent.linux.dhcp.Dnsmasq'
+edpm_neutron_dhcp_agent_DEFAULT_enable_isolated_metadata: False
+edpm_neutron_dhcp_agent_DEFAULT_force_metadata: False
+edpm_neutron_dhcp_agent_DEFAULT_enable_metadata_network: False
+edpm_neutron_dhcp_agent_DEFAULT_num_sync_threads: 4
+edpm_neutron_dhcp_agent_DEFAULT_bulk_reload_interval: 0
+edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_dns_servers: ''
+edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_base_log_dir: ''
+edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_local_resolv: False
+edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_lease_max: 16777216
+edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_enable_addr6_list: False
+edpm_neutron_dhcp_agent_DEFAULT_dhcp_broadcast_reply: False
+# AGENT
+edpm_neutron_dhcp_agent_AGENT_root_helper: 'sudo neutron-rootwrap /etc/neutron.conf.d/01-rootwrap.conf'
+edpm_neutron_dhcp_agent_AGENT_report_interval: 30
+edpm_neutron_dhcp_agent_AGENT_availability_zone: 'nova'

--- a/roles/edpm_neutron_dhcp/handlers/main.yml
+++ b/roles/edpm_neutron_dhcp/handlers/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: restart neutron-dhcp-agent container
+  become: true
+  ansible.builtin.systemd:
+    state: restarted
+    name: "edpm_neutron_dhcp_agent.service"
+  listen: "restart neutron-dhcp-agent"

--- a/roles/edpm_neutron_dhcp/meta/argument_specs.yml
+++ b/roles/edpm_neutron_dhcp/meta/argument_specs.yml
@@ -1,0 +1,160 @@
+---
+argument_specs:
+  # ./roles/edpm_neutron_dhcp/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_neutron_dhcp role.
+    options:
+      edpm_neutron_dhcp_images_download_delay:
+        type: int
+        default: 5
+        description: The seconds between retries for failed download tasks
+      edpm_neutron_dhcp_images_download_retries:
+        type: int
+        default: 5
+        description: The number of retries for failed download tasks
+      edpm_neutron_dhcp_agent_config_src:
+        default: "/var/lib/openstack/configs/neutron-dhcp"
+        description: |
+          The path to the directory containing source of the Neutron DHCP
+          agent configs.
+        type: str
+      edpm_neutron_dhcp_agent_config_dir:
+        default: "/var/lib/config-data/ansible-generated/neutron-dhcp-agent"
+        description: |
+          The path to the directory containing Neutron DHCP agent config
+          files.
+        type: str
+      edpm_neutron_dhcp_image:
+        default: "quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent:current-podified"
+        description: Neutron DHCP agent container image.
+        type: str
+      edpm_neutron_dhcp_common_volumes:
+        default:
+          - /run/netns:/run/netns:shared
+          - "{{ edpm_neutron_dhcp_agent_config_dir }}:/etc/neutron.conf.d:z"
+          - /var/lib/neutron:/var/lib/neutron:shared,z
+          - /var/lib/kolla/config_files/neutron_dhcp_agent.json:/var/lib/kolla/config_files/config.json:ro
+          - /var/log/containers/neutron:/var/log/neutron:z
+          - /run/openvswitch:/run/openvswitch:shared,z
+        description: List of volumes in a mount point form.
+        type: list
+      edpm_neutron_dhcp_DEFAULT_debug:
+        default: false
+        description: "Enable or disable DEBUG mode in the Neutron DHCP agent"
+        type: bool
+      edpm_neutron_dhcp_DEFAULT_rpc_response_timeout:
+        default: 60
+        description: ''
+        type: int
+      edpm_neutron_dhcp_DEFAULT_transport_url:
+        default: ''
+        description: ''
+        type: str
+      edpm_neutron_dhcp_oslo_concurrency_lock_patch:
+        default: '$state_path/lock'
+        description: ''
+        type: str
+      edpm_neutron_dhcp_oslo_messaging_rabbit_heartbeat_timeout_threshold:
+        default: 60
+        description: ''
+        type: int
+      edpm_neutron_dhcp_oslo_middleware_enable_proxy_headers_parsing:
+        default: 60
+        description: ''
+        type: int
+      edpm_neutron_dhcp_rootwrap_DEFAULT_filters_path:
+        default: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+      edpm_neutron_dhcp_rootwrap_DEFAULT_exec_dirs:
+        default: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
+      edpm_neutron_dhcp_rootwrap_DEFAULT_use_syslog:
+        default: false
+        description: ''
+        type: bool
+      edpm_neutron_dhcp_rootwrap_DEFAULT_syslog_log_facility:
+        default: 'syslog'
+        description: ''
+        type: str
+      edpm_neutron_dhcp_rootwrap_DEFAULT_syslog_log_level:
+        default: 'ERROR'
+        description: ''
+        type: str
+      edpm_neutron_dhcp_rootwrap_DEFAULT_daemon_timeout:
+        default: 600
+        description: ''
+        type: int
+      edpm_neutron_dhcp_rootwrap_DEFAULT_rlimit_nofile:
+        default: 1024
+        description: ''
+        type: int
+      edpm_neutron_dhcp_agent_DEFAULT_state_path:
+        default: '/var/lib/neutron'
+        description: ''
+        type: str
+      edpm_neutron_dhcp_agent_DEFAULT_host:
+        default: '{{ ansible_facts["nodename"] }}'
+        description: ''
+        type: str
+      edpm_neutron_dhcp_agent_DEFAULT_resync_interval:
+        default: 5
+        description: ''
+        type: int
+      edpm_neutron_dhcp_agent_DEFAULT_resync_throttle:
+        default: 1
+        description: ''
+        type: int
+      edpm_neutron_dhcp_agent_DEFAULT_dhcp_driver:
+        default: 'neutron.agent.linux.dhcp.Dnsmasq'
+        description: ''
+        type: str
+      edpm_neutron_dhcp_agent_DEFAULT_enable_isolated_metadata:
+        default: false
+        description: ''
+        type: bool
+      edpm_neutron_dhcp_agent_DEFAULT_force_metadata:
+        default: '/var/lib/neutron'
+        description: ''
+        type: str
+      edpm_neutron_dhcp_agent_DEFAULT_enable_metadata_network:
+        default: false
+        description: ''
+        type: bool
+      edpm_neutron_dhcp_agent_DEFAULT_num_sync_threads:
+        default: 4
+        description: ''
+        type: int
+      edpm_neutron_dhcp_agent_DEFAULT_bulk_reload_interval:
+        default: 0
+        description: ''
+        type: int
+      edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_dns_servers:
+        default: ''
+        description: ''
+        type: str
+      edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_base_log_dir:
+        default: ''
+        description: ''
+        type: str
+      edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_local_resolv:
+        default: false
+        description: ''
+        type: bool
+      edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_lease_max:
+        default: 16777216
+        description: ''
+        type: int
+      edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_enable_addr6_list:
+        default: false
+        description: ''
+        type: bool
+      edpm_neutron_dhcp_agent_DEFAULT_dhcp_broadcast_reply:
+        default: false
+        description: ''
+        type: bool
+      edpm_neutron_dhcp_agent_AGENT_root_helper:
+        default: 'sudo neutron-rootwrap /etc/neutron.conf.d/01-rootwrap.conf'
+        description: ''
+        type: str
+      edpm_neutron_dhcp_agent_AGENT_report_interval:
+        default: 300
+        description: ''
+        type: int

--- a/roles/edpm_neutron_dhcp/meta/main.yml
+++ b/roles/edpm_neutron_dhcp/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_neutron_dhcp
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_neutron_dhcp/molecule/default/collections.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+- name: community.general

--- a/roles/edpm_neutron_dhcp/molecule/default/converge.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/converge.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "edpm_neutron_dhcp"
+      vars:
+        edpm_neutron_dhcp_agent_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"

--- a/roles/edpm_neutron_dhcp/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: fake-networker-1
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - verify
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_neutron_dhcp/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/prepare.yml
@@ -1,0 +1,46 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+- name: Prepare test_deps
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+      test_deps_setup_edpm: true
+      test_deps_setup_stream: true
+      test_deps_extra_packages:
+        - iproute
+        - podman
+        - openvswitch
+
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+    - include_role:
+        name: osp.edpm.env_data
+
+    # The openvswitch kernel module needs to be loaded on the host
+    - name: install and modprobe openvswitch
+      shell: |
+        sudo dnf -y install openvswitch
+        sudo modprobe openvswitch
+      delegate_to: localhost
+      run_once: true
+
+    # Openvswitch service needs to be running on "fake host" so that /run/openvswitch exists
+    - name: Ensure Openvswitch is running
+      ansible.builtin.service:
+        name: "openvswitch"
+        state: "started"

--- a/roles/edpm_neutron_dhcp/molecule/default/test-data/10-neutron-dhcp.conf
+++ b/roles/edpm_neutron_dhcp/molecule/default/test-data/10-neutron-dhcp.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+transport_url = fake:/

--- a/roles/edpm_neutron_dhcp/molecule/default/verify.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/verify.yml
@@ -1,0 +1,53 @@
+---
+- name: Verify neutron-dhcp-agent
+  gather_facts: false
+  hosts: all
+  vars:
+    test_helper_dir: "../../../../molecule/test-helpers"
+  tasks:
+    - name: ensure expected directories exist
+      ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_dir.yaml"
+      with_items:
+        - "/var/lib/neutron"
+        - "/var/lib/openstack/config/containers"
+        - "/var/lib/kolla/config_files/neutron_dhcp_agent.json"
+        - "/var/lib/config-data/ansible-generated/neutron-dhcp-agent"
+        - "/var/log/containers/neutron"
+        - "/var/log/containers/stdouts"
+
+    - name: ensure systemd services are defined and functional
+      ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_systemd_unit.yaml"
+      with_items:
+        - {"name": "edpm_neutron_dhcp_agent.service"}
+
+    - name: ensure podman container exists and are running
+      ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_podman.yaml"
+      with_items:
+        - "neutron_dhcp_agent"
+
+    - name: ensure that log file for neutron-dhcp-agent exist
+      become: true
+      block:
+        - name: Check if file /var/log/containers/neutron/neutron-dhcp-agent.log exist
+          ansible.builtin.stat:
+            path: /var/log/containers/neutron/neutron-dhcp-agent.log
+          register: log_file
+        - name: Assert file /var/log/containers/neutron/neutron-dhcp-agent.log exist
+          ansible.builtin.assert:
+            that:
+              - log_file.stat.exists
+            fail_msg: "File /var/log/containers/neutron/neutron-dhcp-agent.log does not exist"
+
+    - name: Ensure that 10-neutron-dhcp.conf was copied into the container
+      block:
+        - name: dhcp config file exists
+          become: true
+          ansible.builtin.stat:
+            path: "/var/lib/config-data/ansible-generated/neutron-dhcp-agent/10-neutron-dhcp.conf"
+          register: dhcp_config
+
+        - name: assert that the config exists
+          ansible.builtin.assert:
+            that:
+              - dhcp_config.stat.exists
+            fail_msg: "dhcp agent config file does not exist"

--- a/roles/edpm_neutron_dhcp/tasks/configure.yml
+++ b/roles/edpm_neutron_dhcp/tasks/configure.yml
@@ -1,0 +1,52 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Configure neutron configuration files
+  block:
+    - name: Render neutron configuration files
+      ansible.builtin.template:
+        src: "{{ item.src }}"
+        dest: "{{ edpm_neutron_dhcp_agent_config_dir }}/{{ item.dest }}"
+        setype: "container_file_t"
+        mode: "0644"
+      with_items:
+        - {"src": "neutron.conf.j2", "dest": "01-neutron.conf"}
+        - {"src": "rootwrap.conf.j2", "dest": "01-rootwrap.conf"}
+        - {"src": "neutron-dhcp-agent.conf.j2", "dest": "01-neutron-dhcp-agent.conf"}
+      tags:
+        - configure
+        - neutron
+      notify:
+      - restart neutron-dhcp-agent
+
+    - name: discover secrets in {{ edpm_neutron_dhcp_agent_config_src }}
+      ansible.builtin.find:
+        paths: "{{ edpm_neutron_dhcp_agent_config_src }}"
+        file_type: file
+        recurse: yes
+        patterns:
+        - "*dhcp*conf"
+      register: edpm_neutron_dhcp_secrets
+      delegate_to: localhost
+      become: false
+
+    - name: flatten secrets into {{ edpm_neutron_dhcp_agent_config_dir }}
+      ansible.builtin.copy:
+        src: "{{ item.path }}"
+        dest: "{{ edpm_neutron_dhcp_agent_config_dir }}/{{ item.path | basename }}"
+        setype: "container_file_t"
+        mode: "0644"
+      with_items: "{{ edpm_neutron_dhcp_secrets.files }}"

--- a/roles/edpm_neutron_dhcp/tasks/download_cache.yml
+++ b/roles/edpm_neutron_dhcp/tasks/download_cache.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Download needed container images
+  containers.podman.podman_image:
+    name: "{{ edpm_neutron_dhcp_image }}"
+  become: true
+  register: edpm_neutron_dhcp_images_download
+  until: edpm_neutron_dhcp_images_download.failed == false
+  retries: "{{ edpm_neutron_dhcp_images_download_retries }}"
+  delay: "{{ edpm_neutron_dhcp_images_download_delay }}"

--- a/roles/edpm_neutron_dhcp/tasks/install.yml
+++ b/roles/edpm_neutron_dhcp/tasks/install.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create neutron-dhcp-agent directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    setype: "container_file_t"
+    state: directory
+    mode: "{{ item.mode | default(omit) }}"
+  with_items:
+    - {'path': "/var/lib/openstack/config/containers", "mode": "0750" }
+    - {'path': "/var/lib/neutron", "mode": "0750" }
+    - {'path': "{{ edpm_neutron_dhcp_agent_config_dir }}", 'mode': '0755'}
+    - {'path': "/var/log/containers/stdouts"}
+    - {'path': "/var/log/containers/neutron"}
+  tags:
+    - install
+    - neutron
+
+- name: render neutron-dhcp-agent container
+  become: true
+  ansible.builtin.template:
+    src: "neutron_dhcp_agent.yaml.j2"
+    dest: "/var/lib/openstack/config/containers/neutron_dhcp_agent.yaml"
+    setype: "container_file_t"
+    mode: 0644
+  notify:
+  - restart neutron-dhcp-agent
+  tags:
+    - install
+    - neutron

--- a/roles/edpm_neutron_dhcp/tasks/main.yml
+++ b/roles/edpm_neutron_dhcp/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Install neutron-dhcp-agent
+  ansible.builtin.import_tasks: install.yml
+
+- name: Configure neutron-dhcp-agent
+  ansible.builtin.import_tasks: configure.yml
+
+- name: Ensure neutron-dhcp-agent is running
+  ansible.builtin.import_tasks: run.yml

--- a/roles/edpm_neutron_dhcp/tasks/run.yml
+++ b/roles/edpm_neutron_dhcp/tasks/run.yml
@@ -1,0 +1,32 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure /usr/libexec/edpm-start-podman-container exists
+  ansible.builtin.import_role:
+    name: edpm_container_manage
+    tasks_from: shutdown.yml
+
+- name: Run neutron-dhcp-agent container
+  debugger: on_failed
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_debug: true
+    edpm_container_standalone_service: neutron_dhcp_agent
+    edpm_container_standalone_container_defs:
+      neutron_dhcp_agent: "{{ lookup('template', 'neutron_dhcp_agent.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      neutron_dhcp_agent: "{{ lookup('template', 'kolla_config/neutron_dhcp_agent.yaml.j2') | from_yaml }}"

--- a/roles/edpm_neutron_dhcp/templates/kolla_config/neutron_dhcp_agent.yaml.j2
+++ b/roles/edpm_neutron_dhcp/templates/kolla_config/neutron_dhcp_agent.yaml.j2
@@ -1,0 +1,16 @@
+command: "/usr/bin/neutron-dhcp-agent"
+permissions:
+  - owner: neutron:neutron
+    path: /var/log/neutron
+    recurse: true
+  - owner: neutron:neutron
+    path: /var/lib/neutron
+    recurse: true
+  - optional: true
+    owner: neutron:neutron
+    path: /etc/pki/tls/certs/neutron_dhcp_agent.crt
+    perm: 0644
+  - optional: true
+    owner: neutron:neutron
+    path: /etc/pki/tls/private/neutron_dhcp_agent.key
+    perm: 0644

--- a/roles/edpm_neutron_dhcp/templates/neutron-dhcp-agent.conf.j2
+++ b/roles/edpm_neutron_dhcp/templates/neutron-dhcp-agent.conf.j2
@@ -1,0 +1,27 @@
+[DEFAULT]
+interface_driver = openvswitch
+ovs_use_veth = False
+state_path = {{ edpm_neutron_dhcp_agent_DEFAULT_state_path }}
+host = {{ edpm_neutron_dhcp_agent_DEFAULT_host }}
+resync_interval = {{ edpm_neutron_dhcp_agent_DEFAULT_resync_interval }}
+resync_throttle = {{ edpm_neutron_dhcp_agent_DEFAULT_resync_throttle }}
+dhcp_driver = {{ edpm_neutron_dhcp_agent_DEFAULT_dhcp_driver }}
+enable_isolated_metadata = {{ edpm_neutron_dhcp_agent_DEFAULT_enable_isolated_metadata }}
+force_metadata = {{ edpm_neutron_dhcp_agent_DEFAULT_force_metadata }}
+enable_metadata_network = {{ edpm_neutron_dhcp_agent_DEFAULT_enable_metadata_network }}
+num_sync_threads = {{ edpm_neutron_dhcp_agent_DEFAULT_num_sync_threads }}
+bulk_reload_interval = {{ edpm_neutron_dhcp_agent_DEFAULT_bulk_reload_interval }}
+dnsmasq_dns_servers = {{ edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_dns_servers }}
+dnsmasq_local_resolv = {{ edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_local_resolv }}
+dnsmasq_lease_max = {{ edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_lease_max }}
+dnsmasq_enable_addr6_list = {{ edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_enable_addr6_list }}
+{% if edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_base_log_dir %}
+dnsmasq_base_log_dir = {{ edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_base_log_dir }}
+{% endif %}
+dhcp_broadcast_reply = {{ edpm_neutron_dhcp_agent_DEFAULT_dhcp_broadcast_reply }}
+
+
+[AGENT]
+root_helper = {{ edpm_neutron_dhcp_agent_AGENT_root_helper }}
+report_interval = {{ edpm_neutron_dhcp_agent_AGENT_report_interval }}
+availability_zone = {{ edpm_neutron_dhcp_agent_AGENT_availability_zone }}

--- a/roles/edpm_neutron_dhcp/templates/neutron.conf.j2
+++ b/roles/edpm_neutron_dhcp/templates/neutron.conf.j2
@@ -1,0 +1,14 @@
+[DEFAULT]
+log_file = /var/log/neutron/neutron-dhcp-agent.log
+debug = {{ edpm_neutron_dhcp_DEFAULT_debug }}
+rpc_response_timeout = {{ edpm_neutron_dhcp_DEFAULT_rpc_response_timeout }}
+transport_url = {{ edpm_neutron_dhcp_DEFAULT_transport_url }}
+
+[oslo_concurrency]
+lock_path = {{ edpm_neutron_dhcp_oslo_concurrency_lock_patch }}
+
+[oslo_messaging_rabbit]
+heartbeat_timeout_threshold = {{ edpm_neutron_dhcp_oslo_messaging_rabbit_heartbeat_timeout_threshold }}
+
+[oslo_middleware]
+enable_proxy_headers_parsing = {{ edpm_neutron_dhcp_oslo_middleware_enable_proxy_headers_parsing }}

--- a/roles/edpm_neutron_dhcp/templates/neutron_dhcp_agent.yaml.j2
+++ b/roles/edpm_neutron_dhcp/templates/neutron_dhcp_agent.yaml.j2
@@ -1,0 +1,14 @@
+start_order: 1
+image: "{{ edpm_neutron_dhcp_image }}"
+net: host
+privileged: true
+user: neutron
+restart: always
+volumes:
+  {% set edpm_neutron_dhcp_volumes = [] %}
+  {%- set edpm_neutron_dhcp_volumes =
+          edpm_neutron_dhcp_volumes +
+          edpm_neutron_dhcp_common_volumes %}
+  {{ edpm_neutron_dhcp_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_neutron_dhcp/templates/rootwrap.conf.j2
+++ b/roles/edpm_neutron_dhcp/templates/rootwrap.conf.j2
@@ -1,0 +1,8 @@
+[DEFAULT]
+filters_path = {{ edpm_neutron_dhcp_rootwrap_DEFAULT_filters_path }}
+exec_dirs = {{ edpm_neutron_dhcp_rootwrap_DEFAULT_exec_dirs }}
+use_syslog = {{ edpm_neutron_dhcp_rootwrap_DEFAULT_use_syslog }}
+syslog_log_facility = {{ edpm_neutron_dhcp_rootwrap_DEFAULT_syslog_log_facility }}
+syslog_log_level = {{ edpm_neutron_dhcp_rootwrap_DEFAULT_syslog_log_level }}
+daemon_timeout = {{ edpm_neutron_dhcp_rootwrap_DEFAULT_daemon_timeout }}
+rlimit_nofile = {{ edpm_neutron_dhcp_rootwrap_DEFAULT_rlimit_nofile }}

--- a/roles/edpm_neutron_dhcp/vars/main.yml
+++ b/roles/edpm_neutron_dhcp/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "edpm_neutron_dhcp"


### PR DESCRIPTION
This new roles deploys, configures and runs neutron-dhcp-agent on the EDPM node if needed.

Jira: [OSP-27538](https://issues.redhat.com//browse/OSP-27538)