### PR TITLE
[nova]Add nova user to the EDPM host

### DIFF
--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -40,3 +40,17 @@
         - "Copying /var/lib/kolla/config_files/nova-blank.conf to /etc/nova/nova.conf"
         - "Copying /var/lib/kolla/config_files/01-nova.conf to /etc/nova/nova.conf.d/01-nova.conf"
         - "Copying /var/lib/kolla/config_files/02-nova-log.conf to /etc/nova/nova.conf.d/02-nova-log.conf"
+
+    - name: Check if user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: nova
+      register: nova_user
+
+    - name: Assert that nova user is created with kolla uid and gid
+      ansible.builtin.assert:
+        that:
+          # user
+          - "nova_user.ansible_facts.getent_passwd.nova[1] == '42436'"
+          # group
+          - "nova_user.ansible_facts.getent_passwd.nova[2] == '42436'"

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -75,3 +75,14 @@
   loop: "{{ edpm_nova_configmaps.files }}"
   notify:
     - Restart nova
+
+- name: Configure nova user and group on the host
+  ansible.builtin.import_role:
+    name: edpm_users
+  vars:
+    edpm_users_users:
+      # 42436 is matching with the uid and gid created by kolla in the nova containers
+      - {"name": "nova", "uid": "42436", "gid": "42436", "shell": "/bin/sh", "comment": "nova user"}
+    edpm_users_extra_dirs: []
+  tags:
+    - edpm_users


### PR DESCRIPTION
This user will be used by nova-compute to copy data between compute nodes during migration.