### PR TITLE
Make `edpm_kernel` compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_kernel/handlers/main.yml
+++ b/roles/edpm_kernel/handlers/main.yml
@@ -17,3 +17,10 @@
 - name: Delete PageKSM
   ansible.builtin.command: echo 2 >/sys/kernel/mm/ksm/run
   become: true
+  changed_when: false
+
+- name: Reload sysctl
+  ansible.builtin.systemd:
+    name: systemd-sysctl.service
+    state: restarted
+  become: true

--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -15,8 +15,13 @@
 # under the License.
 
 - name: Get the command line args of the node
-  ansible.builtin.command: cat /proc/cmdline
-  register: cmdline
+  ansible.builtin.slurp:
+    src: "/proc/cmdline"
+  register: cmdline_encoded
+
+- name: Save the decoded cmdline
+  ansible.builtin.set_fact:
+    cmdline: "{{ cmdline_encoded['content'] | b64decode }}"
 
 - name: TSX KernelArgs compute node reboot prevention
   when:
@@ -109,9 +114,9 @@
           ansible.builtin.set_fact:
             edpm_kernel_args: >-
               {{ _kernel_args |
-                 regex_replace('[\s]+default_hugepagesz=', ' default_hugepagesz=') |
-                 regex_replace('[\s]+', ' ') |
-                 regex_replace('[\s]+$', '')
+                regex_replace('[\s]+default_hugepagesz=', ' default_hugepagesz=') |
+                regex_replace('[\s]+', ' ') |
+                regex_replace('[\s]+$', '')
               }}
 
 - name: Check if the kernelargs entry is already present in the file
@@ -139,17 +144,20 @@
         dest: /etc/default/grub
         regexp: 'EDPM_KERNEL_ARGS'
         state: absent
-    - name: Ensure the kernel args ( {{ edpm_kernel_args }} ) is present as GRUB_EDPM_KERNEL_ARGS
+
+    - name: "Ensure the kernel args are present as GRUB_EDPM_KERNEL_ARGS: {{ edpm_kernel_args }}"
       ansible.builtin.lineinfile:
         dest: /etc/default/grub
         regexp: '^GRUB_EDPM_KERNEL_ARGS.*'
         insertafter: '^GRUB_CMDLINE_LINUX.*'
         line: 'GRUB_EDPM_KERNEL_ARGS=" {{ edpm_kernel_args }} "'
+
     - name: Add GRUB_EDPM_KERNEL_ARGS to the GRUB_CMDLINE_LINUX parameter
       ansible.builtin.lineinfile:
         dest: /etc/default/grub
         line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${GRUB_EDPM_KERNEL_ARGS}"'
         insertafter: '^GRUB_EDPM_KERNEL_ARGS.*'
+
     - name: Check grub config paths
       ansible.builtin.stat:
         path: "{{ item }}"
@@ -159,20 +167,27 @@
         - /boot/efi/EFI/redhat
         - /boot/efi/EFI/centos
         - /boot/efi/EFI/fedora
+
     - name: Generate grub config
       ansible.builtin.command: "grub2-mkconfig -o /boot/grub2/grub.cfg"
+      register: _grub2_mkconfig
+      changed_when: _grub2_mkconfig.rc == 0
+      failed_when: _grub2_mkconfig.rc != 0
 
     - name: Generate EFI grub config
       ansible.builtin.command: "grub2-mkconfig -o {{ item.stat.path }}/grub.cfg"
-      when: item.stat.exists|bool
+      when: item.stat.exists | bool
       loop: "{{ grub_stat.results }}"
+      register: _grub2_mkconfig_efi
+      changed_when: _grub2_mkconfig_efi.rc == 0
+      failed_when: _grub2_mkconfig_efi.rc != 0
 
     - name: Copy grubenv to EFI directory
       ansible.builtin.copy:
         remote_src: true
         src: /boot/grub2/grubenv
         dest: "{{ item.stat.path }}/grubenv"
-        mode: 0644
+        mode: "0644"
       when: item.stat.exists|bool
       loop: "{{ grub_stat.results }}"
 
@@ -189,6 +204,9 @@
       when:
         - tuned_active_profile.stat.exists
         - tuned_active_profile.stat.size | int > 0
+      register: _tuned_adm
+      changed_when: _tuned_adm.rc == 0
+      failed_when: _tuned_adm.rc != 0
 
     - name: Set reboot required fact
       ansible.builtin.set_fact:
@@ -215,7 +233,7 @@
         - grub_file_entry_check is not changed
 
     - name: Skipping reboot for deployed node
-      ansible.builtin.debug:
+      ansible.builtin.debug:  # noqa: no-handler
         msg: "Reboot is skipped for kernel arg change, user has to plan the reboot with migration and downtime"
       when:
         - grub_file_entry_check is changed

--- a/roles/edpm_kernel/tasks/main.yml
+++ b/roles/edpm_kernel/tasks/main.yml
@@ -39,7 +39,7 @@
       ansible.builtin.file:
         path: /etc/modules-load.d
         state: directory
-        mode: 0755
+        mode: "0755"
         owner: root
         group: root
         setype: etc_t
@@ -48,7 +48,7 @@
       ansible.builtin.template:
         src: "edpm-modprobe.conf.j2"
         dest: "/etc/modules-load.d/99-edpm.conf"
-        mode: 0644
+        mode: "0644"
         owner: root
         group: root
         setype: etc_t
@@ -65,15 +65,8 @@
       ansible.builtin.template:
         src: "edpm-sysctl.conf.j2"
         dest: "/etc/sysctl.d/99-edpm.conf"
-        mode: 0644
+        mode: "0644"
         owner: root
         group: root
         setype: etc_t
-      register: _sysctl_result
-
-    - name: Sysctl reload
-      ansible.builtin.systemd:
-        name: systemd-sysctl.service
-        state: restarted
-      when:
-        - _sysctl_result.changed
+      notify: Reload sysctl


### PR DESCRIPTION
- Added `Sysctl reload` as handler removing a `when` clause as for ansible best practice
- Replaced a `command` task with `slurp` module to get remote file content and `set_fact` task to define the `cmdline` variable
- Fixed indentation and spacing for better readability
- Moved jinja templating at the end of a task name
- Added `changed_when` and `failed_when` in command tasks
- Added a debug task to whitelist
- Declared permissions as strings in `mode` parameter as for ansible best practices