### PR TITLE
Make `edpm_users` role compliant with ansible-lint `production` profile

### DIFF
--- a/roles/edpm_users/meta/argument_specs.yml
+++ b/roles/edpm_users/meta/argument_specs.yml
@@ -4,7 +4,7 @@ argument_specs:
   main:
     short_description: The main entry point for the edpm_users role.
     description:
-     - |
+      - |
         This role will create the users and groups listed in this variable and is intended to be used
         whenever we required users and or groups to be created on the host that match the users and or groups
         of the containers running on the host. it can also create directories and set their ownership and permissions.

--- a/roles/edpm_users/tasks/create_users_and_groups.yml
+++ b/roles/edpm_users/tasks/create_users_and_groups.yml
@@ -14,17 +14,17 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: create host user and group
+- name: Create host user and group
   become: true
   tags:
     - edpm_users
   block:
-    - name: Ensure {{ item.name }} group is present on the host
+    - name: Ensure group is present on the host [ {{ item.name }} ]
       ansible.builtin.group:
         name: "{{ item.name }}"
         gid: "{{ item.gid }}"
         state: present
-    - name: Ensure {{ item.name }} user is present on the host
+    - name: Ensure user is present on the host [ {{ item.name }} ]
       when: not (item.group_only | default(false))
       ansible.builtin.user:
         name: "{{ item.name }}"

--- a/roles/edpm_users/tasks/main.yml
+++ b/roles/edpm_users/tasks/main.yml
@@ -14,11 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: create host users and groups
+- name: Create host users and groups
   ansible.builtin.include_tasks: create_users_and_groups.yml
   loop: "{{ edpm_users_users }}"
 
-- name: create host directories
+- name: Create host directories
   become: true
   ansible.builtin.file:
     path: "{{ item.path }}"
@@ -26,6 +26,6 @@
     owner: "{{ item.owner | default(omit) }}"
     group: "{{ item.group | default(omit) }}"
     setype: "{{ item.setype | default(omit) }}"
-    seuser: "{{item.seuser | default(omit) }}"
+    seuser: "{{ item.seuser | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
   loop: "{{ edpm_users_extra_dirs }}"


### PR DESCRIPTION
- Fixed indentation issues
- Capitalized first letter in the task names
- Moved templating to the end of task names