### PR TITLE
[edpm_ssh_known_hosts] Add back hostname globbing

### DIFF
--- a/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
+++ b/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
@@ -25,9 +25,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ssh_host_keys(host):
     expected = [
-        '10.0.0.1,centos.ctlplane.localdomain,10.0.1.1,centos.internalapi.localdomain,centos.localdomain,instance ssh-rsa AAAATESTRSA',
-        '10.0.0.1,centos.ctlplane.localdomain,10.0.1.1,centos.internalapi.localdomain,centos.localdomain,instance ssh-ed25519 AAAATESTED',
-        '10.0.0.1,centos.ctlplane.localdomain,10.0.1.1,centos.internalapi.localdomain,centos.localdomain,instance ecdsa-sha2-nistp256 AAAATESTECDSA',
+        '10.0.0.1,centos.ctlplane.localdomain,10.0.1.1,centos.internalapi.localdomain,centos.localdomain,instance* ssh-rsa AAAATESTRSA',
+        '10.0.0.1,centos.ctlplane.localdomain,10.0.1.1,centos.internalapi.localdomain,centos.localdomain,instance* ssh-ed25519 AAAATESTED',
+        '10.0.0.1,centos.ctlplane.localdomain,10.0.1.1,centos.internalapi.localdomain,centos.localdomain,instance* ecdsa-sha2-nistp256 AAAATESTECDSA',
     ]
 
     for line in expected:

--- a/roles/edpm_ssh_known_hosts/molecule/no_networks/tests/test_no_networks.py
+++ b/roles/edpm_ssh_known_hosts/molecule/no_networks/tests/test_no_networks.py
@@ -25,7 +25,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ssh_host_keys(host):
     expected = [
-        'instance ssh-rsa AAAATEST',
+        'instance* ssh-rsa AAAATEST',
     ]
 
     for line in expected:

--- a/roles/edpm_ssh_known_hosts/tasks/main.yml
+++ b/roles/edpm_ssh_known_hosts/tasks/main.yml
@@ -72,7 +72,7 @@
           {%     if 'canonical_hostname' in hostdata %}
           {%       set _ = entries.append(hostdata['canonical_hostname']) %}
           {%     endif %}
-          {%     set _ = entries.append(host) %}
+          {%     set _ = entries.append(host ~ '*') %}
           {%     set host = entries|unique|join(',') %}
           {%     for key, type in key_types.items() %}
           {%       if key in hostdata['ansible_facts'] %}


### PR DESCRIPTION
The #422 removed all the name globbing as it was in the wrong place. Now this PR adds back globbing for hostname to support the case when hostname is not and fqdn during deployment but later and fqdn is used to ssh between nodes.