### PR TITLE
Adding molecule tests for edpm_neutrond_dhcp role in the zuul CI

### DIFF
--- a/roles/edpm_neutron_dhcp/molecule/default/converge.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/converge.yml
@@ -16,6 +16,7 @@
 
 - name: Converge
   hosts: all
+  become: true
   roles:
     - role: "edpm_neutron_dhcp"
       vars:

--- a/roles/edpm_neutron_dhcp/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ dependency:
   options:
     role-file: collections.yml
 driver:
-  name: podman
+  name: delegated
 platforms:
 - command: /sbin/init
   dockerfile: ../../../../molecule/common/Containerfile.j2

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -51,3 +51,8 @@
     parent: edpm-ansible-molecule-base
     vars:
       TEST_RUN: edpm_ovn_bgp_agent
+- job:
+    name: edpm-ansible-molecule-edpm_neutron_dhcp
+    parent: edpm-ansible-molecule-base
+    vars:
+      TEST_RUN: edpm_neutron_dhcp

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -13,3 +13,4 @@
         - edpm-ansible-molecule-edpm_frr
         - edpm-ansible-molecule-edpm_iscsid
         - edpm-ansible-molecule-edpm_ovn_bgp_agent
+        - edpm-ansible-molecule-edpm_neutron_dhcp


### PR DESCRIPTION
Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/475 