### PR TITLE
ovn: remove ovn-openflow-probe-interval knob

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -41,7 +41,6 @@ edpm_enable_hw_offload: false
 edpm_ovn_multi_rhel: false
 edpm_enable_internal_tls: false
 edpm_ovn_sb_server_port: 6642
-edpm_ovn_of_probe_interval: 60
 edpm_ovn_remote_probe_interval: 60000
 edpm_ovn_ofctrl_wait_before_clear: 8000
 edpm_ovn_controller_agent_image: "quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified"
@@ -75,7 +74,6 @@ edpm_ovn_ovs_external_ids:
   ovn-encap-type: "{{ edpm_ovn_encap_type }}"
   ovn-match-northd-version: true
   ovn-monitor-all: true
-  ovn-openflow-probe-interval: "{{ edpm_ovn_of_probe_interval }}"
   ovn-remote: >-
     "{%- set db_addresses = [] -%}{%- for host in edpm_ovn_dbs -%}
     {{ db_addresses.append([edpm_ovn_protocol, host, edpm_ovn_sb_server_port] | join(':')) }}{%- endfor -%}

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -96,10 +96,6 @@ argument_specs:
         default: false
         description: ''
         type: bool
-      edpm_ovn_of_probe_interval:
-        default: 60
-        description: ''
-        type: int
       edpm_ovn_ofctrl_wait_before_clear:
         default: 8000
         description: ''
@@ -118,7 +114,6 @@ argument_specs:
           ovn-match-northd-version: true
           ovn-monitor-all: true
           ovn-ofctrl-wait-before-clear: '{{ edpm_ovn_ofctrl_wait_before_clear }}'
-          ovn-openflow-probe-interval: '{{ edpm_ovn_of_probe_interval }}'
           ovn-remote: '{% set db_addresses = [] %}{% for host in edpm_ovn_dbs %}{{ db_addresses.append([edpm_ovn_protocol,
             host, edpm_ovn_sb_server_port] | join('':'')) }}{% endfor %}{{ db_addresses
             | join('','') }}'


### PR DESCRIPTION
The knob is useless for unix socket connection to vswitchd.

It is now removed in OVN [1], which makes it even more useless.

[1] https://github.com/ovn-org/ovn/commit/c16e5da803838fa66129eb61d7930fc84d237f85