### PR TITLE
Fix owner of the /var/lib/openstack created by the neutron_dhcp role

### DIFF
--- a/roles/edpm_neutron_dhcp/tasks/install.yml
+++ b/roles/edpm_neutron_dhcp/tasks/install.yml
@@ -19,13 +19,15 @@
     path: "{{ item.path }}"
     setype: "container_file_t"
     state: directory
+    owner: "{{ item.owner | default(ansible_user) }}"
+    group: "{{ item.group | default(ansible_user) }}"
     mode: "{{ item.mode | default(omit) }}"
   loop:
     - {'path': "/var/lib/openstack/config/containers", "mode": "0750" }
     - {'path': "/var/lib/neutron", "mode": "0750" }
     - {'path': "{{ edpm_neutron_dhcp_agent_config_dir }}", "mode": "0755" }
-    - {'path': "/var/log/containers/stdouts"}
-    - {'path': "/var/log/containers/neutron"}
+    - {'path': "/var/log/containers/stdouts", "mode": "0755" }
+    - {'path': "/var/log/containers/neutron", "mode": "0755" }
   tags:
     - install
     - neutron


### PR DESCRIPTION
This directory may be created by libvirt role or neutron_dhcp role and it had wrong owner set (root) when was created by edpm_neutron_dhcp role. Because of that edpm_libvirt role which was run after edpm_neutron_dhcp was failing due to permission error to access /var/lib/openstack/config/ directory.