### PR TITLE
Add `galaxy[version-incorrect]` to ansible-lint skip-list

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -20,3 +20,4 @@ use_default_rules: true
 profile: production
 skip_list:
   - command-instead-of-shell
+  - galaxy[version-incorrect]


### PR DESCRIPTION
Since we are on version 0.0.1, that check fails because it expects at least a `1.x.x` version despite in the official documentation [1] the only requirement is to be compliant with semantic versioning.

[1] https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html