### PR TITLE
Fix trivial YAML errors in several roles

### DIFF
--- a/roles/edpm_chrony/meta/main.yml
+++ b/roles/edpm_chrony/meta/main.yml
@@ -1,3 +1,5 @@
+---
+
 galaxy_info:
   role_name: edpm_chrony
   author: EDPM team

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -37,7 +37,7 @@
       ansible.builtin.systemd:
         name: NetworkManager
         state: restarted
-      when: nm_ovs_status.changed # noqa: no-handler
+      when: nm_ovs_status.changed  # noqa: no-handler
     - name: Load system-roles.network tasks [nmstate]
       ansible.builtin.include_role:
         name: "{{ systemrolename }}"

--- a/roles/edpm_network_config/tasks/network_config.yml
+++ b/roles/edpm_network_config/tasks/network_config.yml
@@ -111,7 +111,7 @@
         content: "{{ os_net_config_mappings_result.mapping | to_nice_yaml }}"
         dest: /etc/os-net-config/mapping.yaml
         mode: "0644"
-      when: os_net_config_mappings_result.changed | bool # noqa: no-handler
+      when: os_net_config_mappings_result.changed | bool  # noqa: no-handler
 
     - name: Manage NetworkConfig with edpm_os_net_config module
       block:

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -67,7 +67,7 @@ edpm_ovn_bgp_agent_tls_volumes:
   - /etc/pki/tls/certs/ovn_bgp_agent.crt:/etc/pki/tls/certs/ovn_bgp_agent.crt
   - /etc/pki/tls/private/ovn_bgp_agent.key:/etc/pki/tls/private/ovn_bgp_agent.key
 
-   # we need to add the InternalTLSCAFile and do a if/then/else in case tls-e
+  # we need to add the InternalTLSCAFile and do a if/then/else in case tls-e
 
 # seconds between retries for download tasks
 edpm_ovn_bgp_agent_images_download_delay: 5

--- a/roles/edpm_sshd/tasks/install.yml
+++ b/roles/edpm_sshd/tasks/install.yml
@@ -34,5 +34,5 @@
       register: generate_sshd_host_keys
       changed_when: generate_sshd_host_keys.rc == 0
       failed_when: generate_sshd_host_keys.rc != 0
-      when: # noqa: no-handler
+      when:  # noqa: no-handler
         - _sshd_install_result.changed


### PR DESCRIPTION
This patch is a followup of the patches submitted for these roles. It fixes few YAML errors:

- `yaml[comments]: Too few spaces before comment`
- `yaml[document-start]: Missing document start "---"`
- `yaml[comments-indentation]: Comment not indented like content`