### PR TITLE
Execute `Ensure legacy iptables services are off` task only if iptables and ip6tables services are present

### DIFF
--- a/roles/edpm_nftables/tasks/service-bootstrap.yml
+++ b/roles/edpm_nftables/tasks/service-bootstrap.yml
@@ -31,6 +31,8 @@
       loop:
         - iptables.service
         - ip6tables.service
+      when:
+        - ansible_facts.services["{{ item }}"] is defined
 
     - name: Ensure nftables service is enabled and running
       ansible.builtin.systemd:


### PR DESCRIPTION
If the task is executed in environment without those services, it raise an error:

```
TASK [osp.edpm.edpm_nftables : Ensure legacy iptables services are off] ********
Friday 13 October 2023  08:23:44 +0000 (0:00:03.253)       0:00:15.801 ******** 
failed: [edpm-compute-0] (item=iptables.service) => {"ansible_loop_var": "item", "changed": false, "item": "iptables.service", "msg": "Could not find the requested service iptables.service: host"}
failed: [edpm-compute-1] (item=iptables.service) => {"ansible_loop_var": "item", "changed": false, "item": "iptables.service", "msg": "Could not find the requested service iptables.service: host"}
failed: [edpm-compute-1] (item=ip6tables.service) => {"ansible_loop_var": "item", "changed": false, "item": "ip6tables.service", "msg": "Could not find the requested service ip6tables.service: host"}
failed: [edpm-compute-0] (item=ip6tables.service) => {"ansible_loop_var": "item", "changed": false, "item": "ip6tables.service", "msg": "Could not find the requested service ip6tables.service: host"}
```