### PR TITLE
Make `edpm_podman` role compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_podman/handlers/main.yml
+++ b/roles/edpm_podman/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Restart rsyslog
+  become: true
   ansible.builtin.systemd:
     name: rsyslog
     state: restarted

--- a/roles/edpm_podman/meta/argument_specs.yml
+++ b/roles/edpm_podman/meta/argument_specs.yml
@@ -1,4 +1,5 @@
 ---
+
 argument_specs:
   # ./roles/edpm_podman/tasks/main.yml entry point
   main:
@@ -56,33 +57,32 @@ argument_specs:
           - quay.io
         description: List of package registries
       edpm_podman_default_network_config:
-          type: dict
-          description: >
-            This is the default network configuration except the range has been moved
-            from 10.88.0.0/16 to 10.255.255.0/24 to try and prevent a conflict in an
-            existing cloud
-          default:
-            cniVersion: 0.4.0
-            name: podman
-            plugins:
-              - type: bridge
-                bridge: cni-podman0
-                isGateway: true
-                ipMasq: true
-                hairpinMode: true
-                ipam:
-                  type: host-local
-                  routes:
-                    - dst: 0.0.0.0/0
-                  ranges:
-                    - - subnet: 10.255.255.0/24
-                        gateway: 10.255.255.1
-              - type: portmap
-                capabilities:
-                  portMappings: true
-              - type: firewall
-              - type: tuning
-
+        type: dict
+        description: >
+          This is the default network configuration except the range has been moved
+          from 10.88.0.0/16 to 10.255.255.0/24 to try and prevent a conflict in an
+          existing cloud
+        default:
+          cniVersion: 0.4.0
+          name: podman
+          plugins:
+            - type: bridge
+              bridge: cni-podman0
+              isGateway: true
+              ipMasq: true
+              hairpinMode: true
+              ipam:
+                type: host-local
+                routes:
+                  - dst: 0.0.0.0/0
+                ranges:
+                  - subnet: 10.255.255.0/24
+                    gateway: 10.255.255.1
+            - type: portmap
+              capabilities:
+                portMappings: true
+            - type: firewall
+            - type: tuning
       edpm_podman_registries:
         type: list
         default: []

--- a/roles/edpm_podman/tasks/buildah_login.yml
+++ b/roles/edpm_podman/tasks/buildah_login.yml
@@ -37,3 +37,5 @@
   no_log: "{{ edpm_podman_hide_sensitive_logs | bool }}"
   loop: "{{ query('dict', edpm_container_registry_logins) }}"
   register: registry_login_buildah
+  changed_when: registry_login_buildah.rc == 0
+  failed_when: registry_login_buildah.rc != 0

--- a/roles/edpm_podman/tasks/configure.yml
+++ b/roles/edpm_podman/tasks/configure.yml
@@ -19,7 +19,7 @@
 - name: Configure edpm_container_manage to generate systemd drop-in dependencies
   ansible.builtin.copy:
     dest: /etc/sysconfig/podman_drop_in
-    mode: '0644'
+    mode: "0644"
     content: |
       This file makes edpm_container_manage generate additional systemd
       dependencies for containers that have special

--- a/roles/edpm_podman/tasks/install.yml
+++ b/roles/edpm_podman/tasks/install.yml
@@ -40,6 +40,9 @@
       ansible.builtin.command: ip link delete cni0
       when:
         - '"cni0" in ansible_facts["interfaces"]'
+      register: delete_legacy_interface
+      changed_when: delete_legacy_interface.rc == 0
+      failed_when: delete_legacy_interface.rc != 0
 
     # don't update the network config if the network is already running
     # meaning cni-podman0 is running somewhere
@@ -53,7 +56,7 @@
             path: /etc/cni/net.d
             state: directory
             recurse: true
-            mode: '0755'
+            mode: "0755"
             owner: root
             group: root
 
@@ -61,7 +64,7 @@
           ansible.builtin.copy:
             dest: /etc/cni/net.d/87-podman-bridge.conflist
             content: "{{ edpm_podman_default_network_config | to_json }}"
-            mode: '0644'
+            mode: "0644"
             owner: root
             group: root
 
@@ -74,18 +77,20 @@
             path: /etc/containers/networks
             state: directory
             recurse: true
