### PR TITLE
[edpm_libvirt]Add libvirt user to the EDPM host

### DIFF
--- a/roles/edpm_libvirt/molecule/default/verify.yml
+++ b/roles/edpm_libvirt/molecule/default/verify.yml
@@ -48,3 +48,17 @@
         - { "name": "edpm_libvirt.target", "enabled": "static"}
         - { "name": "edpm_libvirt_guests.service", "running":false }
         - { "name": "virt-guest-shutdown.target", "enabled": "static", "running":false }
+
+    - name: Check if user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: libvirt
+      register: libvirt_user
+
+    - name: Assert that libvirt user is created with kolla uid and gid
+      ansible.builtin.assert:
+        that:
+          # user
+          - "libvirt_user.ansible_facts.getent_passwd.libvirt[1] == '42473'"
+          # group
+          - "libvirt_user.ansible_facts.getent_passwd.libvirt[2] == '42473'"

--- a/roles/edpm_libvirt/tasks/main.yml
+++ b/roles/edpm_libvirt/tasks/main.yml
@@ -14,6 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Ensure libvirt user
+  ansible.builtin.include_tasks: user.yml
+
 - name: Configure libvirt
   ansible.builtin.include_tasks: configure.yml
 

--- a/roles/edpm_libvirt/tasks/user.yml
+++ b/roles/edpm_libvirt/tasks/user.yml
@@ -1,0 +1,11 @@
+---
+- name: Configure libvirt user and group on the host
+  ansible.builtin.import_role:
+    name: edpm_users
+  vars:
+    edpm_users_users:
+      # 42473 is matching with the uid and gid created by kolla in the libvirt containers
+      - {"name": "libvirt", "uid": "42473", "gid": "42473", "shell": "/sbin/nologin", "comment": "libvirt user"}
+    edpm_users_extra_dirs: []
+  tags:
+    - edpm_users


### PR DESCRIPTION
This is needed for two reasons:
1) to eventually add the nova user to the libvirt group on the host so
   that the incoming live migration connections can access the libvirt
   socket
2) to allow libvirt to be de-containerized in https://github.com/openstack-k8s-operators/edpm-ansible/pull/467 while keeping the ui and guid
   of the libvirt user unchanged
