### PR TITLE
Add role to setup neutron ovn agent

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -28,6 +28,7 @@ jobs:
         - edpm_multipathd
         - edpm_network_config
         - edpm_neutron_metadata
+        - edpm_neutron_ovn
         - edpm_neutron_sriov
         - edpm_nftables
         - edpm_nodes_validation

--- a/playbooks/neutron_ovn.yaml
+++ b/playbooks/neutron_ovn.yaml
@@ -1,0 +1,11 @@
+---
+- name: Deploy EDPM Neutron OVN agent
+  hosts: all
+  strategy: linear
+  become: true
+  tasks:
+    - name: Neutron OVN agent
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_neutron_ovn
+      tags:
+        - edpm_neutron_ovn

--- a/roles/edpm_download_cache/tasks/container_images.yml
+++ b/roles/edpm_download_cache/tasks/container_images.yml
@@ -47,6 +47,14 @@
     - edpm_neutron_metadata
     - download_cache
 
+- name: Download images for edpm_neutron_ovn role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_ovn
+    tasks_from: download_cache.yml
+  tags:
+    - edpm_neutron_ovn
+    - download_cache
+
 - name: Download images for edpm_multipathd role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_multipathd

--- a/roles/edpm_neutron_ovn/OWNERS
+++ b/roles/edpm_neutron_ovn/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+  - slawqo
+  - luis5tb
+  - network-approvers
+
+reviewers:
+  - slawqo
+  - luis5tb
+  - network-approvers

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -1,0 +1,43 @@
+---
+# defaults file for edpm_ovn
+
+# seconds between retries for download tasks
+edpm_neutron_ovn_images_download_delay: 5
+
+# number of retries for download tasks
+edpm_neutron_ovn_images_download_retries: 5
+
+edpm_neutron_ovn_config_src: /var/lib/openstack/configs/neutron-ovn
+edpm_neutron_ovn_agent_config_dir: /var/lib/config-data/ansible-generated/neutron-ovn-agent
+edpm_neutron_ovn_agent_log_dir: "/var/log/neutron"
+
+edpm_neutron_ovn_agent_image: "quay.io/podified-antelope-centos9/openstack-neutron-ovn-agent:current-podified"
+
+edpm_neutron_ovn_common_volumes:
+  - /run/openvswitch:/run/openvswitch:z
+  - "{{ edpm_neutron_ovn_agent_config_dir }}:/etc/neutron.conf.d:z"
+  - /var/log/containers/neutron:/var/log/neutron:z
+  - /var/lib/kolla/config_files/ovn_agent.json:/var/lib/kolla/config_files/config.json:ro
+
+# Neutron conf
+# DEFAULT
+edpm_neutron_ovn_agent_DEFAULT_host: '{{ ansible_facts["nodename"] }}'  # also in missing vars
+
+# rootwrap.conf
+edpm_neutron_ovn_agent_rootwrap_DEFAULT_filters_path: '/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap'
+edpm_neutron_ovn_agent_rootwrap_DEFAULT_exec_dirs: '/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin'
+edpm_neutron_ovn_agent_rootwrap_DEFAULT_use_syslog: 'False'
+edpm_neutron_ovn_agent_rootwrap_DEFAULT_syslog_log_facility: 'syslog'
+edpm_neutron_ovn_agent_rootwrap_DEFAULT_syslog_log_level: 'ERROR'
+edpm_neutron_ovn_agent_rootwrap_DEFAULT_daemon_timeout: '600'
+edpm_neutron_ovn_agent_rootwrap_DEFAULT_rlimit_nofile: '1024'
+
+# neutron-ovn-agent.conf
+edpm_neutron_ovn_agent_DEFAULT_debug: 'True'
+edpm_neutron_ovn_agent_agent_root_helper: 'sudo neutron-rootwrap /etc/neutron.conf.d/01-rootwrap.conf'
+edpm_neutron_ovn_agent_ovs_ovsdb_connection: 'tcp:127.0.0.1:6640'
+edpm_neutron_ovn_agent_ovs_ovsdb_connection_timeout: '180'
+edpm_neutron_ovn_agent_ovn_ovsdb_connection_timeout: '180'
+edpm_neutron_ovn_agent_ovn_ovsdb_probe_interval: '60000'
+edpm_neutron_ovn_agent_ovn_ovn_nb_connection: ''
+edpm_neutron_ovn_agent_ovn_ovn_sb_connection: ''

