### PR TITLE
Make `edpm_nodes_validation` role compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_nodes_validation/tasks/ping.yml
+++ b/roles/edpm_nodes_validation/tasks/ping.yml
@@ -24,13 +24,19 @@
     INT=$(ip ro get {{ controller }} | head -1 | sed -nr "s/.* dev (\w+) .*/\1/p")
     MTU=$(cat /sys/class/net/${INT}/mtu 2>/dev/null || echo "0")
     echo "$INT $MTU"
+  changed_when:
+    - _nic_mtu.stdout.split()[0] != ""
+    - _nic_mtu.stdout.split()[1] != ""
+  failed_when:
+    - _nic_mtu.stdout.split()[0] == ""
+    - _nic_mtu.stdout.split()[1] == ""
 - name: Set interface vars
   ansible.builtin.set_fact:
     _nic: "{{ _nic_mtu.stdout.split()[0] | default('lo') }}"
     _mtu: "{{ _nic_mtu.stdout.split()[1] | default(0) | int - 28 }}"
 - name: Network availability validation block
   when:
-    - not ansible_check_mode|bool
+    - not ansible_check_mode | bool
     - _nic != 'lo'
   block:
     - name: Check IP responsiveness
@@ -41,7 +47,7 @@
       register: ping_result
       until: ping_result.rc == 0
 
-    - name: Validate packet with {{ _mtu }} MTU size can reach controller from {{ _nic }}
+    - name: Validate packet with given MTU size can reach controller from {{ _nic }}
       ansible.builtin.command: "{{ _ping_cmd }} -w 10 -s {{ _mtu }} -c 5 {{ controller }}"
       retries: 10
       delay: 60


### PR DESCRIPTION
- Added `changed_when`/`failed_when` in `shell` task
- Fixed spacing issues
- Fixed task name avoiding templating inside it