### PR TITLE
[ovn] Chassis as external port host edpm config

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -37,6 +37,7 @@ edpm_ovn_chassis_mac_mapping_seed: "{{ ansible_machine_id }}"
 edpm_ovn_encap_type: geneve
 edpm_ovn_dbs: []
 edpm_enable_chassis_gw: false
+edpm_enable_chassis_extport: false
 edpm_enable_hw_offload: false
 edpm_ovn_multi_rhel: false
 edpm_enable_internal_tls: false

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -16,6 +16,11 @@ argument_specs:
         default: false
         description: ''
         type: bool
+      edpm_enable_chassis_extport:
+        default: false
+        description: >
+          Mark Chassis as eligible for scheduling OVN's external ports
+        type: bool
       edpm_enable_hw_offload:
         default: false
         description: ''

--- a/roles/edpm_ovn/molecule/default/molecule.yml
+++ b/roles/edpm_ovn/molecule/default/molecule.yml
@@ -26,6 +26,7 @@ scenario:
   - prepare
   - converge
   - verify
+  - cleanup
   - destroy
 verifier:
   name: ansible

--- a/roles/edpm_ovn/molecule/default/verify.yml
+++ b/roles/edpm_ovn/molecule/default/verify.yml
@@ -11,3 +11,9 @@
         /usr/bin/ovs-vsctl get open_vswitch . other_config:hw-offload
       register: output
       failed_when: output.rc == 0
+
+    - name: Verify ovn-cms-options was not set by default
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open . external_ids
+      register: output
+      failed_when: "'ovn-cms-options' in output.stdout"

--- a/roles/edpm_ovn/molecule/enable_chassis_extport/cleanup.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_extport/cleanup.yml
@@ -1,0 +1,1 @@
+../default/cleanup.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_extport/collections.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_extport/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_extport/converge.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_extport/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2022 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,19 +14,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Cleanup
+- name: Converge
   hosts: all
-  gather_facts: false
-  any_errors_fatal: true
+  gather_facts: true
   become: true
   tasks:
-    - name: Cleanup edpm_ovn
-      ansible.builtin.import_role:
+    - include_role:
         name: "osp.edpm.edpm_ovn"
-        tasks_from: cleanup.yml
-
-    - name: Verify ovn-cms-options was cleared up
-      ansible.builtin.shell: >
-        /usr/bin/ovs-vsctl get open . external_ids
-      register: output
-      failed_when: "'ovn-cms-options' in output.stdout"
+      vars:
+        tenant_ip: "{{ ansible_host }}"
+        edpm_ovn_dbs:
+          - "{{ ansible_host }}"
+        edpm_ovn_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"
+        edpm_enable_chassis_extport: true

--- a/roles/edpm_ovn/molecule/enable_chassis_extport/molecule.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_extport/molecule.yml
@@ -1,0 +1,1 @@
+../default/molecule.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_extport/prepare.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_extport/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_extport/test-data
+++ b/roles/edpm_ovn/molecule/enable_chassis_extport/test-data
@@ -1,0 +1,1 @@
+../default/test-data

--- a/roles/edpm_ovn/molecule/enable_chassis_extport/verify.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_extport/verify.yml
@@ -1,0 +1,13 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Include default tasks
+      ansible.builtin.include_tasks:
+        file: ../default/verify-tasks.yml
+
+    - name: Verify enable-chassis-as-extport-host
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open_vswitch . external_ids:ovn-cms-options
+      register: output
+      failed_when: output.stdout != "enable-chassis-as-extport-host"

--- a/roles/edpm_ovn/molecule/enable_chassis_gw/cleanup.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw/cleanup.yml
@@ -1,0 +1,1 @@
+../default/cleanup.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_gw/collections.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_gw/converge.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2022 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,19 +14,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Cleanup
+- name: Converge
   hosts: all
-  gather_facts: false
-  any_errors_fatal: true
+  gather_facts: true
   become: true
   tasks:
-    - name: Cleanup edpm_ovn
-      ansible.builtin.import_role:
+    - include_role:
         name: "osp.edpm.edpm_ovn"
