### PR TITLE
Add `EDPM_SYSTEMROLES` env var in ansibleee runner image

### DIFF
--- a/openstack_ansibleee/Dockerfile
+++ b/openstack_ansibleee/Dockerfile
@@ -18,5 +18,6 @@ COPY $REMOTE_SOURCE/openstack_ansibleee/edpm_entrypoint.sh /bin/edpm_entrypoint
 RUN sed -i '1d' /bin/entrypoint
 RUN cat /bin/entrypoint >> /bin/edpm_entrypoint
 RUN chmod +x /bin/edpm_entrypoint
+ENV EDPM_SYSTEMROLES='fedora.linux_system_roles'
 WORKDIR /runner
 ENTRYPOINT ["edpm_entrypoint"]

--- a/playbooks/install_os.yml
+++ b/playbooks/install_os.yml
@@ -17,17 +17,9 @@
         tasks_from: install.yml
       tags:
         - edpm_sshd
-    - name: Set FQCN for the timesync role
-      ansible.builtin.set_fact:
-        timesyncfqcn:
-          "{%- if ansible_facts['distribution'] == 'RedHat' -%}
-            redhat.rhel{%- else -%}
-            fedora.linux{%- endif -%}
-          _system_roles.timesync"
-      delegate_to: localhost
     - name: Install and configure time service using timesync system role
       ansible.builtin.include_role:
-        name: "{{timesyncfqcn}}"
+        name: "{{ lookup('ansible.builtin.env', 'EDPM_SYSTEMROLES', default='fedora.linux_system_roles') + '.timesync' }}"
       tags:
         - dataplane_chrony
     - name: Install edpm_logrotate_crond

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -17,14 +17,6 @@
 - name: Configure network with network role from system roles [nmstate]
   when: edpm_network_config_tool == 'nmstate'
   block:
-    - name: Retrieve role name [nmstate]
-      ansible.builtin.set_fact:
-        systemrolename:
-          "{%- if ansible_facts['distribution'] == 'RedHat' -%}
-            redhat.rhel{%- else -%}
-            fedora.linux{%- endif -%}
-          _system_roles.network"
-      delegate_to: localhost
     - name: Install OVS NetworkManager plugin [nmstate]
       ansible.builtin.dnf:
         name: "{{ edpm_network_config_systemrole_nmstate_dependencies }}"
@@ -43,7 +35,7 @@
         network_state: "{{ edpm_network_config_template | from_yaml }}"
     - name: Load system-roles.network tasks [nmstate]
       ansible.builtin.include_role:
-        name: "{{ systemrolename }}"
+        name: "{{ lookup('ansible.builtin.env', 'EDPM_SYSTEMROLES',  default='fedora.linux_system_roles') + '.network' }}"
 
 - name: Load edpm_network_config tasks [os-net-config]
   ansible.builtin.include_tasks:


### PR DESCRIPTION
In order to avoid the dynamic building of the system roles collection name based on the runner where is running (Fedora or RHEL), which is complicated and potentially slow, we define an environment variable during the container building so we can gather it with a lookup during the execution of playbooks.