-            mode: '0755'
+            mode: "0755"
             owner: root
             group: root
         - name: Get current podman network
           ansible.builtin.shell: |
             podman network inspect podman
           register: podman_network_inspect
+          changed_when: podman_network_inspect.rc == 0
+          failed_when: podman_network_inspect.rc != 0
         - name: Update the default network configuration
           ansible.builtin.template:
             src: podman_network_config.j2
             dest: /etc/containers/networks/podman.json
-            mode: '0644'
+            mode: "0644"
             owner: root
             group: root
           when:
@@ -98,7 +103,7 @@
         owner: root
         group: root
         setype: etc_t
-        mode: '0644'
+        mode: "0644"
 
     - name: Write containers.conf
       community.general.ini_file:
@@ -106,7 +111,7 @@
         owner: root
         group: root
         setype: etc_t
-        mode: '0644'
+        mode: "0644"
         create: true
         section: "{{ item.section }}"
         option: "{{ item.option }}"

--- a/roles/edpm_podman/tasks/login.yml
+++ b/roles/edpm_podman/tasks/login.yml
@@ -17,10 +17,8 @@
 
 - name: Perform container registry login(s) with podman
   become: true
-  ansible.builtin.shell: |-
-    podman login --username=$REGISTRY_USERNAME \
-                 --password=$REGISTRY_PASSWORD \
-                 $REGISTRY
+  ansible.builtin.shell: >
+    podman login --username=$REGISTRY_USERNAME --password=$REGISTRY_PASSWORD $REGISTRY
   environment:
     REGISTRY_USERNAME: "{{ lookup('dict', item.value).key }}"
     REGISTRY_PASSWORD: "{{ lookup('dict', item.value).value }}"
@@ -28,3 +26,5 @@
   no_log: "{{ edpm_podman_hide_sensitive_logs | bool }}"
   loop: "{{ query('dict', edpm_container_registry_logins) }}"
   register: registry_login_podman
+  changed_when: registry_login_podman.rc == 0
+  failed_when: registry_login_podman.rc != 0

--- a/roles/edpm_podman/tasks/purge.yml
+++ b/roles/edpm_podman/tasks/purge.yml
@@ -15,17 +15,16 @@
 # under the License.
 
 
-- name: Podman image prune
+- name: Clean podman images
   become: true
-  block:
-    - name: Clean podman images
-      ansible.builtin.command: podman image prune -a -f
-  rescue:
-    # In case -f isn't available yet, we fallback to old way.
-    # https://bugs.launchpad.net/edpm/+bug/1889418
-    - name: Clean podman images
-      ansible.builtin.command: podman image prune -a
+  ansible.builtin.command: podman image prune -a -f
+  register: clean_podman_image
+  changed_when: clean_podman_image.rc == 0
+  failed_when: clean_podman_image.rc != 0
 
 - name: Clean podman volumes
   become: true
   ansible.builtin.command: podman volume prune -f
+  register: clean_podman_volumes
+  changed_when: clean_podman_volumes.rc == 0
+  failed_when: clean_podman_volumes.rc != 0

--- a/roles/edpm_podman/tasks/rsyslog.yml
+++ b/roles/edpm_podman/tasks/rsyslog.yml
@@ -35,11 +35,5 @@
           & stop
         create: true
         path: /etc/rsyslog.d/podman.conf
-        mode: 0644
-      register: logconfig
-
-    - name: Restart rsyslog service after logging conf change
-      ansible.builtin.systemd:
-        name: rsyslog
-        state: restarted
-      when: logconfig is changed
+        mode: "0644"
+      notify: Restart rsyslog

--- a/roles/edpm_podman/tasks/rsyslog_cleanup.yml
+++ b/roles/edpm_podman/tasks/rsyslog_cleanup.yml
@@ -9,5 +9,5 @@
   ansible.builtin.file:
     path: /etc/rsyslog.d/openstack-healthcheck.conf
     state: absent
-  ignore_errors: true
+  failed_when: false
   notify: Restart rsyslog


### PR DESCRIPTION
- Fixed YAML indentation and spacing
- Added `changed_when`/`failed_when` in `command` and `shell` tasks
- Replaced `'` with `"` in `mode` parameter for coherence with the rest of the repo
- Changed `Clean podman images` from a block of tasks since we don't need the rescue task anymore
- Replaced `ignore_errors: true` with `failed_when: false`
- Replaced a task with an (existing) handler task
- Added `become: true` in handler task