### PR TITLE
Make `edpm_neutron_sriov` role compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_neutron_sriov/handlers/main.yml
+++ b/roles/edpm_neutron_sriov/handlers/main.yml
@@ -14,9 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: restart neutron-sriov-agent container
+- name: Restart neutron-sriov-agent container
   become: true
   ansible.builtin.systemd:
     state: restarted
     name: "edpm_neutron_sriov_agent.service"
-  listen: "restart neutron-sriov-agent"
+  listen: "Restart neutron-sriov-agent"

--- a/roles/edpm_neutron_sriov/tasks/configure.yml
+++ b/roles/edpm_neutron_sriov/tasks/configure.yml
@@ -30,20 +30,20 @@
         - configure
         - neutron
       notify:
-      - restart neutron-sriov-agent
+        - Restart neutron-sriov-agent
 
-    - name: discover secrets in {{ edpm_neutron_sriov_agent_config_src }}
+    - name: Discover secrets in {{ edpm_neutron_sriov_agent_config_src }}
       ansible.builtin.find:
         paths: "{{ edpm_neutron_sriov_agent_config_src }}"
         file_type: file
-        recurse: yes
+        recurse: true
         patterns:
-        - "*sriov*conf"
+          - "*sriov*conf"
       register: edpm_neutron_sriov_secrets
       delegate_to: localhost
       become: false
 
-    - name: flatten secrets into {{ edpm_neutron_sriov_agent_config_dir }}
+    - name: Flatten secrets into {{ edpm_neutron_sriov_agent_config_dir }}
       ansible.builtin.copy:
         src: "{{ item.path }}"
         dest: "{{ edpm_neutron_sriov_agent_config_dir }}/{{ item.path | basename }}"

--- a/roles/edpm_neutron_sriov/tasks/install.yml
+++ b/roles/edpm_neutron_sriov/tasks/install.yml
@@ -21,24 +21,24 @@
     state: directory
     mode: "{{ item.mode | default(omit) }}"
   loop:
-    - {'path': "/var/lib/openstack/config/containers", "mode": "0750" }
-    - {'path': "/var/lib/neutron", "mode": "0750" }
-    - {'path': "{{ edpm_neutron_sriov_agent_config_dir }}", 'mode': '0755'}
-    - {'path': "/var/log/containers/stdouts"}
-    - {'path': "/var/log/containers/neutron"}
+    - { 'path': "/var/lib/openstack/config/containers", "mode": "0750" }
+    - { 'path': "/var/lib/neutron", "mode": "0750" }
+    - { 'path': "{{ edpm_neutron_sriov_agent_config_dir }}", "mode": "0755" }
+    - { 'path': "/var/log/containers/stdouts" }
+    - { 'path': "/var/log/containers/neutron" }
   tags:
     - install
     - neutron
 
-- name: render neutron-sriov-agent container
+- name: Render neutron-sriov-agent container
   become: true
   ansible.builtin.template:
     src: "neutron_sriov_agent.yaml.j2"
     dest: "/var/lib/openstack/config/containers/neutron_sriov_agent.yaml"
     setype: "container_file_t"
-    mode: 0644
+    mode: "0644"
   notify:
-  - restart neutron-sriov-agent
+    - Restart neutron-sriov-agent
   tags:
     - install
     - neutron


### PR DESCRIPTION
- Capitalized first letter of the task names
- Fixed spacing issues
- Changed `yes` to `true`
- Fixed indentation
- Changed `mode` parameter to be a string