### PR TITLE
Do not log exclude Ceph containers from podman container list

### DIFF
--- a/roles/edpm_container_manage/tasks/delete_orphan.yml
+++ b/roles/edpm_container_manage/tasks/delete_orphan.yml
@@ -26,6 +26,7 @@
   when:
     - not (item['Name'] | regex_search('^ceph.*'))
   loop: "{{ podman_containers.containers }}"
+  no_log: true
 
 - name: "Delete orphan containers managed by Podman for {{ edpm_container_manage_config }}"
   when:


### PR DESCRIPTION
Patch 0e6058cc47c5f147a2338b41f07d6f8dd8bac5de resulted in a lot of output in the Ansible logs which made a CI job for the following PR get stuck. The output is unnecessary so do not log it in an attempt to relieve IO pressure.

https://github.com/openstack-k8s-operators/data-plane-adoption/pull/171