### PR TITLE
use correct ceph host dir for libvirt and nova

### DIFF
--- a/roles/edpm_libvirt/molecule/default/prepare.yml
+++ b/roles/edpm_libvirt/molecule/default/prepare.yml
@@ -58,8 +58,6 @@
               proto: tcp
               dport: 22
 
-    # edpm_nova molecule depends on edpm_libvirt so it tests
-    # the case where this directory does not exsit
     - name: Create Ceph client file directory
       become: true
       ansible.builtin.file:

--- a/roles/edpm_libvirt/molecule/default/verify.yml
+++ b/roles/edpm_libvirt/molecule/default/verify.yml
@@ -17,7 +17,7 @@
         - "/var/log/containers"
         - "/var/log/containers/stdouts"
         # extrenal deps
-        - "/etc/ceph"
+        - "/var/lib/openstack/config/ceph"
         # libvirt directories
         - "/var/lib/libvirt"
         - "/var/lib/openstack/config/libvirt"

--- a/roles/edpm_libvirt/tasks/install.yml
+++ b/roles/edpm_libvirt/tasks/install.yml
@@ -35,7 +35,7 @@
   # dont set owner/group or mode on these, as they are managed
   # by other roles, just ensure they exist.
   - { "path": "/var/log/containers/stdouts" }
-  - { "path": "/etc/ceph" }
+  - { "path": "/var/lib/openstack/config/ceph" }
 - name: render libvirt container
   tags:
     - install

--- a/roles/edpm_libvirt/templates/libvirt_virtqemud/libvirt_virtqemud.json.j2
+++ b/roles/edpm_libvirt/templates/libvirt_virtqemud/libvirt_virtqemud.json.j2
@@ -17,6 +17,6 @@
         "/var/lib/nova:/var/lib/nova:shared,z",
         "/run/libvirt:/run/libvirt:shared,z",
         "/dev:/dev",
-        "/etc/ceph:/var/lib/kolla/config_files/ceph:ro"
+        "/var/lib/openstack/config/ceph:/var/lib/kolla/config_files/ceph:ro"
     ]
   }

--- a/roles/edpm_nova/molecule/default/prepare.yml
+++ b/roles/edpm_nova/molecule/default/prepare.yml
@@ -42,10 +42,10 @@
         src: /usr/share/zoneinfo/UTC
         state: link
     - name: set timezone
-      import_role:
+      ansible.builtin.import_role:
         name: osp.edpm.edpm_timezone
     - name: install podman
-      import_role:
+      ansible.builtin.import_role:
         name: osp.edpm.edpm_podman
     - name: Create firewall directory
       become: true
@@ -65,7 +65,7 @@
               proto: tcp
               dport: 22
     - name: install libvirt
-      import_role:
+      ansible.builtin.import_role:
         name: osp.edpm.edpm_libvirt
     - name: ensure /etc/multipath.conf exists
       become: true
@@ -73,3 +73,11 @@
         path: /etc/multipath.conf
         state: touch
         mode: "0644"
+    - name: Create Ceph client file directory
+      become: true
+      ansible.builtin.file:
+        path: '/var/lib/openstack/config/ceph/'
+        state: directory
+        owner: root
+        group: root
+        mode: 0755

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -17,7 +17,7 @@
         - "/var/log/containers"
         - "/var/log/containers/stdouts"
         # extrenal deps
-        - "/etc/ceph"
+        - "/var/lib/openstack/config/ceph"
          # nova directories
         - "/var/lib/nova"
         - "/var/lib/openstack/config/nova"

--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -22,6 +22,6 @@
         "/etc/multipath:/etc/multipath:z",
         "/etc/multipath.conf:/etc/multipath.conf:ro",
         "/etc/iscsi:/etc/iscsi:ro",
-        "/etc/ceph:/var/lib/kolla/config_files/ceph:ro"
+        "/var/lib/openstack/config/ceph:/var/lib/kolla/config_files/ceph:ro"
     ]
 }


### PR DESCRIPTION
This change modifies the ceph dir that is mounted
to the libvirt qemu and nova comptute contaienr
from /etc/ceph  to /var/lib/openstack/config/ceph

(cherry picked from commit 81f2fe811aa8aac5a317ceb300a9c8ab37c05c99)