### PR TITLE
Make `edpm_ovn_bgp_agent` role compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
+++ b/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
@@ -1,4 +1,5 @@
 ---
+
 argument_specs:
   # ./roles/edpm_ovn_bgp_agent/tasks/main.yml entry point
   main:
@@ -82,7 +83,7 @@ argument_specs:
       edpm_ovn_bgp_agent_ovs_manager:
         type: str
         default: "ptcp:6640:127.0.0.1"
-        description:  OVSDB connection method.
+        description: OVSDB connection method.
       edpm_ovn_bgp_agent_image:
         type: str
         default: "quay.io/podified-antelope-centos9/openstack-ovn-bgp-agent:current-podified"

--- a/roles/edpm_ovn_bgp_agent/meta/main.yml
+++ b/roles/edpm_ovn_bgp_agent/meta/main.yml
@@ -21,7 +21,7 @@ galaxy_info:
   description: EDPM OpenStack Role -- edpm_ovn_bgp_agent
   company: Red Hat
   license: Apache-2.0
-  min_ansible_version: 2.9
+  min_ansible_version: '2.9'
   #
   # Provide a list of supported platforms, and for each platform a list of versions.
   # If you don't wish to enumerate all versions for a particular platform, use 'all'.
@@ -31,8 +31,8 @@ galaxy_info:
   platforms:
     - name: 'EL'
       versions:
-        - 8
-        - 9
+        - '8'
+        - '9'
 
   galaxy_tags:
     - edpm

--- a/roles/edpm_ovn_bgp_agent/tasks/configure.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/configure.yml
@@ -18,7 +18,7 @@
   ansible.builtin.template:
     src: ovn-bgp-agent.conf.j2
     dest: "{{ edpm_ovn_bgp_agent_config_basedir }}/etc/ovn-bgp-agent/bgp-agent.conf"
-    mode: '640'
+    mode: "640"
     selevel: s0
     setype: container_file_t
   register: _ovn_bgp_agent_config_result
@@ -27,10 +27,15 @@
   block:
     - name: Check if OVS Manager already exists
       ansible.builtin.shell: >
+        set -o pipefail
         ovs-vsctl show | grep -q "Manager"
       register: ovs_manager_configured
-      ignore_errors: yes
+      failed_when: false
+      changed_when: true
     - name: Add OVS Manager if not exists
       ansible.builtin.shell: >
         ovs-vsctl --timeout=5 --id=@manager -- create Manager target=\"{{ edpm_ovn_bgp_agent_ovs_manager }}\" -- add Open_vSwitch . manager_options @manager
       when: ovs_manager_configured.rc == 1
+      register: ovs_manager_if_not_exists
+      changed_when: ovs_manager_if_not_exists.rc == 0
+      failed_when: ovs_manager_if_not_exists.rc != 0


### PR DESCRIPTION
- Fixed yaml indentation issues
- Added `set -o pipefail` in `shell` task
- Added `changed_when`/`failed_when` in shell task
- Replaced `ignore_errors: true` with `failed_when: false`
- Changed `'` to `"` in `mode` parameter to be coherent with the rest of the repo

Signed-off-by: Roberto Alfieri <ralfieri@redhat.com>