### PR TITLE
[edpm_ssh_known_hosts]Cleanup unused code paths

### DIFF
--- a/roles/edpm_ssh_known_hosts/molecule/default/molecule.yml
+++ b/roles/edpm_ssh_known_hosts/molecule/default/molecule.yml
@@ -25,17 +25,10 @@ provisioner:
           allovercloud:
             hosts:
               instance:
-                ansible_port: 2222
+                ansible_port: "2222"
                 canonical_hostname: centos.localdomain
-                ctlplane_hostname: centos.ctlplane.localdomain
                 ctlplane_ip: 10.0.0.1
-                edpm_role_networks:
-                - ctlplane
-                - internal_api
-                - management
-                internal_api_hostname: centos.internalapi.localdomain
                 internal_api_ip: 10.0.1.1
-                management_ip: 10.0.0.1
         hosts:
           instance:
             ansible_python_interpreter: /usr/bin/python3

--- a/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
+++ b/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
@@ -25,9 +25,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ssh_host_keys(host):
     expected = [
-        '[10.0.0.1]:2222,[centos.ctlplane.localdomain]:2222,[10.0.1.1]:2222,[centos.internalapi.localdomain]:2222,[centos.localdomain]:2222,[instance*]:2222 ssh-rsa AAAATESTRSA',
-        '[10.0.0.1]:2222,[centos.ctlplane.localdomain]:2222,[10.0.1.1]:2222,[centos.internalapi.localdomain]:2222,[centos.localdomain]:2222,[instance*]:2222 ssh-ed25519 AAAATESTED',
-        '[10.0.0.1]:2222,[centos.ctlplane.localdomain]:2222,[10.0.1.1]:2222,[centos.internalapi.localdomain]:2222,[centos.localdomain]:2222,[instance*]:2222 ecdsa-sha2-nistp256 AAAATESTECDSA',
+        '[centos.localdomain]:2222,[instance*]:2222 ssh-rsa AAAATESTRSA',
+        '[centos.localdomain]:2222,[instance*]:2222 ssh-ed25519 AAAATESTED',
+        '[centos.localdomain]:2222,[instance*]:2222 ecdsa-sha2-nistp256 AAAATESTECDSA',
     ]
 
     for line in expected:

--- a/roles/edpm_ssh_known_hosts/tasks/main.yml
+++ b/roles/edpm_ssh_known_hosts/tasks/main.yml
@@ -60,15 +60,6 @@
           {%   set hostdata = hostvars[host] %}
           {%   if hostdata['ansible_facts'].keys() | intersect(key_types.keys()) %}
           {%     set entries = [] %}
-          {%     set enabled_host_networks = hostdata['edpm_role_networks']|default([]) %}
-          {%     for network in enabled_host_networks %}
-          {%       if (network ~ '_ip') in hostdata %}
-          {%         set _ = entries.append(hostdata[network ~ '_ip']) %}
-          {%       endif %}
-          {%       if (network ~ '_hostname') in hostdata %}
-          {%         set _ = entries.append(hostdata[network ~ '_hostname']) %}
-          {%       endif %}
-          {%     endfor %}
           {%     if 'canonical_hostname' in hostdata %}
           {%       set _ = entries.append(hostdata['canonical_hostname']) %}
           {%     endif %}


### PR DESCRIPTION
The logic that collected the name and IP of the host was referring to variables that are not defined in the EDPM inventory today. Those are probably old tripleo variables. So this patch removes the dead code.