### PR TITLE
Make `edpm_multipathd` role compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_multipathd/meta/argument_specs.yml
+++ b/roles/edpm_multipathd/meta/argument_specs.yml
@@ -22,15 +22,15 @@ argument_specs:
         type: str
       edpm_multipathd_volumes:
         default:
-        - /var/lib/kolla/config_files/multipathd.json:/var/lib/kolla/config_files/config.json:ro
-        - /dev:/dev
-        - /run/udev:/run/udev
-        - /sys:/sys
-        - /lib/modules:/lib/modules:ro
-        - /etc/iscsi:/etc/iscsi:ro
-        - /var/lib/iscsi:/var/lib/iscsi:z
-        - /etc/multipath:/etc/multipath:z
-        - /etc/multipath.conf:/etc/multipath.conf:ro
+          - /var/lib/kolla/config_files/multipathd.json:/var/lib/kolla/config_files/config.json:ro
+          - /dev:/dev
+          - /run/udev:/run/udev
+          - /sys:/sys
+          - /lib/modules:/lib/modules:ro
+          - /etc/iscsi:/etc/iscsi:ro
+          - /var/lib/iscsi:/var/lib/iscsi:z
+          - /etc/multipath:/etc/multipath:z
+          - /etc/multipath.conf:/etc/multipath.conf:ro
         description: List of volumes in a mount point format.
         type: list
       edpm_multipathd_restart_sentinel:

--- a/roles/edpm_multipathd/tasks/configure.yml
+++ b/roles/edpm_multipathd/tasks/configure.yml
@@ -55,6 +55,8 @@
       register: blacklist_section
 
     - name: Add a blacklist section if it's missing
+      when:
+        - blacklist_section.rc|int == 1
       block:
         - name: Start the blacklist section
           ansible.builtin.lineinfile:
@@ -65,8 +67,7 @@
             path: /etc/multipath.conf
             regexp: '^(blacklist {)'
             replace: '\1\n}'
-      when:
-        - blacklist_section.rc|int == 1
+
 
     - name: Remove global blacklist if multipathd is enabled
       ansible.builtin.replace:
@@ -91,12 +92,12 @@
         insertafter: '^defaults'
         firstmatch: true
         regexp: "^\\s+{{ item.var }}"
-        line: "        {{ item.var }} {{ (item.value|bool) | ternary('yes', 'no') }}"
+        line: "        {{ item.var }} {{ (item.value | bool) | ternary('yes', 'no') }}"
       loop:
-        - {var: find_multipaths, value: "{{edpm_multipathd_find_multipaths}}"}
-        - {var: recheck_wwid, value: "{{edpm_multipathd_recheck_wwid}}"}
-        - {var: skip_kpartx, value: "{{edpm_multipathd_skip_kpartx}}"}
-        - {var: user_friendly_names, value: "{{edpm_multipathd_user_friendly_names}}"}
+        - { var: find_multipaths, value: "{{ edpm_multipathd_find_multipaths }}" }
+        - { var: recheck_wwid, value: "{{ edpm_multipathd_recheck_wwid }}" }
+        - { var: skip_kpartx, value: "{{ edpm_multipathd_skip_kpartx }}" }
+        - { var: user_friendly_names, value: "{{ edpm_multipathd_user_friendly_names }}" }
       loop_control:
         index_var: multipath_var_index
 

--- a/roles/edpm_multipathd/tasks/install.yml
+++ b/roles/edpm_multipathd/tasks/install.yml
@@ -17,15 +17,8 @@
 - name: Run multipathd install tasks with root privileges
   become: true
   block:
-    - name: Check if multipathd is deployed on the host
-      ansible.builtin.command: systemctl is-enabled --quiet multipathd
-      failed_when: false
-      register: multipathd_enabled_result
-      check_mode: false
-
-    - name: Set fact multipathd_enabled
-      set_fact:
-        multipathd_enabled: "{{ multipathd_enabled_result.rc == 0 }}"
+    - name: Gather services facts
+      ansible.builtin.service_facts:
 
     - name: Stop multipathd service on the host
       ansible.builtin.systemd:
@@ -33,8 +26,9 @@
         state: stopped
         enabled: false
       when:
-        - multipathd_enabled|bool
-      ignore_errors: true
+        - ansible_facts.service["multipathd"] is defined
+        - ansible_facts.service["multipathd"].status == "enabled"
+      failed_when: false
       loop:
         - multipathd.service
         - multipathd.socket


### PR DESCRIPTION
- Fixed indentation issues
- Fixed key order in block
- Fixed jinja spacing issues
- Replaced `systemctl` usage in `command` task with `ansible.builtin.service_facts` facts and adapted the `when` condition in `systemd` task
- Replaced `ignore_errors: true` with `failed_when: false` since it's better to debug when task fails