-        tasks_from: cleanup.yml
-
-    - name: Verify ovn-cms-options was cleared up
-      ansible.builtin.shell: >
-        /usr/bin/ovs-vsctl get open . external_ids
-      register: output
-      failed_when: "'ovn-cms-options' in output.stdout"
+      vars:
+        tenant_ip: "{{ ansible_host }}"
+        edpm_ovn_dbs:
+          - "{{ ansible_host }}"
+        edpm_ovn_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"
+        edpm_enable_chassis_gw: true

--- a/roles/edpm_ovn/molecule/enable_chassis_gw/molecule.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw/molecule.yml
@@ -1,0 +1,1 @@
+../default/molecule.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_gw/prepare.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_gw/test-data
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw/test-data
@@ -1,0 +1,1 @@
+../default/test-data

--- a/roles/edpm_ovn/molecule/enable_chassis_gw/verify.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw/verify.yml
@@ -1,0 +1,13 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Include default tasks
+      ansible.builtin.include_tasks:
+        file: ../default/verify-tasks.yml
+
+    - name: Verify enable-chassis-as-gw
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open_vswitch . external_ids:ovn-cms-options
+      register: output
+      failed_when: output.stdout != "enable-chassis-as-gw"

--- a/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/cleanup.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/cleanup.yml
@@ -1,0 +1,1 @@
+../default/cleanup.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/collections.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/converge.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2022 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,19 +14,17 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Cleanup
+- name: Converge
   hosts: all
-  gather_facts: false
-  any_errors_fatal: true
+  gather_facts: true
   become: true
   tasks:
-    - name: Cleanup edpm_ovn
-      ansible.builtin.import_role:
+    - include_role:
         name: "osp.edpm.edpm_ovn"
-        tasks_from: cleanup.yml
-
-    - name: Verify ovn-cms-options was cleared up
-      ansible.builtin.shell: >
-        /usr/bin/ovs-vsctl get open . external_ids
-      register: output
-      failed_when: "'ovn-cms-options' in output.stdout"
+      vars:
+        tenant_ip: "{{ ansible_host }}"
+        edpm_ovn_dbs:
+          - "{{ ansible_host }}"
+        edpm_ovn_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"
+        edpm_enable_chassis_gw: true
+        edpm_enable_chassis_extport: true

--- a/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/molecule.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/molecule.yml
@@ -1,0 +1,1 @@
+../default/molecule.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/prepare.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/test-data
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/test-data
@@ -1,0 +1,1 @@
+../default/test-data

--- a/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/verify.yml
+++ b/roles/edpm_ovn/molecule/enable_chassis_gw_and_extport/verify.yml
@@ -1,0 +1,13 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Include default tasks
+      ansible.builtin.include_tasks:
+        file: ../default/verify-tasks.yml
+
+    - name: Verify enable-chassis-as-gw and enable-chassis-as-extport-host
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open_vswitch . external_ids:ovn-cms-options
+      register: output
+      failed_when: output.stdout != "\"enable-chassis-as-gw,enable-chassis-as-extport-host\""

--- a/roles/edpm_ovn/tasks/cleanup.yml
+++ b/roles/edpm_ovn/tasks/cleanup.yml
@@ -22,10 +22,43 @@
   failed_when: cleanup_hw_offload.rc != 0
   when: not edpm_enable_hw_offload | bool
 
-- name: Cleanup enable-chassis-as-gw when chassis GW not enabled
+- name: Get OVN CMS Options from the local OVSDB
   ansible.builtin.shell: >
