### PR TITLE
[edpm_libvirt]Mount knonw_hosts file

### DIFF
--- a/roles/edpm_libvirt/molecule/default/prepare.yml
+++ b/roles/edpm_libvirt/molecule/default/prepare.yml
@@ -105,3 +105,12 @@
                                     'allow rwx pool=\1') | join(', ') }}
       vars:
         pools: ['vms', 'volumes', 'images']
+
+    - name: Create ssh_known_hosts file
+      become: true
+      ansible.builtin.file:
+        path: '/etc/ssh/ssh_known_hosts'
+        state: touch
+        owner: root
+        group: root
+        mode: '0655'

--- a/roles/edpm_libvirt/molecule/default/verify.yml
+++ b/roles/edpm_libvirt/molecule/default/verify.yml
@@ -16,6 +16,7 @@
         - "/var/lib/openstack/config/containers"
         - "/var/log/containers"
         - "/var/log/containers/stdouts"
+        - "/etc/ssh/ssh_known_hosts"
         # extrenal deps
         - "/var/lib/openstack/config/ceph"
         # libvirt directories

--- a/roles/edpm_libvirt/templates/libvirt_virtqemud/libvirt_virtqemud.json.j2
+++ b/roles/edpm_libvirt/templates/libvirt_virtqemud/libvirt_virtqemud.json.j2
@@ -17,6 +17,7 @@
         "/var/lib/nova:/var/lib/nova:shared,z",
         "/run/libvirt:/run/libvirt:shared,z",
         "/dev:/dev",
-        "/var/lib/openstack/config/ceph:/var/lib/kolla/config_files/ceph:ro"
+        "/var/lib/openstack/config/ceph:/var/lib/kolla/config_files/ceph:ro",
+        "/etc/ssh/ssh_known_hosts:/etc/ssh/ssh_known_hosts:ro"
     ]
   }

--- a/roles/edpm_nova/molecule/default/prepare.yml
+++ b/roles/edpm_nova/molecule/default/prepare.yml
@@ -64,6 +64,14 @@
             rule:
               proto: tcp
               dport: 22
+    - name: Create ssh_known_hosts file
+      become: true
+      ansible.builtin.file:
+        path: '/etc/ssh/ssh_known_hosts'
+        state: touch
+        owner: root
+        group: root
+        mode: '0655'
     - name: install libvirt
       ansible.builtin.import_role:
         name: osp.edpm.edpm_libvirt
@@ -81,11 +89,3 @@
         owner: root
         group: root
         mode: 0755
-    - name: Create ssh_known_hosts file
-      become: true
-      ansible.builtin.file:
-        path: '/etc/ssh/ssh_known_hosts'
-        state: touch
-        owner: root
-        group: root
-        mode: '0655'


### PR DESCRIPTION
This is needed to support live migration as libvirt needs to initiate an ssh connection between compute nodes.