### PR TITLE
[molecule]Fix known_hosts molecule test

### DIFF
--- a/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
+++ b/roles/edpm_ssh_known_hosts/molecule/default/tests/test_default.py
@@ -25,9 +25,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ssh_host_keys(host):
     expected = [
-        '[centos.localdomain]:2222,[instance*]:2222 ssh-rsa AAAATESTRSA',
-        '[centos.localdomain]:2222,[instance*]:2222 ssh-ed25519 AAAATESTED',
-        '[centos.localdomain]:2222,[instance*]:2222 ecdsa-sha2-nistp256 AAAATESTECDSA',
+        '[centos.localdomain]:2222,[10.0.0.1]:2222,[instance*]:2222 ssh-rsa AAAATESTRSA',
+        '[centos.localdomain]:2222,[10.0.0.1]:2222,[instance*]:2222 ssh-ed25519 AAAATESTED',
+        '[centos.localdomain]:2222,[10.0.0.1]:2222,[instance*]:2222 ecdsa-sha2-nistp256 AAAATESTECDSA',
     ]
 
     for line in expected:


### PR DESCRIPTION
By merging #448 after #449 caused that the molecule test is now failing on main. Separately the two PRs wer doing the correct thing. The github action doing the pre-merge testing does not do a rebase before running the test so it cannot detect if the merged in PR fails the test.

This PR fixing the molecule test.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/448/files#diff-654bc2164f880d6ff16c6009ecd64121cac7d59497ada186aab1ffded0a466b8