--- a/roles/edpm_neutron_ovn/meta/argument_specs.yml
+++ b/roles/edpm_neutron_ovn/meta/argument_specs.yml
@@ -1,0 +1,100 @@
+---
+argument_specs:
+  # ./roles/edpm_neutron_ovn/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_neutron_ovn role.
+    options:
+      edpm_neutron_ovn_images_download_delay:
+        type: int
+        default: 5
+        description: The seconds between retries for failed download tasks
+      edpm_neutron_ovn_images_download_retries:
+        type: int
+        default: 5
+        description: The number of retries for failed download tasks
+      edpm_neutron_ovn_agent_image:
+        default: quay.io/podified-antelope-centos9/openstack-neutron-ovn-agent:current-podified
+        description: The container image to use to deploy Neutron OVN agent
+        type: str
+      edpm_neutron_ovn_agent_log_dir:
+        default: /var/log/neutron
+        description: Log directory to be used by Neutron OVN agent
+        type: str
+      edpm_neutron_ovn_agent_DEFAULT_debug:
+        default: 'True'
+        description: Enable debug mode
+        type: str
+      edpm_neutron_ovn_agent_agent_root_helper:
+        default: sudo neutron-rootwrap /etc/neutron.conf.d/01-rootwrap.conf
+        description: Neutron OVN agent root_helper command
+        type: str
+      edpm_neutron_ovn_agent_ovn_ovsdb_connection_timeout:
+        default: '180'
+        description: Timeout in seconds for the OVSDB connection transaction
+        type: str
+      edpm_neutron_ovn_agent_ovn_ovn_nb_connection:
+        default: ''
+        description: The connection string for the OVN_Northbound OVSDB
+        type: str
+      edpm_neutron_ovn_agent_ovn_ovn_sb_connection:
+        default: ''
+        description: The connection string for the OVN_Southbound OVSDB
+        type: str
+      edpm_neutron_ovn_agent_ovn_ovsdb_probe_interval:
+        default: '60000'
+        description: The probe interval for the OVSDB session in milliseconds
+        type: str
+      edpm_neutron_ovn_agent_ovs_ovsdb_connection:
+        default: tcp:127.0.0.1:6640
+        description: The connection string for the OVSDB backend
+        type: str
+      edpm_neutron_ovn_agent_ovs_ovsdb_connection_timeout:
+        default: '180'
+        description: Timeout in seconds for the OVSDB connection transaction
+        type: str
+      edpm_neutron_ovn_agent_rootwrap_DEFAULT_daemon_timeout:
+        default: '600'
+        description: Rootwrap daemon exits after this seconds of inactivity
+        type: str
+      edpm_neutron_ovn_agent_rootwrap_DEFAULT_exec_dirs:
+        default: /sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin
+        description: List of directories to search executables in
+        type: str
+      edpm_neutron_ovn_agent_rootwrap_DEFAULT_filters_path:
+        default: /etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap
+        description: List of directories to load filter definitions from
+        type: str
+      edpm_neutron_ovn_agent_rootwrap_DEFAULT_rlimit_nofile:
+        default: '1024'
+        description: Rootwrap daemon limits itself to that many file descriptors
+        type: str
+      edpm_neutron_ovn_agent_rootwrap_DEFAULT_syslog_log_facility:
+        default: syslog
+        description: Which syslog facility to use
+        type: str
+      edpm_neutron_ovn_agent_rootwrap_DEFAULT_syslog_log_level:
+        default: ERROR
+        description: Type of messages to log
+        type: str
+      edpm_neutron_ovn_agent_rootwrap_DEFAULT_use_syslog:
+        default: 'False'
+        description: Enable logging to syslog
+        type: str
+      edpm_neutron_ovn_common_volumes:
+        default:
+          - /run/openvswitch:/run/openvswitch:z
+          - '{{ edpm_neutron_ovn_agent_config_dir }}:/etc/neutron.conf.d:z'
+          - /var/log/containers/neutron:/var/log/neutron:z
+          - /var/lib/kolla/config_files/ovn_agent.json:/var/lib/kolla/config_files/config.json:ro
+        description: Volume mounts for Neutron OVN agent
+        type: list
+      edpm_neutron_ovn_agent_config_src:
+        default: "/var/lib/openstack/configs/neutron-ovn"
+        description: |
+          The path to the directory containing source of the Neutron OVN
+          agent configs.
+        type: str
+      edpm_neutron_ovn_agent_config_dir:
+        default: /var/lib/config-data/ansible-generated/neutron-ovn-agent
+        description: 'The directory that contains configuration files for Neutron OVN Agent.'
+        type: str

