### PR TITLE
Added downgrade of crun in molecule scenario where podman is needed

### DIFF
--- a/roles/edpm_frr/molecule/default/prepare.yml
+++ b/roles/edpm_frr/molecule/default/prepare.yml
@@ -26,6 +26,17 @@
           - python3-pip
           - os-net-config
   tasks:
+    # needed due to regression in 1.11.1
+    # see https://github.com/containers/crun/issues/1338
+    # fixed with https://github.com/containers/crun/pull/1341
+    # we should wait to crun > 1.11.2
+    - name: Downgrade crun for 1.11.1 regression
+      become: true
+      ansible.builtin.dnf:
+        name: crun < 1.11
+        allow_downgrade: true
+        state: present
+
     - name: Install os-net-config
       ansible.builtin.package:
         name: os-net-config

--- a/roles/edpm_neutron_dhcp/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/prepare.yml
@@ -38,6 +38,17 @@
     - include_role:
         name: osp.edpm.env_data
 
+    # needed due to regression in 1.11.1
+    # see https://github.com/containers/crun/issues/1338
+    # fixed with https://github.com/containers/crun/pull/1341
+    # we should wait to crun > 1.11.2
+    - name: Downgrade crun for 1.11.1 regression
+      become: true
+      ansible.builtin.dnf:
+        name: crun < 1.11
+        allow_downgrade: true
+        state: present
+
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |

--- a/roles/edpm_neutron_metadata/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_metadata/molecule/default/prepare.yml
@@ -39,6 +39,17 @@
     - ansible.builtin.include_role:
         name: osp.edpm.env_data
 
+    # needed due to regression in 1.11.1
+    # see https://github.com/containers/crun/issues/1338
+    # fixed with https://github.com/containers/crun/pull/1341
+    # we should wait to crun > 1.11.2
+    - name: Downgrade crun for 1.11.1 regression
+      become: true
+      ansible.builtin.dnf:
+        name: crun < 1.11
+        allow_downgrade: true
+        state: present
+
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |

--- a/roles/edpm_neutron_ovn/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/prepare.yml
@@ -30,6 +30,17 @@
     - ansible.builtin.include_role:
         name: osp.edpm.env_data
 
+    # needed due to regression in 1.11.1
+    # see https://github.com/containers/crun/issues/1338
+    # fixed with https://github.com/containers/crun/pull/1341
+    # we should wait to crun > 1.11.2
+    - name: Downgrade crun for 1.11.1 regression
+      become: true
+      ansible.builtin.dnf:
+        name: crun < 1.11
+        allow_downgrade: true
+        state: present
+
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |

--- a/roles/edpm_neutron_sriov/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/prepare.yml
@@ -20,3 +20,14 @@
       test_deps_extra_packages:
         - iproute
         - podman
+  tasks:
+    # needed due to regression in 1.11.1
+    # see https://github.com/containers/crun/issues/1338
+    # fixed with https://github.com/containers/crun/pull/1341
+    # we should wait to crun > 1.11.2
+    - name: Downgrade crun for 1.11.1 regression
+      become: true
+      ansible.builtin.dnf:
+        name: crun < 1.11
+        allow_downgrade: true
+        state: present

--- a/roles/edpm_ovn/molecule/default/prepare.yml
+++ b/roles/edpm_ovn/molecule/default/prepare.yml
@@ -30,6 +30,17 @@
     - ansible.builtin.include_role:
         name: osp.edpm.env_data
 
+    # needed due to regression in 1.11.1
+    # see https://github.com/containers/crun/issues/1338
+    # fixed with https://github.com/containers/crun/pull/1341
+    # we should wait to crun > 1.11.2
+    - name: Downgrade crun for 1.11.1 regression
+      become: true
+      ansible.builtin.dnf:
+        name: crun < 1.11
+        allow_downgrade: true
+        state: present
+
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |

--- a/roles/edpm_ovn/molecule/noconfig/prepare.yml
+++ b/roles/edpm_ovn/molecule/noconfig/prepare.yml
@@ -30,6 +30,17 @@
     - include_role:
         name: osp.edpm.env_data
 
+    # needed due to regression in 1.11.1
+    # see https://github.com/containers/crun/issues/1338
+    # fixed with https://github.com/containers/crun/pull/1341
+    # we should wait to crun > 1.11.2
+    - name: Downgrade crun for 1.11.1 regression
+      become: true
+      ansible.builtin.dnf:
+        name: crun < 1.11
+        allow_downgrade: true
+        state: present
+
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |


### PR DESCRIPTION
There's a regression in crun 1.11.1 (see https://github.com/containers/crun/issues/1338) that prevents podman to being executed on podman containers in some molecule scenario.

We are downgrade crun to last known version (1.10.1) until the new package will arrive in Centos 9 Stream.