### PR TITLE
Make `edpm_neutron_dhcp` role compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -53,7 +53,7 @@ edpm_neutron_dhcp_oslo_middleware_enable_proxy_headers_parsing: 60
 # DEFAULT
 edpm_neutron_dhcp_rootwrap_DEFAULT_filters_path: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
 edpm_neutron_dhcp_rootwrap_DEFAULT_exec_dirs: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/etc/neutron/kill_scripts'
-edpm_neutron_dhcp_rootwrap_DEFAULT_use_syslog: False
+edpm_neutron_dhcp_rootwrap_DEFAULT_use_syslog: false
 edpm_neutron_dhcp_rootwrap_DEFAULT_syslog_log_facility: 'syslog'
 edpm_neutron_dhcp_rootwrap_DEFAULT_syslog_log_level: 'ERROR'
 edpm_neutron_dhcp_rootwrap_DEFAULT_daemon_timeout: 600
@@ -66,17 +66,17 @@ edpm_neutron_dhcp_agent_DEFAULT_host: '{{ ansible_facts["nodename"] }}'
 edpm_neutron_dhcp_agent_DEFAULT_resync_interval: 5
 edpm_neutron_dhcp_agent_DEFAULT_resync_throttle: 1
 edpm_neutron_dhcp_agent_DEFAULT_dhcp_driver: 'neutron.agent.linux.dhcp.Dnsmasq'
-edpm_neutron_dhcp_agent_DEFAULT_enable_isolated_metadata: False
-edpm_neutron_dhcp_agent_DEFAULT_force_metadata: False
-edpm_neutron_dhcp_agent_DEFAULT_enable_metadata_network: False
+edpm_neutron_dhcp_agent_DEFAULT_enable_isolated_metadata: false
+edpm_neutron_dhcp_agent_DEFAULT_force_metadata: false
+edpm_neutron_dhcp_agent_DEFAULT_enable_metadata_network: false
 edpm_neutron_dhcp_agent_DEFAULT_num_sync_threads: 4
 edpm_neutron_dhcp_agent_DEFAULT_bulk_reload_interval: 0
 edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_dns_servers: ''
 edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_base_log_dir: ''
-edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_local_resolv: False
+edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_local_resolv: false
 edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_lease_max: 16777216
-edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_enable_addr6_list: False
-edpm_neutron_dhcp_agent_DEFAULT_dhcp_broadcast_reply: False
+edpm_neutron_dhcp_agent_DEFAULT_dnsmasq_enable_addr6_list: false
+edpm_neutron_dhcp_agent_DEFAULT_dhcp_broadcast_reply: false
 # AGENT
 edpm_neutron_dhcp_agent_AGENT_root_helper: 'sudo neutron-rootwrap /etc/neutron.conf.d/01-rootwrap.conf'
 edpm_neutron_dhcp_agent_AGENT_report_interval: 30

--- a/roles/edpm_neutron_dhcp/handlers/main.yml
+++ b/roles/edpm_neutron_dhcp/handlers/main.yml
@@ -14,9 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: restart neutron-dhcp-agent container
+- name: Restart neutron-dhcp-agent container
   become: true
   ansible.builtin.systemd:
     state: restarted
     name: "edpm_neutron_dhcp_agent.service"
-  listen: "restart neutron-dhcp-agent"
+  listen: "Restart neutron-dhcp-agent"

--- a/roles/edpm_neutron_dhcp/tasks/configure.yml
+++ b/roles/edpm_neutron_dhcp/tasks/configure.yml
@@ -30,20 +30,20 @@
         - configure
         - neutron
       notify:
-      - restart neutron-dhcp-agent
+        - Restart neutron-dhcp-agent
 
-    - name: discover secrets in {{ edpm_neutron_dhcp_agent_config_src }}
+    - name: Discover secrets in {{ edpm_neutron_dhcp_agent_config_src }}
       ansible.builtin.find:
         paths: "{{ edpm_neutron_dhcp_agent_config_src }}"
         file_type: file
-        recurse: yes
+        recurse: true
         patterns:
-        - "*dhcp*conf"
+          - "*dhcp*conf"
       register: edpm_neutron_dhcp_secrets
       delegate_to: localhost
       become: false
 
-    - name: flatten secrets into {{ edpm_neutron_dhcp_agent_config_dir }}
+    - name: Flatten secrets into {{ edpm_neutron_dhcp_agent_config_dir }}
       ansible.builtin.copy:
         src: "{{ item.path }}"
         dest: "{{ edpm_neutron_dhcp_agent_config_dir }}/{{ item.path | basename }}"

--- a/roles/edpm_neutron_dhcp/tasks/install.yml
+++ b/roles/edpm_neutron_dhcp/tasks/install.yml
@@ -23,22 +23,22 @@
   loop:
     - {'path': "/var/lib/openstack/config/containers", "mode": "0750" }
     - {'path': "/var/lib/neutron", "mode": "0750" }
-    - {'path': "{{ edpm_neutron_dhcp_agent_config_dir }}", 'mode': '0755'}
+    - {'path': "{{ edpm_neutron_dhcp_agent_config_dir }}", "mode": "0755" }
     - {'path': "/var/log/containers/stdouts"}
     - {'path': "/var/log/containers/neutron"}
   tags:
     - install
     - neutron
 
-- name: render neutron-dhcp-agent container
+- name: Render neutron-dhcp-agent container
   become: true
   ansible.builtin.template:
     src: "neutron_dhcp_agent.yaml.j2"
     dest: "/var/lib/openstack/config/containers/neutron_dhcp_agent.yaml"
     setype: "container_file_t"
-    mode: 0644
+    mode: "0644"
   notify:
-  - restart neutron-dhcp-agent
+    - Restart neutron-dhcp-agent
   tags:
     - install
     - neutron


### PR DESCRIPTION
- Fixed `false` values in `defaults/main.yml`
- Capitalized first letter of task names
- Fixed indentation issues
- Define `mode` parameter as a string