### PR TITLE
[edpm_ssh_known_hosts]Ensure host IP is added

### DIFF
--- a/roles/edpm_ssh_known_hosts/tasks/main.yml
+++ b/roles/edpm_ssh_known_hosts/tasks/main.yml
@@ -72,6 +72,9 @@
           {%     if 'canonical_hostname' in hostdata %}
           {%       set _ = entries.append(hostdata['canonical_hostname']) %}
           {%     endif %}
+          {%     if 'ctlplane_ip' in hostdata %}
+          {%       set _ = entries.append(hostdata['ctlplane_ip']) %}
+          {%     endif %}
           {%     set _ = entries.append(host ~ '*') %}
           {%     if 'ansible_port' in hostdata and hostdata['ansible_port']|int != 22 %}
           {%       set hosts = [] %}


### PR DESCRIPTION
Unfortunately nova still uses the IP of the compute nodes to scp data during cold migration instead of the hypervisor_hostname which is the FQDN of the compute node. So we need to make sure the ctlplane_ip of the node is also in the known_hosts file.