### PR TITLE
ovn: don't explicitly set vlan-limit=0

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -85,5 +85,4 @@ edpm_ovn_ovs_external_ids:
   rundir: "/var/run/openvswitch"
 
 # Set openvswitch other_config.
-edpm_ovn_ovs_other_config:
-  vlan-limit: 0
+edpm_ovn_ovs_other_config: {}

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -127,8 +127,7 @@ argument_specs:
         description: Sets external_id data from provided variables using Jinja templating
         type: dict
       edpm_ovn_ovs_other_config:
-        default:
-          vlan-limit: 0
+        default: {}
         description: Openvswitch other_config
         type: dict
       edpm_ovn_protocol:

--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -66,6 +66,7 @@
   register: ovs_external_ids
   changed_when: ovs_external_ids.rc == 0
   failed_when: ovs_external_ids.rc != 0
+  when: edpm_ovn_ovs_external_ids | length > 0
 
 - name: Configure OVS other_config
   ansible.builtin.shell: >
@@ -73,6 +74,7 @@
   register: ovs_other_config
   changed_when: ovs_other_config.rc == 0
   failed_when: ovs_other_config.rc != 0
+  when: edpm_ovn_ovs_other_config | length > 0
 
 - name: Add OVS Manager
   block:


### PR DESCRIPTION
ovn-controller does it automatically since 21.09.0 [1].

https://github.com/ovn-org/ovn/commit/7e2c892c380aeddc4bbc9ceb5e759ee9ac62176d