### PR TITLE
Revert "Do not attempt to manage collocated Ceph containers"

### DIFF
--- a/docs/source/roles/role-edpm_container_manage.rst
+++ b/docs/source/roles/role-edpm_container_manage.rst
@@ -29,9 +29,6 @@ This Ansible role allows to do the following tasks:
 
   * The container config_id doesn't match with the one in input.
 
-  * The container's name starts with "ceph". Ceph containers are not
-    managed by this role.
-
   Once the previous conditions checked, then these reasons will make the
   containers deleted:
 

--- a/roles/edpm_container_manage/tasks/delete_orphan.yml
+++ b/roles/edpm_container_manage/tasks/delete_orphan.yml
@@ -20,14 +20,6 @@
   when:
     - edpm_container_manage_cli == 'podman'
 
-- name: Exclude Ceph containers from podman container list
-  ansible.builtin.set_fact:
-    filtered_containers: "{{ filtered_containers | default([]) + [item] }}"
-  when:
-    - not (item['Name'] | regex_search('^ceph.*'))
-  loop: "{{ podman_containers.containers }}"
-  no_log: true
-
 - name: "Delete orphan containers managed by Podman for {{ edpm_container_manage_config }}"
   when:
     - edpm_container_manage_systemd_teardown | bool
@@ -36,7 +28,6 @@
   vars:
     edpm_container_cli: "{{ edpm_container_manage_cli }}"
     edpm_containers_to_rm: >-
-      {{ filtered_containers | default([]) |
-      osp.edpm.needs_delete(config=all_containers_hash,
+      {{ podman_containers.containers | osp.edpm.needs_delete(config=all_containers_hash,
       config_id=edpm_container_manage_config_id, check_config=False,
       clean_orphans=True) }}


### PR DESCRIPTION
This reverts commit 0e6058cc47c5f147a2338b41f07d6f8dd8bac5de.

This breaks HCI but HCI is not yet in CI so a follow up patch will fix what this patch breaks for people deploying HCI.

The commit being reverted introduced a task that we still the functionality of, however, its implementation was not efficient and takes too long to run in the CI as documented:

https://github.com/openstack-k8s-operators/data-plane-adoption/pull/171

We still need to exclude the ceph containers but will need to do it with less computational resources (e.g. maybe pure jinja will be faster or we might need a custom filter).

Conflicts:
	roles/edpm_container_manage/tasks/delete_orphan.yml