-    ovs-vsctl remove open . external_ids ovn-cms-options
-  register: cleanup_enable_chassis_as_gw
-  changed_when: cleanup_enable_chassis_as_gw.rc == 0
-  failed_when: cleanup_enable_chassis_as_gw.rc != 0
-  when: not edpm_enable_chassis_gw | bool
+    ovs-vsctl get Open_vSwitch . external_ids:ovn-cms-options | sed 's/\"//g'
+  register: cleanup_ovn_cms_options
+  changed_when: false
+  ignore_errors: true
+
+- name: Cleanup enable-chassis-as-gw when chassis GW not enabled
+  ansible.builtin.set_fact:
+    cleanup_ovn_cms_options: "{{ cleanup_ovn_cms_options | regex_replace('enable-chassis-as-gw' ~ ',?', '') }}"
+  when:
+    - not edpm_enable_chassis_gw | bool
+    - cleanup_ovn_cms_options.rc == 0
+
+- name: Cleanup enable-chassis-as-extport-host when chassis extport not enabled
+  ansible.builtin.set_fact:
+    cleanup_ovn_cms_options: "{{ cleanup_ovn_cms_options | regex_replace('enable-chassis-as-extport-host' ~ ',?', '') }}"
+  when:
+    - not edpm_enable_chassis_extport | bool
+    - cleanup_ovn_cms_options.rc == 0
+
+- name: Set updated OVN CMS Options to the local OVSDB
+  ansible.builtin.shell: >
+    ovs-vsctl set Open_vSwitch . external_ids:ovn-cms-options={{ cleanup_ovn_cms_options.stdout }}
+  register: cleanup_ovn_cms_options_set
+  changed_when: cleanup_ovn_cms_options_set.rc == 0
+  failed_when: cleanup_ovn_cms_options_set.rc != 0
+  when:
+    - cleanup_ovn_cms_options.rc == 0
+    - cleanup_ovn_cms_options.stdout != ""
+
+- name: Clear OVN CMS Options if updated string is empty
+  ansible.builtin.shell: >
+    ovs-vsctl remove Open_vSwitch . external_ids ovn-cms-options
+  register: cleanup_ovn_cms_options_remove
+  changed_when: cleanup_ovn_cms_options_remove.rc == 0
+  failed_when: cleanup_ovn_cms_options_remove.rc != 0
+  when:
+    - cleanup_ovn_cms_options.rc == 0
+    - cleanup_ovn_cms_options.stdout == ""

--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -36,17 +36,31 @@
       ansible.builtin.set_fact:
         edpm_ovn_ovs_external_ids: "{{ edpm_ovn_ovs_external_ids | combine(edpm_ovn_configmap_facts | default({})) }}"
 
-- name: Configure GW ports on chassis setting when enabled
-  when: edpm_enable_chassis_gw | default(false)
+- name: Configure OVN CMS Options
   block:
-    - name: Set enable-chassis-as-gw
+    - name: Configure GW ports on chassis setting when enabled
       ansible.builtin.set_fact:
-        cms_options:
-          ovn-cms-options: "enable-chassis-as-gw"
+        chassis_options:
+          - "enable-chassis-as-gw"
+      when: edpm_enable_chassis_gw | default(false)
 
-    - name: Append CMS options to external_ids
+    - name: Configure external port hosting on chassis setting when enabled
       ansible.builtin.set_fact:
-        edpm_ovn_ovs_external_ids: "{{ edpm_ovn_ovs_external_ids | combine(cms_options) }}"
+        chassis_options: "{{ chassis_options | default([]) + ['enable-chassis-as-extport-host'] }}"
+      when: edpm_enable_chassis_extport | default(false)
+
+    - name: Build OVN CMS Options
+      ansible.builtin.set_fact:
+        ovn_cms_options:
+          ovn-cms-options: "{{ chassis_options | join(',') }}"
+      when:
+        - chassis_options is defined
+
+    - name: Append OVN CMS Options to external_ids
+      ansible.builtin.set_fact:
+        edpm_ovn_ovs_external_ids: "{{ edpm_ovn_ovs_external_ids | combine(ovn_cms_options | default({})) }}"
+      when:
+        - ovn_cms_options is defined
 
 - name: Configure hw-offload when required
   when: edpm_enable_hw_offload | default(false)


### PR DESCRIPTION
This patch allows for configuring a Chassis as a host for external ports. This feature was introduced in ML2/OVN by https://review.opendev.org/c/openstack/neutron/+/894767.

This patch creates a new configuration for edpm_ovn called "edpm_enable_chassis_extport" which when enabled sets the "enable-chassis-as-extport-host" to the OVN CMS Options.