--- a/roles/edpm_neutron_ovn/meta/main.yml
+++ b/roles/edpm_neutron_ovn/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  namespace: openstack
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_neutron_ovn
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.9'
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_neutron_ovn/molecule/default/collections.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+- name: community.general

--- a/roles/edpm_neutron_ovn/molecule/default/converge.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/converge.yml
@@ -1,0 +1,28 @@
+---
+# Copyright 2021 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: true
+  become: true
+  tasks:
+    - ansible.builtin.include_role:
+        name: "osp.edpm.edpm_neutron_ovn"
+      vars:
+        tenant_ip: "{{ ansible_host }}"
+        edpm_ovn_dbs:
+          - "{{ ansible_host }}"
+        edpm_neutron_ovn_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"

--- a/roles/edpm_neutron_ovn/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - verify
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_neutron_ovn/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/prepare.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+- name: Prepare test_deps
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+      test_deps_setup_edpm: true
+      test_deps_setup_stream: true
+      test_deps_extra_packages:
+        - openvswitch
+        - iproute
+        - podman
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+    - ansible.builtin.include_role:
+        name: osp.edpm.env_data
+
+    # The openvswitch kernel module needs to be loaded on the host
+    - name: install and modprobe openvswitch
+      shell: |
+        sudo dnf -y install openvswitch
+        sudo modprobe openvswitch
+      delegate_to: localhost
+      run_once: true
+
+  post_tasks: []

--- a/roles/edpm_neutron_ovn/molecule/default/test-data/10-neutron-ovn.conf
+++ b/roles/edpm_neutron_ovn/molecule/default/test-data/10-neutron-ovn.conf
@@ -1,0 +1,3 @@
+[ovn]
+ovn_nb_connection = tcp:6.7.8.9:1233
+ovn_sb_connection = tcp:6.7.8.9:1234

--- a/roles/edpm_neutron_ovn/molecule/default/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/verify.yml
@@ -1,0 +1,17 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Ensure that 10-neutron-ovn.conf was copied into the container
+      block:
+        - name: ovn-agent config file exists
+          become: true
+          ansible.builtin.stat:
+            path: "/var/lib/config-data/ansible-generated/neutron-ovn-agent/10-neutron-ovn.conf"
+          register: ovn_agent_config
+
+        - name: assert that the config exists
+          ansible.builtin.assert:
+            that:
+              - ovn_agent_config.stat.exists
+            fail_msg: "ovn agent config file does not exist"

--- a/roles/edpm_neutron_ovn/tasks/bootstrap.yml
+++ b/roles/edpm_neutron_ovn/tasks/bootstrap.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure the Openvswitch package is installed
+  ansible.builtin.package:
+    name: openvswitch
+    state: present
+
+- name: Ensure the OVS service is running
+  ansible.builtin.systemd:
+    name: openvswitch
+    state: started

