### PR TITLE
Make `edpm_ovn` compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -65,18 +65,21 @@ edpm_ovn_ovs_external_ids:
   hostname: "{{ ansible_nodename }}"
   ovn-bridge: "{{ edpm_ovn_bridge }}"
   ovn-bridge-mappings: "{{ edpm_ovn_bridge_mappings | join(',') }}"
-  ovn-chassis-mac-mappings:
+  ovn-chassis-mac-mappings: >-
     "{%- set chassis_mac_mappings = [] -%}
-     {%- for physnet, mac_prefix in edpm_ovn_chassis_mac_mapping_prefixes.items() -%}
-       {{ chassis_mac_mappings.append([physnet, mac_prefix | community.general.random_mac(seed=edpm_ovn_chassis_mac_mapping_seed)] | join(':')) }}
-     {%- endfor -%}
-     {{ chassis_mac_mappings | join(',') }}"
+    {%- for physnet, mac_prefix in edpm_ovn_chassis_mac_mapping_prefixes.items() -%}
+    {{ chassis_mac_mappings.append([physnet, mac_prefix | community.general.random_mac(seed=edpm_ovn_chassis_mac_mapping_seed)] |
+      join(':')) }}{%- endfor -%}
+    {{ chassis_mac_mappings | join(',') }}"
   ovn-encap-ip: "{{ edpm_ovn_encap_ip }}"
   ovn-encap-type: "{{ edpm_ovn_encap_type }}"
   ovn-match-northd-version: true
   ovn-monitor-all: true
   ovn-openflow-probe-interval: "{{ edpm_ovn_of_probe_interval }}"
-  ovn-remote: "{% set db_addresses = [] %}{% for host in edpm_ovn_dbs %}{{ db_addresses.append([edpm_ovn_protocol, host, edpm_ovn_sb_server_port] | join(':')) }}{% endfor %}{{ db_addresses | join(',') }}"
+  ovn-remote: >-
+    "{%- set db_addresses = [] -%}{%- for host in edpm_ovn_dbs -%}
+    {{ db_addresses.append([edpm_ovn_protocol, host, edpm_ovn_sb_server_port] | join(':')) }}{%- endfor -%}
+    {{ db_addresses | join(',') }}"
   ovn-remote-probe-interval: "{{ edpm_ovn_remote_probe_interval }}"
   ovn-ofctrl-wait-before-clear: "{{ edpm_ovn_ofctrl_wait_before_clear }}"
   rundir: "/var/run/openvswitch"

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -30,15 +30,15 @@ argument_specs:
         type: str
       edpm_ovn_bridge_mappings:
         default:
-        - datacentre:br-ex
+          - datacentre:br-ex
         description: ''
         type: list
       edpm_ovn_chassis_mac_first_octets:
         default:
-        - 0e
-        - 1e
-        - 2e
-        - 3e
+          - 0e
+          - 1e
+          - 2e
+          - 3e
         description: ''
         type: list
       edpm_ovn_chassis_mac_mapping_prefixes:
@@ -66,18 +66,18 @@ argument_specs:
         type: str
       edpm_ovn_controller_common_volumes:
         default:
-        - /lib/modules:/lib/modules:ro
-        - /run:/run
-        - /var/lib/openvswitch/ovn:/run/ovn:shared,z
-        - /var/log/containers/openvswitch:/var/log/openvswitch:z
-        - /var/log/containers/openvswitch:/var/log/ovn:z
-        - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
+          - /lib/modules:/lib/modules:ro
+          - /run:/run
+          - /var/lib/openvswitch/ovn:/run/ovn:shared,z
+          - /var/log/containers/openvswitch:/var/log/openvswitch:z
+          - /var/log/containers/openvswitch:/var/log/ovn:z
+          - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
         description: List of volumes in a mount point form.
         type: list
       edpm_ovn_controller_tls_volumes:
         default:
-        - /etc/pki/tls/certs/:/etc/pki/tls/certs/
-        - /etc/pki/tls/private/:/etc/pki/tls/private/
+          - /etc/pki/tls/certs/:/etc/pki/tls/certs/
+          - /etc/pki/tls/private/:/etc/pki/tls/private/
         description: List of TLS volumes in a mount point form.
         type: list
       edpm_ovn_dbs:

--- a/roles/edpm_ovn/tasks/cleanup.yml
+++ b/roles/edpm_ovn/tasks/cleanup.yml
@@ -17,9 +17,15 @@
 - name: Cleanup hw-offload when no longer required
   ansible.builtin.shell: >
     ovs-vsctl remove open . other_config hw-offload
+  register: cleanup_hw_offload
+  changed_when: cleanup_hw_offload.rc == 0
+  failed_when: cleanup_hw_offload.rc != 0
   when: not edpm_enable_hw_offload | bool
 
 - name: Cleanup enable-chassis-as-gw when chassis GW not enabled
   ansible.builtin.shell: >
     ovs-vsctl remove open . external_ids ovn-cms-options
