### PR TITLE
Make `env_data` role compliant with ansible-lint `production` profile

### DIFF
--- a/roles/env_data/meta/argument_specs.yml
+++ b/roles/env_data/meta/argument_specs.yml
@@ -4,6 +4,6 @@ argument_specs:
   main:
     short_description: The main entry point for the osp.edpm.env_data role.
     description:
-    - Role gathers information about local env and prints it as debug.
-    - No arguments are expected or necessary.
+      - Role gathers information about local env and prints it as debug.
+      - No arguments are expected or necessary.
     options: {}

--- a/roles/env_data/tasks/main.yml
+++ b/roles/env_data/tasks/main.yml
@@ -21,6 +21,8 @@
 - name: Gather repository list
   ansible.builtin.command: dnf repolist
   register: repo_list
+  changed_when: false
+  failed_when: repo_list.rc != 0
 
 - name: Output installed packages
   ansible.builtin.debug:


### PR DESCRIPTION
- Fixed indentation issues
- Added `changed_when`/`failed_when` in `command` task