### PR TITLE
Added missing `become:true` in `edpm_bootstrap` handlers tasks

### DIFF
--- a/roles/edpm_bootstrap/handlers/main.yml
+++ b/roles/edpm_bootstrap/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Setup linux swap area on file if needed
+  become: true
   ansible.builtin.command: mkswap "{{ edpm_bootstrap_swap_path }}"
   register: _mkswap_command
   changed_when: _mkswap_command.rc == 0
@@ -8,6 +9,7 @@
   listen: "create and activate swap"
 
 - name: Activate swap
+  become: true
   ansible.builtin.command: swapon "{{ edpm_bootstrap_swap_path }}"
   register: _swapon_command
   changed_when: _swapon_command.rc == 0


### PR DESCRIPTION
This PR fixed a regression in `edpm_bootstrap` role generated by [this](https://github.com/openstack-k8s-operators/edpm-ansible/pull/391) PR since the both handlers tasks weren't executed as root.