### PR TITLE
Set correct default for SRIOV agent report_interval

### DIFF
--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -64,7 +64,7 @@ edpm_neutron_sriov_rootwrap_DEFAULT_rlimit_nofile: 1024
 edpm_neutron_sriov_agent_DEFAULT_state_path: '/var/lib/neutron'
 # AGENT
 edpm_neutron_sriov_agent_AGENT_root_helper: 'sudo neutron-rootwrap /etc/neutron.conf.d/01-rootwrap.conf'
-edpm_neutron_sriov_agent_AGENT_report_interval: 300
+edpm_neutron_sriov_agent_AGENT_report_interval: 30
 edpm_neutron_sriov_agent_AGENT_extensions: 'qos'
 edpm_neutron_sriov_agent_AGENT_polling_interval: 2
 # SRIOV_NIC

--- a/roles/edpm_neutron_sriov/meta/argument_specs.yml
+++ b/roles/edpm_neutron_sriov/meta/argument_specs.yml
@@ -99,7 +99,7 @@ argument_specs:
         description: ''
         type: str
       edpm_neutron_sriov_agent_AGENT_report_interval:
-        default: 300
+        default: 30
         description: ''
         type: int
       edpm_neutron_sriov_agent_AGENT_extensions:


### PR DESCRIPTION
In Neutron default value for the 'report_interval' option is set to 30 seconds and this works well for the typical deployments, together with the 'agent_down_time' option set on the neutron server side to 75 seconds by default.

In the neutron_sriov role default for the report_interval was previously set to 300 seconds which was causing agent flapping UP/DOWN.

This patch sets default value for this config option to 30 seconds which is the same as is used in Neutron.