### PR TITLE
Mount TLS certs

### DIFF
--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -28,3 +28,10 @@ edpm_nova_image_download_retries: 5
 edpm_nova_config_src: /var/lib/openstack/configs
 edpm_nova_config_dest: /var/lib/openstack/config/nova
 edpm_nova_compute_image: "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"
+
+# certs
+edpm_nova_certs_src: /var/lib/openstack/certs
+edpm_nova_certs_dest: /var/lib/openstack/certs/nova
+edpm_nova_cacerts_src: /var/lib/openstack/cacerts
+edpm_nova_cacerts_dest: /var/lib/openstack/cacerts/nova
+edpm_nova_tls_certs_enabled: "{{ tls_certs_enabled | default(False) }}"

--- a/roles/edpm_nova/meta/argument_specs.yml
+++ b/roles/edpm_nova/meta/argument_specs.yml
@@ -25,6 +25,36 @@ argument_specs:
         description: |
           The path to the directory where the nova config files
           will be rendered on the compute node.
+      edpm_nova_certs_src:
+        type: str
+        default: /var/lib/openstack/certs
+        description: |
+          The path to the directory containing the nova cert and key files
+          in the ansibleEE container. This is the directory
+          where all TLS certs and keys for the nova service are mounted.
+      edpm_nova_certs_dest:
+        type: str
+        default: /var/lib/openstack/certs/nova
+        description: |
+          The path to the directory where the nova cert and key files
+          will be rendered on the compute node.
+      edpm_nova_cacerts_src:
+        type: str
+        default: /var/lib/openstack/cacerts
+        description: |
+          The path to the directory containing the cacert files
+          in the ansibleEE container. This is the directory
+          where all cacert PEM files for the nova service are mounted.
+      edpm_nova_cacerts_dest:
+        type: str
+        default: /var/lib/openstack/cacerts/nova
+        description: |
+          The path to the directory where the cacert PEM files
+          for the nova service will be rendered on the compute node.
+      edpm_nova_tls_certs_enabled:
+        type: bool
+        default: false
+        description: Boolean to specify whether TLS certs are enabled.
       edpm_nova_compute_image:
         type: str
         default: "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -15,6 +15,8 @@
   loop:
     - {"path": "{{ edpm_nova_config_dest }}", "mode": "0755"}
     - {"path": "/var/lib/openstack/config/containers", "mode": "0755"}
+    - {"path": "{{ edpm_nova_certs_dest }}", "mode": "0755"}
+    - {"path": "{{ edpm_nova_cacerts_dest }}", "mode": "0755"}
 - name: Create persistent directories
   tags:
     - configure
@@ -118,3 +120,20 @@
     mode: '0600'
     owner: nova
     group: nova
+
+- name: Copy TLS files to the compute node
+  tags:
+    - configure
+    - nova
+  become: true
+  loop:
+    - {"src": "{{ edpm_nova_certs_src }}/{{ inventory_hostname }}-tls.crt", "dest": "{{ edpm_nova_certs_dest }}/tls.crt"}
+    - {"src": "{{ edpm_nova_certs_src }}/{{ inventory_hostname }}-tls.key", "dest": "{{ edpm_nova_certs_dest }}/tls.key"}
+    - {"src": "{{ edpm_nova_cacerts_src }}/TLSCABundleFile", "dest": "{{ edpm_nova_cacerts_dest }}/TLSCABundleFile"}
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: '0600'
+    owner: nova
+    group: nova
+  when: edpm_nova_tls_certs_enabled

--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -10,6 +10,11 @@
     },
     "volumes": [
         "/var/lib/openstack/config/nova:/var/lib/kolla/config_files:ro",
+{% if edpm_nova_tls_certs_enabled %}
+	"/var/lib/openstack/certs/nova/tls.crt:/etc/pki/nova/server-cert.pem:ro",
+	"/var/lib/openstack/certs/nova/tls.key:/etc/pki/nova/private/server-key.pem:ro",
+	"/var/lib/openstack/cacerts/nova/TLSCABundleFile:/etc/pki/CA/cacert.pem:ro",
+{% endif %}
         "/etc/localtime:/etc/localtime:ro",
         "/lib/modules:/lib/modules:ro",
         "/dev:/dev",


### PR DESCRIPTION
The dataplane operator will provide certs and keys to the ansibleEE pod in /var/lib/openstack/certs as well as a cacert file in /var/lib/openstack/cacerts.  It will also pass an ansible variable tls_certs_enabled to indicate that the certs are present.

This PR copies these files to the appropriate place on the compute node and then mounts these files in the nova-compute container.

We still need to confirm that these files are in the right location in the container and add config to use these certs - as well as code to trust the cacert.  Will need help from compute DFG for that.