--- a/roles/edpm_neutron_ovn/tasks/configure.yml
+++ b/roles/edpm_neutron_ovn/tasks/configure.yml
@@ -1,0 +1,46 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Configure neutron configuration files
+  block:
+    - name: Render neutron config files
+      ansible.builtin.template:
+        src: "{{ item.src }}"
+        dest: "{{ edpm_neutron_ovn_agent_config_dir }}/{{ item.dest }}"
+        setype: "container_file_t"
+        mode: "0644"
+      loop:
+        - {"src": "rootwrap.conf.j2", "dest": "01-rootwrap.conf"}
+        - {"src": "neutron-ovn-agent.conf.j2", "dest": "01-neutron-ovn-agent.conf"}
+
+    - name: Discover secrets in {{ edpm_neutron_ovn_config_src }}
+      ansible.builtin.find:
+        paths: "{{ edpm_neutron_ovn_config_src }}"
+        file_type: file
+        recurse: true
+        patterns:
+          - "*ovn.conf"
+      register: edpm_neutron_ovn_secrets
+      delegate_to: localhost
+      become: false
+
+    - name: Flatten secrets into {{ edpm_neutron_ovn_agent_config_dir }}
+      ansible.builtin.copy:
+        src: "{{ item.path }}"
+        dest: "{{ edpm_neutron_ovn_agent_config_dir }}/{{ item.path | basename }}"
+        setype: "container_file_t"
+        mode: "0644"
+      loop: "{{ edpm_neutron_ovn_secrets.files }}"

--- a/roles/edpm_neutron_ovn/tasks/download_cache.yml
+++ b/roles/edpm_neutron_ovn/tasks/download_cache.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Download needed container images
+  containers.podman.podman_image:
+    name: "{{ item }}"
+  loop:
+    - "{{ edpm_neutron_ovn_agent_image }}"
+  become: true
+  register: edpm_neutron_ovn_images_download
+  until: edpm_neutron_ovn_images_download.failed == false
+  retries: "{{ edpm_neutron_ovn_images_download_retries }}"
+  delay: "{{ edpm_neutron_ovn_images_download_delay }}"

--- a/roles/edpm_neutron_ovn/tasks/install.yml
+++ b/roles/edpm_neutron_ovn/tasks/install.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create persistent directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    setype: "container_file_t"
+    mode: "{{ item.mode | default(omit) }}"
+  loop:
+    - {'path': "{{ edpm_neutron_ovn_agent_config_dir }}"}
+    - {'path': "/var/log/containers/neutron"}

--- a/roles/edpm_neutron_ovn/tasks/main.yml
+++ b/roles/edpm_neutron_ovn/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+- name: Include host prep tasks
+  ansible.builtin.import_tasks: install.yml
+
+- name: Include bootstrap tasks
+  ansible.builtin.import_tasks: bootstrap.yml
+
+- name: Configure neutron ovn agent
+  ansible.builtin.import_tasks: configure.yml
+
+- name: Ensure neutron-ovn-agent is running
+  ansible.builtin.import_tasks: run.yml

--- a/roles/edpm_neutron_ovn/tasks/run.yml
+++ b/roles/edpm_neutron_ovn/tasks/run.yml
@@ -1,0 +1,30 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure /usr/libexec/edpm-start-podman-container exists
+  ansible.builtin.import_role:
+    name: edpm_container_manage
+    tasks_from: shutdown.yml
+
+- name: Run ovn_agent container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: ovn_agent
+    edpm_container_standalone_container_defs:
+      ovn_agent: "{{ lookup('template', 'ovn_agent.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      ovn_agent: "{{ lookup('template', 'kolla_ovn_agent.yaml.j2') | from_yaml }}"

