### PR TITLE
[edpm_ssh_known_hosts]Fix hostname pattern

### DIFF
--- a/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
+++ b/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
@@ -25,9 +25,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ssh_host_keys(host):
     expected = [
-        '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[instance]* ssh-rsa AAAATESTRSA',
-        '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[instance]* ssh-ed25519 AAAATESTED',
-        '[10.0.0.1]*,[centos.ctlplane.localdomain]*,[10.0.1.1]*,[centos.internalapi.localdomain]*,[centos.localdomain]*,[instance]* ecdsa-sha2-nistp256 AAAATESTECDSA',
+        '10.0.0.1,centos.ctlplane.localdomain,10.0.1.1,centos.internalapi.localdomain,centos.localdomain,instance ssh-rsa AAAATESTRSA',
+        '10.0.0.1,centos.ctlplane.localdomain,10.0.1.1,centos.internalapi.localdomain,centos.localdomain,instance ssh-ed25519 AAAATESTED',
+        '10.0.0.1,centos.ctlplane.localdomain,10.0.1.1,centos.internalapi.localdomain,centos.localdomain,instance ecdsa-sha2-nistp256 AAAATESTECDSA',
     ]
 
     for line in expected:

--- a/roles/edpm_ssh_known_hosts/molecule/no_networks/tests/test_no_networks.py
+++ b/roles/edpm_ssh_known_hosts/molecule/no_networks/tests/test_no_networks.py
@@ -25,7 +25,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ssh_host_keys(host):
     expected = [
-        '[instance]* ssh-rsa AAAATEST',
+        'instance ssh-rsa AAAATEST',
     ]
 
     for line in expected:

--- a/roles/edpm_ssh_known_hosts/tasks/main.yml
+++ b/roles/edpm_ssh_known_hosts/tasks/main.yml
@@ -63,16 +63,16 @@
           {%     set enabled_host_networks = hostdata['edpm_role_networks']|default([]) %}
           {%     for network in enabled_host_networks %}
           {%       if (network ~ '_ip') in hostdata %}
-          {%         set _ = entries.append('[' ~ hostdata[network ~ '_ip'] ~ ']*') %}
+          {%         set _ = entries.append(hostdata[network ~ '_ip']) %}
           {%       endif %}
           {%       if (network ~ '_hostname') in hostdata %}
-          {%         set _ = entries.append('[' ~ hostdata[network ~ '_hostname'] ~ ']*') %}
+          {%         set _ = entries.append(hostdata[network ~ '_hostname']) %}
           {%       endif %}
           {%     endfor %}
           {%     if 'canonical_hostname' in hostdata %}
-          {%       set _ = entries.append('[' ~ hostdata['canonical_hostname'] ~ ']*') %}
+          {%       set _ = entries.append(hostdata['canonical_hostname']) %}
           {%     endif %}
-          {%     set _ = entries.append('[' ~ host ~ ']*') %}
+          {%     set _ = entries.append(host) %}
           {%     set host = entries|unique|join(',') %}
           {%     for key, type in key_types.items() %}
           {%       if key in hostdata['ansible_facts'] %}


### PR DESCRIPTION
Originally the role generated hostnames in the known_hosts file with the
following pattern:
[edpm-compute-0]*,...

This pattern does not work as it does not match with the edpm-compute-0
hostname:
```
[root@edpm-compute-0 ~]# ssh edpm-compute-0
The authenticity of host 'edpm-compute-0 (192.168.122.100)' can't be established.
ED25519 key fingerprint is SHA256:ba66xyWDSkO0qv/9EATAZWT4NHhgDnScka4U7FIreaY.
This host key is known by the following other names/addresses:
    /etc/ssh/ssh_known_hosts:4: [edpm-compute-0]*
Are you sure you want to continue connecting (yes/no/[fingerprint])?
```

According to the ssh docs * and ? can be used for globbing. However []
can only be used for defining hosts with non default ssh port in the form
of [hostname]:portnumber. Based on my testing on EDPM nodes. The globbing
does not work for port numbers even if I add the missing ':'. Our ssh
server in EDPM runs on the default port so the []: format is not at all
needed. Also we have separate hostkeys for each node so globbing on the
hostname does not needed either.

This PR removes the unnecessary complication from the known_hosts
generation and therefore fixing the hostname matching during host key
verification.