### PR TITLE
Fix usage of pipefail in shell tasks

### DIFF
--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -77,7 +77,7 @@
 - name: Add OVS Manager
   block:
     - name: Check if OVS Manager already exists
-      ansible.builtin.shell: >
+      ansible.builtin.shell: |
         set -o pipefail
         ovs-vsctl show | grep -q "Manager"
       register: ovs_manager_configured

--- a/roles/edpm_ovn_bgp_agent/tasks/configure.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/configure.yml
@@ -26,7 +26,7 @@
 - name: Add OVS Manager
   block:
     - name: Check if OVS Manager already exists
-      ansible.builtin.shell: >
+      ansible.builtin.shell: |
         set -o pipefail
         ovs-vsctl show | grep -q "Manager"
       register: ovs_manager_configured


### PR DESCRIPTION
[1][2] added it wrongly causing the shell task not working as expected, this patch fixes it.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/433
[2] https://github.com/openstack-k8s-operators/edpm-ansible/pull/434