### PR TITLE
[nova]Set up ssh keys auth for the nova user 

### DIFF
--- a/roles/edpm_nova/molecule/default/prepare.yml
+++ b/roles/edpm_nova/molecule/default/prepare.yml
@@ -81,3 +81,11 @@
         owner: root
         group: root
         mode: 0755
+    - name: Create ssh_known_hosts file
+      become: true
+      ansible.builtin.file:
+        path: '/etc/ssh/ssh_known_hosts'
+        state: touch
+        owner: root
+        group: root
+        mode: '0655'

--- a/roles/edpm_nova/molecule/default/test-data/migration-key/ssh-privatekey
+++ b/roles/edpm_nova/molecule/default/test-data/migration-key/ssh-privatekey
@@ -1,0 +1,1 @@
+test data: ssh private key

--- a/roles/edpm_nova/molecule/default/test-data/migration-key/ssh-publickey
+++ b/roles/edpm_nova/molecule/default/test-data/migration-key/ssh-publickey
@@ -1,0 +1,1 @@
+test data: ssh public key

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -40,6 +40,8 @@
         - "Copying /var/lib/kolla/config_files/nova-blank.conf to /etc/nova/nova.conf"
         - "Copying /var/lib/kolla/config_files/01-nova.conf to /etc/nova/nova.conf.d/01-nova.conf"
         - "Copying /var/lib/kolla/config_files/02-nova-log.conf to /etc/nova/nova.conf.d/02-nova-log.conf"
+        - "Copying /var/lib/kolla/config_files/ssh-config to /var/lib/nova/.ssh/config"
+        - "Copying /var/lib/kolla/config_files/ssh-privatekey to /var/lib/nova/.ssh/ssh-privatekey"
 
     - name: Check if user exists
       ansible.builtin.getent:
@@ -54,3 +56,14 @@
           - "nova_user.ansible_facts.getent_passwd.nova[1] == '42436'"
           # group
           - "nova_user.ansible_facts.getent_passwd.nova[2] == '42436'"
+
+    - name: Stat /home/nova/.ssh/authorized_keys
+      become: true
+      ansible.builtin.stat:
+        path: /home/nova/.ssh/authorized_keys
+      register: nova_authorized_keys
+
+    - name: Assert that nova user has authorized_keys on the host
+      ansible.builtin.assert:
+        that:
+          - "nova_authorized_keys.stat.mode == '0600'"

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -16,6 +16,7 @@
         - "/var/lib/openstack/config/containers"
         - "/var/log/containers"
         - "/var/log/containers/stdouts"
+        - "/etc/ssh/ssh_known_hosts"
         # extrenal deps
         - "/var/lib/openstack/config/ceph"
          # nova directories

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -50,6 +50,7 @@
   loop:
     - {"src": "config.json.j2", "dest": "config.json"}
     - {"src": "nova-blank.conf", "dest": "nova-blank.conf"}
+    - {"src": "ssh-config", "dest": "ssh-config"}
   notify:
     - Restart nova
 
@@ -86,3 +87,22 @@
     edpm_users_extra_dirs: []
   tags:
     - edpm_users
+
+- name: Create .ssh directory for the nova user on the host
+  become: true
+  ansible.builtin.file:
+    path: "/home/nova/.ssh"
+    state: "directory"
+    owner: nova
+    group: nova
+    mode: '0700'
+
+- name: Copy the migration ssh public key as authorized_keys to the nova user
+  become: true
+  ansible.builtin.copy:
+    src: "{{ edpm_nova_config_dest }}/ssh-publickey"
+    remote_src: true
+    dest: "/home/nova/.ssh/authorized_keys"
+    mode: '0600'
+    owner: nova
+    group: nova

--- a/roles/edpm_nova/templates/config.json.j2
+++ b/roles/edpm_nova/templates/config.json.j2
@@ -19,6 +19,19 @@
             "owner": "nova",
             "perm": "0700",
             "optional": true
+        },
+        {
+            "source": "/var/lib/kolla/config_files/ssh-privatekey",
+            "dest": "/var/lib/nova/.ssh/",
+            "owner": "nova",
+            "perm": "0600",
+            "optional": true
+        },
+        {
+            "source": "/var/lib/kolla/config_files/ssh-config",
+            "dest": "/var/lib/nova/.ssh/config",
+            "owner": "nova",
+            "perm": "0600"
         }
     ],
     "permissions": [
@@ -36,6 +49,16 @@
             "path": "/var/lib/nova",
             "owner": "nova:nova",
             "recurse": true
+        },
+        {
+            "path": "/var/lib/nova/.ssh/",
+            "owner": "nova:nova",
+            "perm:": "0700"
+        },
+        {
+            "path": "/var/lib/nova/.ssh/*",
+            "owner": "nova:nova",
+            "perm:": "0600"
         }
     ]
 }

--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -22,6 +22,7 @@
         "/etc/multipath:/etc/multipath:z",
         "/etc/multipath.conf:/etc/multipath.conf:ro",
         "/etc/iscsi:/etc/iscsi:ro",
-        "/var/lib/openstack/config/ceph:/var/lib/kolla/config_files/ceph:ro"
+        "/var/lib/openstack/config/ceph:/var/lib/kolla/config_files/ceph:ro",
+        "/etc/ssh/ssh_known_hosts:/etc/ssh/ssh_known_hosts:ro"
     ]
 }

--- a/roles/edpm_nova/templates/ssh-config
+++ b/roles/edpm_nova/templates/ssh-config
@@ -1,0 +1,3 @@
+Host *
+    User nova
+    IdentityFile /var/lib/nova/.ssh/ssh-privatekey


### PR DESCRIPTION
The nova user needs to be able to copy files between the compute nodes.
The edpm_nova role now expects that a Secret is mounted to the AnsibleEE
CR containing an ssh keypair (ssh-privatekey and ssh-publickey). This
keypair is used to set up the auth for the nova user between the
compute nodes. On the EDPM host the nova user will have the public key
added as authorized_keys. While the nova user in the nova-compute
container will have the private key added as identity in
/var/lib/nova/.ssh. Also an ssh config file is added in the container to
ensure that this identity is used for all the outgoing ssh connection.

Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/471