### PR TITLE
Fix molecule `default` scenario for `edpm_network_config` role

### DIFF
--- a/roles/edpm_network_config/molecule/default/converge.yml
+++ b/roles/edpm_network_config/molecule/default/converge.yml
@@ -19,55 +19,18 @@
   hosts: all
   vars:
     edpm_network_config_template: |
-         ---
-         {% set control_virtual_ip = net_vip_map.ctlplane %}
-         {% set public_virtual_ip = vip_port_map.external.ip_address %}
-         {% if ':' in control_virtual_ip %}
-         {%   set control_virtual_cidr = 128 %}
-         {% else %}
-         {%   set control_virtual_cidr = 32 %}
-         {%   endif %}
-         {% if ':' in public_virtual_ip %}
-         {%   set public_virtual_cidr = 128 %}
-         {% else %}
-         {%   set public_virtual_cidr = 32 %}
-         {%   endif %}
-         network_config:
-         - type: ovs_bridge
-           name: br-ctlplane
-           use_dhcp: false
-           mtu: {{ ctlplane_mtu }}
-           ovs_extra:
-           - br-set-external-id br-ctlplane bridge-id br-ctlplane
-           addresses:
-           - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
-           - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
-           - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
-           routes: {{ ctlplane_host_routes }}
-           dns_servers: {{ ctlplane_dns_nameservers }}
-           domain: {{ dns_search_domains }}
-           members:
-             - type: interface
-               name: {{ neutron_public_interface_name }}
-               primary: true
-               mtu: {{ ctlplane_mtu }}
+      ---
+      network_config:
+        - type: interface
+          name: dummy0
+          use_dhcp: false
+          use_dhcpv6: false
+          addresses:
+            - ip_netmask: 192.168.180.2
+          routes:
+            - ip_netmask: 192.168.181.0/24
+              next_hop: 192.168.180.1
     edpm_network_config_manage_service: false
     edpm_network_config_hide_sensitive_logs: false
-    ctlplane_mtu: 1500
-    ctlplane_ip: 203.0.113.1
-    ctlplane_subnet_cidr: 24
-    ctlplane_host_routes: []
-    ctlplane_dns_nameservers: []
-    dns_search_domains: []
-    neutron_public_interface_name: dummy0
-    net_vip_map:
-      ctlplane: 203.0.113.3
-      ctlplane_subnet: 203.0.113.0/24
-      ctlplane_uri: 203.0.113.3
-    vip_port_map:
-      external:
-        ip_address: 203.0.113.1
-        ip_address_uri: 203.0.113.1
-        ip_subnet: 203.0.113.0/24
   roles:
     - role: "osp.edpm.edpm_network_config"


### PR DESCRIPTION
Since the molecule test will be executed in a container, we can't configure an ovs bridge on top of a dummy interface or a tap interface. 

The scope of this test isn't to provide a "working" EDPM scenario example, so we are going to provide a sample os-net-config configuration which works in a container on top of a dummy interface.

To add some context, at the moment the test will run successfully but it won't give the expected results. As you can see in the snippet below, os-net-config doesn't find an *active* interface to apply its configuration (nor the `tap0` interface or the created `dummy0` interface are available as ovs-bridge members), so the command run with rc 0, but it doesn't touch the network configuration, giving an unreliable result.

```
[root@instance /]# os-net-config --detailed-exit-codes --verbose
2023-10-27 10:26:00.373 INFO os_net_config.main Using config file at: /etc/os-net-config/config.yaml
2023-10-27 10:26:00.373 INFO os_net_config.impl_ifcfg.__init__ Ifcfg net config provider created.
2023-10-27 10:26:00.373 INFO os_net_config.main Not using any mapping file.
2023-10-27 10:26:00.478 INFO os_net_config.utils._ordered_nics Finding active nics
2023-10-27 10:26:00.478 INFO os_net_config.utils._ordered_nics tap0 is not an active nic
2023-10-27 10:26:00.478 INFO os_net_config.utils._ordered_nics dummy0 is not an active nic
2023-10-27 10:26:00.478 INFO os_net_config.utils._ordered_nics lo is not an active nic
2023-10-27 10:26:00.478 INFO os_net_config.utils._ordered_nics No DPDK mapping available in path (/var/lib/os-net-config/dpdk_mapping.yaml)
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics Active nics are []
2023-10-27 10:26:00.479 WARNING os_net_config.objects.mapped_nics No active nics found.
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics Finding active nics
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics tap0 is not an active nic
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics dummy0 is not an active nic
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics lo is not an active nic
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics No DPDK mapping available in path (/var/lib/os-net-config/dpdk_mapping.yaml)
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics Active nics are []
2023-10-27 10:26:00.479 WARNING os_net_config.objects.mapped_nics No active nics found.
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics Finding active nics
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics tap0 is not an active nic
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics dummy0 is not an active nic
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics lo is not an active nic
2023-10-27 10:26:00.479 INFO os_net_config.utils._ordered_nics No DPDK mapping available in path (/var/lib/os-net-config/dpdk_mapping.yaml)
2023-10-27 10:26:00.480 INFO os_net_config.utils._ordered_nics Active nics are []
2023-10-27 10:26:00.480 WARNING os_net_config.objects.mapped_nics No active nics found.
2023-10-27 10:26:00.480 INFO os_net_config.utils._ordered_nics Finding active nics
2023-10-27 10:26:00.480 INFO os_net_config.utils._ordered_nics tap0 is not an active nic
2023-10-27 10:26:00.480 INFO os_net_config.utils._ordered_nics dummy0 is not an active nic
2023-10-27 10:26:00.480 INFO os_net_config.utils._ordered_nics lo is not an active nic
2023-10-27 10:26:00.480 INFO os_net_config.utils._ordered_nics No DPDK mapping available in path (/var/lib/os-net-config/dpdk_mapping.yaml)
2023-10-27 10:26:00.480 INFO os_net_config.utils._ordered_nics Active nics are []
2023-10-27 10:26:00.480 WARNING os_net_config.objects.mapped_nics No active nics found.
2023-10-27 10:26:00.480 INFO os_net_config.impl_ifcfg.add_bridge adding bridge: br-ctlplane
2023-10-27 10:26:00.480 INFO os_net_config.impl_ifcfg.add_interface adding interface: dummy0
2023-10-27 10:26:00.480 INFO os_net_config.impl_ifcfg.apply applying network configs...
2023-10-27 10:26:00.480 INFO os_net_config.impl_ifcfg.apply No changes required for interface: dummy0
2023-10-27 10:26:00.480 INFO os_net_config.impl_ifcfg.apply No changes required for bridge: br-ctlplane
[root@instance /]# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: tap0: <BROADCAST,UP,LOWER_UP> mtu 65520 qdisc fq_codel state UNKNOWN group default qlen 1000
    link/ether 7a:19:68:fa:d1:2c brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.100/24 brd 10.0.2.255 scope global tap0
       valid_lft forever preferred_lft forever
    inet6 fd00::7819:68ff:fefa:d12c/64 scope global dynamic mngtmpaddr
       valid_lft 86046sec preferred_lft 14046sec
    inet6 fe80::7819:68ff:fefa:d12c/64 scope link
       valid_lft forever preferred_lft forever
3: dummy0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 96:01:7d:a1:e8:bb brd ff:ff:ff:ff:ff:ff
    inet6 fe80::9401:7dff:fea1:e8bb/64 scope link
       valid_lft forever preferred_lft forever
```