### PR TITLE
[edpm_nova]Configure my_ip to ctlplane_ip for nova-compute

### DIFF
--- a/roles/edpm_nova/molecule/default/molecule.yml
+++ b/roles/edpm_nova/molecule/default/molecule.yml
@@ -13,6 +13,13 @@ platforms:
       - compute
 provisioner:
   name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          compute-1:
+            ctlplane_ip: 10.0.0.3
+
 verifier:
   name: ansible
 scenario:

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -43,6 +43,12 @@
         - "Copying /var/lib/kolla/config_files/02-nova-log.conf to /etc/nova/nova.conf.d/02-nova-log.conf"
         - "Copying /var/lib/kolla/config_files/ssh-config to /var/lib/nova/.ssh/config"
         - "Copying /var/lib/kolla/config_files/ssh-privatekey to /var/lib/nova/.ssh/ssh-privatekey"
+        - "Copying /var/lib/kolla/config_files/02-nova-host-specific.conf to /etc/nova/nova.conf.d/02-nova-host-specific.conf"
+
+    - name: Assert that my_ip is rendered into the host specific config
+      ansible.builtin.assert:
+        that:
+          - "'10.0.0.3' in lookup('ansible.builtin.file', '/var/lib/openstack/config/nova/02-nova-host-specific.conf')"
 
     - name: Check if user exists
       ansible.builtin.getent:

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -51,6 +51,18 @@
     - {"src": "config.json.j2", "dest": "config.json"}
     - {"src": "nova-blank.conf", "dest": "nova-blank.conf"}
     - {"src": "ssh-config", "dest": "ssh-config"}
+    # NOTE(gibi): This is unfortunate as we would like to avoid config
+    # generation in ansible. This config is only needed to specify the IP
+    # address of the node nova-compute should use. Right now this is hardcoded
+    # to use the ctlplane_ip. In the future we might want to support
+    # configuring which network nova-compute uses when connecting between
+    # compute nodes. However that needs careful syncing between IPs in the
+    # known_hosts file and IPs in the TLS certificates.
+    # NOTE(gibi): There is an upstream nova blueprint that will allow us to
+    # remove this host specific configuration in the future (not earlier than
+    # openstack Caracal)
+    # https://blueprints.launchpad.net/nova/+spec/libvirt-migrate-with-hostname-instead-of-ip
+    - {"src": "02-nova-host-specific.conf.j2", "dest": "02-nova-host-specific.conf"}
   notify:
     - Restart nova
 

--- a/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
+++ b/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
@@ -1,0 +1,2 @@
+[DEFAULT]
+my_ip = {{ ctlplane_ip }}


### PR DESCRIPTION
This is needed as nova-compute, if my_ip is not configured, tries to figure out its own IP address in complicated way and in a system with multiple network interfaces there is no guarantee that it selects the IP of the designated control plane interface.

The my_ip configuration is EDPM node specific so it cannot be generated globally for a cell in nova-operator. So this is generated by ansible now.

There is an upstream nova blueprint to eventually get rid of the need of this configuration: https://blueprints.launchpad.net/nova/+spec/libvirt-migrate-with-hostname-instead-of-ip