### PR TITLE
Execute `edpm_bootstrap_command` during `download_cache`

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -77,3 +77,7 @@ edpm_bootstrap_swap_partition_label: swap1
 # Shell command that is executed before any packages are installed by the role.
 # Can be used to register systems using any arbitrary registration command(s).
 edpm_bootstrap_command: ""
+
+# The path of the file that will be used as a marker when the edpm_bootstrap_command
+# has been executed on the node.
+edpm_bootstrap_command_done_file: /.bootstrap_command_done

--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -94,3 +94,10 @@ argument_specs:
         description: |
           Shell command that is executed before any packages are installed by the role.
           Can be used to register systems using any arbitrary registration command(s).
+
+      edpm_bootstrap_command_done_file:
+        type: path
+        default: /.bootstrap_command_done
+        description: |
+          The path of the file that will be used as a marker when the edpm_bootstrap_command
+          has been executed on the node.

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -57,22 +57,8 @@
     - cloud_init_vendor_disabled is changed
   become: true
 
-- name: Bootstrap command
-  when: edpm_bootstrap_command != ""
-  become: true
-  block:
-    - name: Bootstrap command
-      ansible.builtin.shell: "{{ edpm_bootstrap_command }}"
-      register: bootstrap_cmd
-      changed_when: bootstrap_cmd.rc == 0
-      failed_when: false
-
-    - name: Bootstrap command output
-      ansible.builtin.debug:
-        msg:
-          stdout: "{{ bootstrap_cmd.stdout_lines }}"
-          stderr: "{{ bootstrap_cmd.stderr_lines }}"
-      failed_when: bootstrap_cmd.rc != 0
+- name: Execute bootstrap command
+  ansible.builtin.import_tasks: bootstrap_command.yml
 
 - name: Import packages tasks
   ansible.builtin.import_tasks: packages.yml

--- a/roles/edpm_bootstrap/tasks/bootstrap_command.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap_command.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Check if bootstrap command has been executed
+  ansible.builtin.stat:
+    path: "{{ edpm_bootstrap_command_done_file }}"
+  register: edpm_bootstrap_command_executed
+
+- name: Bootstrap command
+  when:
+    - edpm_bootstrap_command != ""
+    - not edpm_bootstrap_command_executed.stat.exists
+  become: true
+  block:
+
+    - name: Bootstrap command
+      ansible.builtin.shell: "{{ edpm_bootstrap_command }}"
+      register: bootstrap_cmd
+      changed_when: bootstrap_cmd.rc == 0
+      failed_when: false
+
+    - name: Bootstrap command output
+      ansible.builtin.debug:
+        msg:
+          stdout: "{{ bootstrap_cmd.stdout_lines }}"
+          stderr: "{{ bootstrap_cmd.stderr_lines }}"
+      failed_when: bootstrap_cmd.rc != 0
+
+    - name: Mark bootstrap command as executed on node
+      ansible.builtin.file:
+        path: "{{ edpm_bootstrap_command_done_file }}"
+        state: touch
+        mode: '0600'
+
+  rescue:
+
+    - name: "Delete {{ edpm_bootstrap_command_done_file }}"
+      ansible.builtin.file:
+        path: "{{ edpm_bootstrap_command_done_file }}"
+        state: absent

--- a/roles/edpm_download_cache/tasks/install.yml
+++ b/roles/edpm_download_cache/tasks/install.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Execute bootstrap command
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_bootstrap
+    tasks_from: bootstrap_command.yml
+  tags:
+    - edpm_bootstrap
+    - download_cache
+
 - name: Grow volumes
   ansible.builtin.import_role:
     name: osp.edpm.edpm_growvols


### PR DESCRIPTION
Since the registration of the EL nodes is performed during the `edpm_bootstrap_command` task in the `edpm_bootstrap` role, we moved that task into a new task file called `bootstrap_command.yml` so it can be called by the `edpm_download_cache` role without invoking the entire role. We also added a marker that will avoid to execute the task twice if it's been already executed.