### PR TITLE
Setting default value of the user

### DIFF
--- a/roles/edpm_neutron_dhcp/tasks/install.yml
+++ b/roles/edpm_neutron_dhcp/tasks/install.yml
@@ -19,8 +19,8 @@
     path: "{{ item.path }}"
     setype: "container_file_t"
     state: directory
-    owner: "{{ item.owner | default(ansible_user) }}"
-    group: "{{ item.group | default(ansible_user) }}"
+    owner: "{{ item.owner | default(lookup('env', 'USER')) }}"
+    group: "{{ item.group | default(lookup('env', 'USER')) }}"
     mode: "{{ item.mode | default(omit) }}"
   loop:
     - {'path': "/var/lib/openstack/config/containers", "mode": "0750"}


### PR DESCRIPTION
The `ansible_user` variable is not alway set to a sensible default, and may in fact be undefined. By running a lookup on the target host we can effectivelly avoid the problem.

Discovered during #472  