### PR TITLE
[neutron_metadata] Add missing mount

### DIFF
--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -32,7 +32,7 @@ edpm_neutron_dhcp_image: "quay.io/podified-antelope-centos9/openstack-neutron-dh
 edpm_neutron_dhcp_common_volumes:
   - /run/netns:/run/netns:shared
   - "{{ edpm_neutron_dhcp_agent_config_dir }}:/etc/neutron.conf.d:z"
-  - /var/lib/neutron:/var/lib/neutron:shared,z
+  - "{{ edpm_neutron_dhcp_agent_lib_dir }}:/var/lib/neutron:shared,z"
   - /var/lib/kolla/config_files/neutron_dhcp_agent.json:/var/lib/kolla/config_files/config.json:ro
   - /var/log/containers/neutron:/var/log/neutron:z
   - /run/openvswitch:/run/openvswitch:shared,z

--- a/roles/edpm_neutron_dhcp/meta/argument_specs.yml
+++ b/roles/edpm_neutron_dhcp/meta/argument_specs.yml
@@ -38,7 +38,7 @@ argument_specs:
         default:
           - /run/netns:/run/netns:shared
           - "{{ edpm_neutron_dhcp_agent_config_dir }}:/etc/neutron.conf.d:z"
-          - /var/lib/neutron:/var/lib/neutron:shared,z
+          - "{{ edpm_neutron_dhcp_agent_lib_dir }}:/var/lib/neutron:shared,z"
           - /var/lib/kolla/config_files/neutron_dhcp_agent.json:/var/lib/kolla/config_files/config.json:ro
           - /var/log/containers/neutron:/var/log/neutron:z
           - /run/openvswitch:/run/openvswitch:shared,z

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -20,6 +20,7 @@ edpm_neutron_metadata_common_volumes:
   - /run/netns:/run/netns:shared
   - /var/log/containers/neutron:/var/log/neutron:z
   - /var/lib/kolla/config_files/ovn_metadata_agent.json:/var/lib/kolla/config_files/config.json:ro
+  - "{{ edpm_neutron_metadata_agent_lib_dir }}:/var/lib/neutron:shared,z"
   - "{{ edpm_neutron_metadata_agent_lib_dir }}/ovn_metadata_haproxy_wrapper:/usr/local/bin/haproxy:ro"
   - "{{ edpm_neutron_metadata_agent_lib_dir }}/kill_scripts:/etc/neutron/kill_scripts:ro"
 

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -113,6 +113,7 @@ argument_specs:
           - /run/netns:/run/netns:shared
           - /var/log/containers/neutron:/var/log/neutron:z
           - /var/lib/kolla/config_files/ovn_metadata_agent.json:/var/lib/kolla/config_files/config.json:ro
+          - "{{ edpm_neutron_metadata_agent_lib_dir }}:/var/lib/neutron:shared,z"
           - "{{ edpm_neutron_metadata_agent_lib_dir }}/ovn_metadata_haproxy_wrapper:/usr/local/bin/haproxy:ro"
           - "{{ edpm_neutron_metadata_agent_lib_dir }}/kill_scripts:/etc/neutron/kill_scripts:ro"
         description: ''


### PR DESCRIPTION
With [1] merged, it requires shared mount
between ovn_metadata_agent and haproxy containers.

Also use variable instead of hardcoded /var/lib/neutron in neutron_dhcp_agent role.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/394