### PR TITLE
Upgrade collection requirements during ansibleee runner build

### DIFF
--- a/openstack_ansibleee/Dockerfile
+++ b/openstack_ansibleee/Dockerfile
@@ -5,8 +5,8 @@ ARG REMOTE_SOURCE_DIR=/var/tmp/edpm-ansible
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
 RUN cd /var/tmp/edpm-ansible && \
-    ansible-galaxy collection install --timeout 120 -r requirements.yml --collections-path "/usr/share/ansible/collections" && \
-    ansible-galaxy collection install $REMOTE_SOURCE_DIR --collections-path "/usr/share/ansible/collections"
+    ansible-galaxy collection install -U --timeout 120 -r requirements.yml --collections-path "/usr/share/ansible/collections" && \
+    ansible-galaxy collection install -U $REMOTE_SOURCE_DIR --collections-path "/usr/share/ansible/collections"
 
 FROM quay.io/ansible/creator-ee:v0.14.1 as runner
 


### PR DESCRIPTION
During the build of the AnsibleEE runner image, if the collections are already installed (as it happens on github runners) they are never upgraded.

If a specific version of a collection is needed, it should be pinned in the `requirements.yml` file in the root of the repository.