### PR TITLE
install systemd-containerd on all edpm hosts as part of bootstrap

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -41,6 +41,10 @@ edpm_bootstrap_packages_bootstrap:
   - sysstat
   - iproute-tc
   - ksmtuned
+  # This is required for correct management of cgroups applied to qemu
+  # instances without this libvirt falls back to a legacy cgroup
+  # codepath that is no-longer tested or supported in rhel as of rhel 8...
+  - systemd-container
 
 edpm_bootstrap_release_version_package:
   - rhosp-release

--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -30,6 +30,7 @@ argument_specs:
           - sysstat
           - iproute-tc
           - ksmtuned
+          - systemd-container
         description: "List of packages that are requred to bootstrap EDPM."
 
       edpm_bootstrap_release_version_package:


### PR DESCRIPTION
systemd-container is required to allow libvirt to manage cgroups
for qemu instance across container restarts.

Without systemd-container libvirt falls back to a legacy code
path where it directly manages cgroups without registering
vms in systemd-machined. This is nolonger tested by libvirt team
downstream and is known to cause issues with podman.

We solve this requirement by installing the package in the bootstrap
role to ensure its always installed on edpm hosts.
