### PR TITLE
Fixed typo while using `ansible.builtin.service_facts` in `edpm_multipathd` role

### DIFF
--- a/roles/edpm_multipathd/tasks/install.yml
+++ b/roles/edpm_multipathd/tasks/install.yml
@@ -26,8 +26,8 @@
         state: stopped
         enabled: false
       when:
-        - ansible_facts.service["multipathd"] is defined
-        - ansible_facts.service["multipathd"].status == "enabled"
+        - ansible_facts.services["multipathd"] is defined
+        - ansible_facts.services["multipathd"].status == "enabled"
       failed_when: false
       loop:
         - multipathd.service


### PR DESCRIPTION
- Changed `service` to `services` in when clause