### PR TITLE
[edpm_nova]Add nova user to libvirt group

### DIFF
--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -58,6 +58,18 @@
           # group
           - "nova_user.ansible_facts.getent_passwd.nova[2] == '42436'"
 
+    - name: Lookup libvirt group
+      ansible.builtin.getent:
+        database: group
+        key: libvirt
+      register: libvirt_group
+
+    - name: Assert that nova is in the libvirt group
+      ansible.builtin.assert:
+        that:
+          # 2: the users in the group
+          - "'nova' in libvirt_group.ansible_facts.getent_group.libvirt[2]"
+
     - name: Stat /home/nova/.ssh/authorized_keys
       become: true
       ansible.builtin.stat:

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -83,7 +83,7 @@
   vars:
     edpm_users_users:
       # 42436 is matching with the uid and gid created by kolla in the nova containers
-      - {"name": "nova", "uid": "42436", "gid": "42436", "shell": "/bin/sh", "comment": "nova user"}
+      - {"name": "nova", "uid": "42436", "gid": "42436", "shell": "/bin/sh", "comment": "nova user", "groups": "libvirt"}
     edpm_users_extra_dirs: []
   tags:
     - edpm_users


### PR DESCRIPTION
During live migration libvirt initiates an ssh connection from the
source compute to the dest compute with the nova user to pipe the guest
memory content to the destination node. So the nova user needs to have
access to the libvirt socket on the host.