### PR TITLE
Update testing_with_ansibleee example for OpenStackDataPlaneNodeSet

### DIFF
--- a/docs/source/testing_with_ansibleee.rst
+++ b/docs/source/testing_with_ansibleee.rst
@@ -100,7 +100,7 @@ Add extraMount to your OpenStackDataPlane CR
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use kustomize or "oc edit" to add the edpm-ansible PVC to the
-OpenStackDataPlane's /spec/roles/edpm-compute/nodeTemplate/extraMounts. The
+OpenStackDataPlane's /spec/nodeTemplate/extraMounts. The
 mountPath is where the edpm-ansible *roles* and *plugins* directories are
 located inside the openstack-ansibleee-runner container image. The
 OpenStackDataPlane CR should contain the following snippet:
@@ -108,16 +108,14 @@ OpenStackDataPlane CR should contain the following snippet:
 .. code-block:: console
 
   spec:
-    roles:
-      edpm-compute:
-        nodeTemplate:
-          extraMounts:
-          - extraVolType: edpm-ansible
-            mounts:
-            - mountPath: /usr/share/ansible/collections/ansible_collections/osp/edpm
-              name: edpm-ansible
-            volumes:
-            - name: edpm-ansible
-              persistentVolumeClaim:
-                claimName: edpm-ansible
-                readOnly: true
+    nodeTemplate:
+      extraMounts:
+      - extraVolType: edpm-ansible
+        mounts:
+        - mountPath: /usr/share/ansible/collections/ansible_collections/osp/edpm
+          name: edpm-ansible
+        volumes:
+        - name: edpm-ansible
+          persistentVolumeClaim:
+            claimName: edpm-ansible
+            readOnly: true


### PR DESCRIPTION

With the switch from `OpenStackDataPlaneNode` to `OpenStackDataPlaneNodeSet`, the `nodeTemplate` entry for `extraMounts` is no longer under `roles` and now under `spec` so update the example accordingly.