### PR TITLE
Make `edpm_logrotate_crond` role compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_logrotate_crond/files/logrotate_crond.yaml
+++ b/roles/edpm_logrotate_crond/files/logrotate_crond.yaml
@@ -1,6 +1,8 @@
+---
+
 command: /usr/sbin/crond -s -n
 config_files:
-- source: "/var/lib/kolla/config_files/src/*"
-  dest: "/"
-  merge: true
-  preserve_properties: true
+  - source: "/var/lib/kolla/config_files/src/*"
+    dest: "/"
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_logrotate_crond/meta/argument_specs.yml
+++ b/roles/edpm_logrotate_crond/meta/argument_specs.yml
@@ -84,7 +84,7 @@ argument_specs:
         description: Configures the dateext parameter.
       edpm_logrotate_crond_dateformat:
         default: null
-        description:  Configures the dateformat parameter used with dateext parameter.
+        description: Configures the dateformat parameter used with dateext parameter.
       edpm_logrotate_crond_dateyesterday:
         default: null
         description: Configures the dateyesterday parameter used with dateext parameter.

--- a/roles/edpm_logrotate_crond/tasks/configure.yml
+++ b/roles/edpm_logrotate_crond/tasks/configure.yml
@@ -22,7 +22,7 @@
         dest: /usr/local/sbin/containers-tmpwatch
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
         content: |
           #!/bin/sh
           tmpwatch --nodirs \
@@ -55,7 +55,7 @@
       ansible.builtin.template:
         src: logrotate-crond.conf.j2
         dest: "{{ edpm_logrotate_crond_config_dir }}/etc/logrotate-crond.conf"
-        mode: 0644
+        mode: "0644"
 
     - name: Configure cron entry command
       ansible.builtin.cron:
@@ -68,7 +68,9 @@
         weekday: "*"
         env: false
         name: openstack
-        job: sleep `expr ${RANDOM} \% 90`; /usr/sbin/logrotate -s /var/lib/logrotate/logrotate-crond.status /etc/logrotate-crond.conf 2>&1|logger -t logrotate-crond
+        job: >
+          sleep `expr ${RANDOM} \% 90`; /usr/sbin/logrotate -s /var/lib/logrotate/logrotate-crond.status /etc/logrotate-crond.conf 2>&1|
+          logger -t logrotate-crond
 
     - name: Configure cron entry $PATH env var
       ansible.builtin.cron:


### PR DESCRIPTION
- Fixed indentation in yaml file
- Changed `mode` parameter to be a string
- Fixed spacing issues