+  register: cleanup_enable_chassis_as_gw
+  changed_when: cleanup_enable_chassis_as_gw.rc == 0
+  failed_when: cleanup_enable_chassis_as_gw.rc != 0
   when: not edpm_enable_chassis_gw | bool

--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -16,28 +16,28 @@
 
 - name: Apply ovsdb configuration from configMaps
   block:
-  - name: Check that config file exists
-    stat:
-      path: "{{ edpm_ovn_config_src }}/ovsdb-config"
-    register: ovsdb_config_exists
-    delegate_to: localhost
-    become: false
+    - name: Check that config file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_ovn_config_src }}/ovsdb-config"
+      register: ovsdb_config_exists
+      delegate_to: localhost
+      become: false
 
-  - name: Load ovsdb configuration from file
-    ansible.builtin.include_vars:
-      file: "{{ edpm_ovn_config_src }}/ovsdb-config"
-      name: edpm_ovn_configmap_facts
-    when:
-      ovsdb_config_exists.stat.exists
-    delegate_to: localhost
-    become: false
+    - name: Load ovsdb configuration from file
+      ansible.builtin.include_vars:
+        file: "{{ edpm_ovn_config_src }}/ovsdb-config"
+        name: edpm_ovn_configmap_facts
+      when:
+        ovsdb_config_exists.stat.exists
+      delegate_to: localhost
+      become: false
 
-  - name: Append ovsdb configMap options to external_ids
-    ansible.builtin.set_fact:
-      edpm_ovn_ovs_external_ids: "{{ edpm_ovn_ovs_external_ids | combine(edpm_ovn_configmap_facts|default({})) }}"
+    - name: Append ovsdb configMap options to external_ids
+      ansible.builtin.set_fact:
+        edpm_ovn_ovs_external_ids: "{{ edpm_ovn_ovs_external_ids | combine(edpm_ovn_configmap_facts | default({})) }}"
 
 - name: Configure GW ports on chassis setting when enabled
-  when: edpm_enable_chassis_gw|default(false)
+  when: edpm_enable_chassis_gw | default(false)
   block:
     - name: Set enable-chassis-as-gw
       ansible.builtin.set_fact:
@@ -62,20 +62,32 @@
 
 - name: Configure OVS external_ids
   ansible.builtin.shell: >
-    ovs-vsctl set open . {% for key, value in edpm_ovn_ovs_external_ids.items() %} external_ids:{{ key }}={{ value }} {% endfor %}
+    ovs-vsctl set open . {% for key, value in edpm_ovn_ovs_external_ids.items() -%} external_ids:{{ key }}={{ value }} {% endfor %}
+  register: ovs_external_ids
+  changed_when: ovs_external_ids.rc == 0
+  failed_when: ovs_external_ids.rc != 0
 
 - name: Configure OVS other_config
   ansible.builtin.shell: >
     ovs-vsctl set open . {% for key, value in edpm_ovn_ovs_other_config.items() %} other_config:{{ key }}={{ value }} {% endfor %}
+  register: ovs_other_config
+  changed_when: ovs_other_config.rc == 0
+  failed_when: ovs_other_config.rc != 0
 
 - name: Add OVS Manager
   block:
     - name: Check if OVS Manager already exists
       ansible.builtin.shell: >
+        set -o pipefail
         ovs-vsctl show | grep -q "Manager"
       register: ovs_manager_configured
-      ignore_errors: yes
+      changed_when: true
+      failed_when: false
+
     - name: Add OVS Manager if not exists
       ansible.builtin.shell: >
         ovs-vsctl --timeout=5 --id=@manager -- create Manager target=\"ptcp:6640:127.0.0.1\" -- add Open_vSwitch . manager_options @manager
       when: ovs_manager_configured.rc == 1
+      register: ovs_manager_if_not_exists
+      changed_when: ovs_manager_if_not_exists.rc == 0
+      failed_when: ovs_manager_if_not_exists.rc != 0

--- a/roles/edpm_ovn/tasks/firewall.yml
+++ b/roles/edpm_ovn/tasks/firewall.yml
@@ -48,10 +48,10 @@
 
 - name: Configure firewall for the ovn
   ansible.builtin.include_role:
-      name: osp.edpm.edpm_nftables
-      tasks_from: "configure.yml"
+    name: osp.edpm.edpm_nftables
+    tasks_from: "configure.yml"
 
 - name: Apply firewall for the ovn
   ansible.builtin.include_role:
-      name: osp.edpm.edpm_nftables
-      tasks_from: "run.yml"
+    name: osp.edpm.edpm_nftables
+    tasks_from: "run.yml"


### PR DESCRIPTION
- Fixed yaml indentation issues
- Added `changed_when`/`failed_when` in `shell` tasks
- Replaced `ignore_errors: true` with `failed_when: false`
- Added FQCN where needed