### PR TITLE
Merge the frr and ovn-bgp-agent roles into one

### DIFF
--- a/playbooks/frr.yml
+++ b/playbooks/frr.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Deploy EDPM FRR
+  hosts: all
+  strategy: linear
+  become: true
+  tasks:
+    - name: EDPM FRR
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_frr
+      tags:
+        - edpm_frr

--- a/playbooks/ovn_bgp_agent.yml
+++ b/playbooks/ovn_bgp_agent.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Deploy EDPM OVN BGP Agent
+  hosts: all
+  strategy: linear
+  become: true
+  tasks:
+    - name: EDPM OVN BGP Agent
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_ovn_bgp_agent
+      tags:
+        - edpm_ovn_bgp_agent


### PR DESCRIPTION
There is no need to split the roles in install, configure and run. This task is about unifying them so that we just have a frr role and an ovn-bgp-agent role.

To avoid breaking other repositories that still use the split roles, we will decompose the merging of the roles in two steps. This patch represents the first step, creating the future role that will replace the other three (install, configure, run).

A future patch, once it is confirmed that the dependent repositories are already using the unified role, will eliminate the split roles.