### PR TITLE
[edpm_nova]Pre-generate compute_id

### DIFF
--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -91,3 +91,16 @@
       ansible.builtin.assert:
         that:
           - "nova_authorized_keys.stat.mode == '0600'"
+
+    - name: Stat /var/lib/nova/compute_id
+      become: true
+      ansible.builtin.stat:
+        path: /var/lib/nova/compute_id
+      register: compute_id
+
+    - name: Assert that compute_id exists, not empty, and read-only
+      ansible.builtin.assert:
+        that:
+          - "compute_id.stat.size == 37"
+          - "compute_id.stat.mode == '0400'"
+          - "compute_id.stat.attr_flags == 'i'"

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -118,3 +118,58 @@
     mode: '0600'
     owner: nova
     group: nova
+
+- name: Copy TLS files to the compute node
+  tags:
+    - configure
+    - nova
+  become: true
+  loop:
+    - {"src": "{{ edpm_nova_certs_src }}/{{ inventory_hostname }}-tls.crt", "dest": "{{ edpm_nova_certs_dest }}/tls.crt"}
+    - {"src": "{{ edpm_nova_certs_src }}/{{ inventory_hostname }}-tls.key", "dest": "{{ edpm_nova_certs_dest }}/tls.key"}
+    - {"src": "{{ edpm_nova_cacerts_src }}/TLSCABundleFile", "dest": "{{ edpm_nova_cacerts_dest }}/TLSCABundleFile"}
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: '0600'
+    owner: nova
+    group: nova
+  when: edpm_nova_tls_certs_enabled
+
+- name: Check if compute_id exists in state_path
+  tags:
+    - configure
+    - nova
+  become: true
+  ansible.builtin.stat:
+    path: /var/lib/nova/compute_id
+  register: compute_id
+
+- name: Pre-generate compute_id if not already exists
+  tags:
+    - configure
+    - nova
+  become: true
+  ansible.builtin.copy:
+    dest: "/var/lib/nova/compute_id"
+    owner: nova
+    group: nova
+    mode: "0400"
+    attributes: "+i"
+    content: |
+      {{ lookup('ansible.builtin.pipe', 'uuidgen') }}
+  when: not compute_id.stat.exists
+
+- name: Make compute_id ready-only
+  tags:
+    - configure
+    - nova
+  become: true
+  ansible.builtin.file:
+    path: "/var/lib/nova/compute_id"
+    state: file
+    owner: nova
+    group: nova
+    mode: "0400"
+    attributes: "+i"
+  when: compute_id.stat.exists


### PR DESCRIPTION
Use the nova stable compute uuid feature.
* In greenfield pre-generate compute_id before the first start of the nova-compute service
* During adoption of old deployment preserve the compute_id if exists but make it ready only

Depends-on: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/223
Implements: https://issues.redhat.com/browse/OSPRH-117