### PR TITLE
[edpm_ssh_known_hosts]Support multiple host key types

### DIFF
--- a/roles/edpm_ssh_known_hosts/molecule/default/converge.yml
+++ b/roles/edpm_ssh_known_hosts/molecule/default/converge.yml
@@ -20,7 +20,13 @@
   pre_tasks:
     - name: Override ssh_host_key_rsa_public test value in ansible_facts
       ansible.builtin.set_fact:
-        ansible_facts: "{{ ansible_facts|combine({'ssh_host_key_rsa_public': 'AAAATEST'}) }}"
+        ansible_facts: "{{ ansible_facts|combine({'ssh_host_key_rsa_public': 'AAAATESTRSA'}) }}"
+    - name: Override ssh_host_key_ed25519_public test value in ansible_facts
+      ansible.builtin.set_fact:
+        ansible_facts: "{{ ansible_facts|combine({'ssh_host_key_ed25519_public': 'AAAATESTED'}) }}"
+    - name: Override ssh_host_key_ecdsa_public test value in ansible_facts
+      ansible.builtin.set_fact:
+        ansible_facts: "{{ ansible_facts|combine({'ssh_host_key_ecdsa_public': 'AAAATESTECDSA'}) }}"
   tasks:
   - name: "Include edpm_ssh_known_hosts"
     ansible.builtin.include_role:

--- a/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
+++ b/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
@@ -25,7 +25,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ssh_host_keys(host):
     expected = [
-        '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[instance]* ssh-rsa AAAATEST',
+        '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[instance]* ssh-rsa AAAATESTRSA',
+        '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[instance]* ssh-ed25519 AAAATESTED',
+        '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[instance]* ecdsa-sha2-nistp256 AAAATESTECDSA',
     ]
 
     for line in expected:

--- a/roles/edpm_ssh_known_hosts/tasks/main.yml
+++ b/roles/edpm_ssh_known_hosts/tasks/main.yml
@@ -50,9 +50,15 @@
       run_once: true
       ansible.builtin.set_fact:
         ssh_known_hosts_lines: |-
+          {%- set key_types = {
+                'ssh_host_key_rsa_public': 'ssh-rsa',
+                'ssh_host_key_ed25519_public': 'ssh-ed25519',
+                'ssh_host_key_ecdsa_public': 'ecdsa-sha2-nistp256',
+              }
+          -%}
           {% for host in groups['all'] | intersect(play_hosts) %}
           {%   set hostdata = hostvars[host] %}
-          {%   if 'ssh_host_key_rsa_public' in hostdata['ansible_facts'] %}
+          {%   if hostdata['ansible_facts'].keys() | intersect(key_types.keys()) %}
           {%     set entries = [] %}
           {%     set enabled_host_networks = hostdata['edpm_role_networks']|default([]) %}
           {%     for network in enabled_host_networks %}
@@ -67,8 +73,13 @@
           {%       set _ = entries.append('[' ~ hostdata['canonical_hostname'] ~ ']*') %}
           {%     endif %}
           {%     set _ = entries.append('[' ~ host ~ ']*') %}
-          {%     set line = entries|unique|join(',') ~ ' ssh-rsa ' ~ hostdata['ansible_facts']['ssh_host_key_rsa_public'] %}
+          {%     set host = entries|unique|join(',') %}
+          {%     for key, type in key_types.items() %}
+          {%       if key in hostdata['ansible_facts'] %}
+          {%         set line = host ~ ' ' ~ type ~ ' ' ~ hostdata['ansible_facts'][key] %}
           {{ line }}
+          {%       endif %}
+          {%     endfor %}
           {%   endif %}
           {% endfor %}
 


### PR DESCRIPTION
Originally the role only copied the RSA host keys to the generated known_hosts file. However newer ssh version prefer ED25519 over RSA. This resulted that even though the known_hosts file was present in the EDPM nodes when an SSH connection is initiated between the nodes the user is got prompted to accept the host key. This is against the purpose of the role.

So this PR adds support for ED25519 and ECDSA host keys as well while keep supporting RSA as well.