### PR TITLE
Version bump `ansible-lint` to `v6.20.3` and enforce `ansible-core` version requirement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,13 +25,12 @@ repos:
         # E501 - line is too long, would require local ignore or obfuscating changes
         # W503 - line break before binary operator, ignored by default
         entry: flake8 --ignore=E501,W503
-  - repo: https://github.com/ansible-community/ansible-lint
-    rev: v6.14.2
+  - repo: https://github.com/ansible/ansible-lint
+    rev: v6.20.3
     hooks:
       - id: ansible-lint
         additional_dependencies:
-          - ansible-core
-          - yamllint
+          - ansible-core>=2.14.0,<2.15.0
   - repo: https://github.com/openstack-dev/bashate.git
     rev: 2.1.1
     hooks:


### PR DESCRIPTION
- `ansible-lint` version bump to `v6.20.3` to enforce all the needed checks for "modern" ansible development
- `ansible-core` version pinned to version `>=2.14.0,<2.15.0` which is the version that we are using on our ansibleee runner
- changed the url of the ansible-lint tool since the old link was a redirect

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/459