--- a/roles/edpm_neutron_ovn/templates/kolla_ovn_agent.yaml.j2
+++ b/roles/edpm_neutron_ovn/templates/kolla_ovn_agent.yaml.j2
@@ -1,0 +1,16 @@
+command: "neutron-ovn-agent --log-file={{ edpm_neutron_ovn_agent_log_dir }}/ovn-agent.log"
+permissions:
+  - owner: neutron:neutron
+    path: /var/log/neutron
+    recurse: true
+  - owner: neutron:neutron
+    path: /var/lib/neutron
+    recurse: true
+  - optional: true
+    owner: neutron:neutron
+    path: /etc/pki/tls/certs/ovn_agent.crt
+    perm: 0644
+  - optional: true
+    owner: neutron:neutron
+    path: /etc/pki/tls/private/ovn_agent.key
+    perm: 0644

--- a/roles/edpm_neutron_ovn/templates/neutron-ovn-agent.conf.j2
+++ b/roles/edpm_neutron_ovn/templates/neutron-ovn-agent.conf.j2
@@ -1,0 +1,15 @@
+[DEFAULT]
+debug = {{ edpm_neutron_ovn_agent_DEFAULT_debug }}
+
+[agent]
+root_helper = {{ edpm_neutron_ovn_agent_agent_root_helper }}
+
+[ovs]
+ovsdb_connection = {{ edpm_neutron_ovn_agent_ovs_ovsdb_connection }}
+ovsdb_connection_timeout = {{ edpm_neutron_ovn_agent_ovs_ovsdb_connection_timeout }}
+
+[ovn]
+ovsdb_connection_timeout = {{ edpm_neutron_ovn_agent_ovn_ovsdb_connection_timeout }}
+ovsdb_probe_interval = {{ edpm_neutron_ovn_agent_ovn_ovsdb_probe_interval }}
+ovn_nb_connection = {{ edpm_neutron_ovn_agent_ovn_ovn_nb_connection }}
+ovn_sb_connection = {{ edpm_neutron_ovn_agent_ovn_ovn_sb_connection }}

--- a/roles/edpm_neutron_ovn/templates/ovn_agent.yaml.j2
+++ b/roles/edpm_neutron_ovn/templates/ovn_agent.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 2
+image: "{{ edpm_neutron_ovn_agent_image }}"
+net: host
+privileged: true
+user: root
+restart: always
+depends_on:
+  - openvswitch.service
+volumes:
+  {% set edpm_neutron_ovn_volumes = [] %}
+  {%- set edpm_neutron_ovn_volumes =
+          edpm_neutron_ovn_volumes +
+          edpm_neutron_ovn_common_volumes %}
+  {{ edpm_neutron_ovn_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_neutron_ovn/templates/rootwrap.conf.j2
+++ b/roles/edpm_neutron_ovn/templates/rootwrap.conf.j2
@@ -1,0 +1,8 @@
+[DEFAULT]
+filters_path = {{ edpm_neutron_ovn_agent_rootwrap_DEFAULT_filters_path }}
+exec_dirs = {{ edpm_neutron_ovn_agent_rootwrap_DEFAULT_exec_dirs }}
+use_syslog = {{ edpm_neutron_ovn_agent_rootwrap_DEFAULT_use_syslog }}
+syslog_log_facility = {{ edpm_neutron_ovn_agent_rootwrap_DEFAULT_syslog_log_facility }}
+syslog_log_level = {{ edpm_neutron_ovn_agent_rootwrap_DEFAULT_syslog_log_level }}
+daemon_timeout = {{ edpm_neutron_ovn_agent_rootwrap_DEFAULT_daemon_timeout }}
+rlimit_nofile = {{ edpm_neutron_ovn_agent_rootwrap_DEFAULT_rlimit_nofile }}


### PR DESCRIPTION
This agent is used to provide QoS to hardware offloaded ports on the compute nodes.

Related-Issue: [OSP-26191](https://issues.redhat.com//browse/OSP-26191)