### PR TITLE
Add role to run node reboot

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -37,6 +37,7 @@ jobs:
         - edpm_nftables
         - edpm_nodes_validation
         - edpm_ovn
+        - edpm_reboot
         - edpm_sshd
         - edpm_ssh_known_hosts
         - edpm_timezone

--- a/playbooks/reboot.yml
+++ b/playbooks/reboot.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Reboot nodes if reboot is required
+  hosts: all
+  strategy: linear
+  become: true
+  tasks:
+    - name: Run edpm_reboot
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_reboot
+      tags:
+        - edpm_reboot

--- a/roles/edpm_kernel/meta/argument_specs.yml
+++ b/roles/edpm_kernel/meta/argument_specs.yml
@@ -32,14 +32,6 @@ argument_specs:
         type: str
         default: ""
         description: Grub kernel args.
-      edpm_kernel_reboot_timeout:
-        type: int
-        default: 3600
-        description: Reboot timeout in seconds
-      edpm_kernel_post_reboot_delay:
-        type: int
-        default: 60
-        description: Reboot delay in seconds
       edpm_kernel_defer_reboot:
         type: bool
         default: false

--- a/roles/edpm_kernel/tasks/reboot.yaml
+++ b/roles/edpm_kernel/tasks/reboot.yaml
@@ -65,13 +65,18 @@
       loop:
         - "{{ ifcfg_files.files }}"
 
-- name: Reboot debug message
+- name: Display reboot debug message
   ansible.builtin.debug:
-    msg: "Going to reboot the node after applying kernel args..."
+    msg: "Creating edpm_kernel file under reboot_required for applying kernel args settings"
 
-# Reboot the node
-- name: Reboot after kernel args update
-  become: true
-  ansible.builtin.reboot:
-    post_reboot_delay: "{{ edpm_kernel_post_reboot_delay }}"
-    reboot_timeout: "{{ edpm_kernel_reboot_timeout }}"
+- name: Create a reboot_required directory if it does not exist
+  ansible.builtin.file:
+    path: /var/lib/openstack/reboot_required
+    state: directory
+    mode: '0755'
+
+- name: Create file for reboot required
+  ansible.builtin.file:
+    path: /var/lib/openstack/reboot_required/edpm_kernel
+    state: touch
+    mode: '0600'

--- a/roles/edpm_reboot/defaults/main.yaml
+++ b/roles/edpm_reboot/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2019 Red Hat, Inc.
+# Copyright 2023 Red Hat, Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -17,22 +17,7 @@
 
 # All variables intended for modification should be placed in this file.
 
-# seconds between retries for download tasks
-edpm_kernel_download_delay: 5
-
-# number of retries for download tasks
-edpm_kernel_download_retries: 5
-
-edpm_kernel_extra_modules: {}
-edpm_kernel_extra_packages: []
-edpm_kernel_sysctl_extra_settings: {}
-edpm_kernel_args: ""
-edpm_kernel_defer_reboot: false
-edpm_kernel_hugepages: {}
-edpm_kernel_hugepages_remove: false
-
-# This should be synced with edpm_nova_compute role
-edpm_nova_compute_config_dir: /var/lib/config-data/ansible-generated/nova_libvirt
-
-# KSM control
-edpm_kernel_enable_ksm: false
+edpm_reboot_force_reboot: false
+edpm_reboot_nova_compute_config_dir: /var/lib/openstack/config/nova
+edpm_reboot_timeout_reboot: 3600
+edpm_reboot_post_reboot_delay: 60

--- a/roles/edpm_reboot/meta/argument_specs.yml
+++ b/roles/edpm_reboot/meta/argument_specs.yml
@@ -1,0 +1,25 @@
+---
+argument_specs:
+  # ./roles/edpm_reboot/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_reboot role.
+    options:
+      edpm_reboot_force_reboot:
+        description: |
+          Force reboot of the node. Automated reboot for nodes is by defulat defered as it can impact running vms.
+          Only on initial run when nova related files are not yet created reboot is not defered.
+          When edpm_reboot_force_reboot is set to true, reboot is allowed and will be perfomed if required.
+        type: bool
+        default: false
+      edpm_reboot_nova_compute_config_dir:
+        type: path
+        default: /var/lib/openstack/config/nova
+        description: This should be synced with edpm_nova_compute role
+      edpm_reboot_timeout_reboot:
+        type: int
+        default: 3600
+        description: Reboot timeout in seconds
+      edpm_reboot_post_reboot_delay:
+        type: int
+        default: 60
+        description: Reboot delay in seconds

--- a/roles/edpm_reboot/meta/main.yaml
+++ b/roles/edpm_reboot/meta/main.yaml
@@ -1,0 +1,44 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  namespace: openstack
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_reboot
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.9'
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_reboot/molecule/default/converge.yml
+++ b/roles/edpm_reboot/molecule/default/converge.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Create reboot_required directory
+      ansible.builtin.file:
+        path: /var/lib/openstack/reboot_required/
+        state: directory
+        mode: '0755'
+    - name: Create sample file in /var/lib/openstack/reboot_required/
+      ansible.builtin.file:
+        path: /var/lib/openstack/reboot_required/edpm_kernel
+        state: touch
+        mode: '0600'
+    - name: Run reboot role
+      ansible.builtin.include_role:
+        name: "osp.edpm.edpm_reboot"

--- a/roles/edpm_reboot/molecule/default/molecule.yml
+++ b/roles/edpm_reboot/molecule/default/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  config_options:
+    defaults:
+      callbacks_enabled: profile_tasks, timer, yaml
+      interpreter_python: auto_silent
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - verify
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_reboot/molecule/default/prepare.yml
+++ b/roles/edpm_reboot/molecule/default/prepare.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare test_deps
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: osp.edpm.env_data
+  tasks:
+    - name: Create nova config directory
+      ansible.builtin.file:
+        path: /var/lib/openstack/config/nova
+        state: directory
+        mode: "0775"
+
+    - name: Create nova.conf
+      ansible.builtin.copy:
+        dest: /var/lib/openstack/config/nova/01-nova.conf
+        mode: "0644"
+        owner: root
+        group: root
+        content: |
+          [DEFAULT]
+          debug = True
+          transport_url = fake:/
+          compute_driver = libvirt.LibvirtDriver

--- a/roles/edpm_reboot/tasks/main.yaml
+++ b/roles/edpm_reboot/tasks/main.yaml
@@ -1,0 +1,80 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Make sure yum-utils is installed
+  ansible.builtin.dnf:
+    name: yum-utils
+
+- name: Check if reboot is required with needs-restarting
+  ansible.builtin.command: needs-restarting -r
+  register: needs_restarting_output
+  changed_when: false
+  failed_when: needs_restarting_output.rc >= 2
+
+- name: Print return information from needs-restarting
+  ansible.builtin.debug:
+    var: needs_restarting_output.stdout
+
+- name: Create reboot file for needs-restarting
+  when: needs_restarting_output.rc == 1
+  block:
+    - name: Create a reboot_required directory if it does not exist
+      ansible.builtin.file:
+        path: /var/lib/openstack/reboot_required/
+        state: directory
+        mode: '0755'
+
+    - name: Create file for reboot required
+      ansible.builtin.file:
+        path: /var/lib/openstack/reboot_required/needs_restarting
+        state: touch
+        mode: '0600'
+
+    - name: Save result of needs_restarting result to file
+      ansible.builtin.lineinfile:
+        dest: /var/lib/openstack/reboot_required/needs_restarting
+        line: "{{ needs_restarting_output.stdout }}"
+
+- name: Check reboot_required folder for other services that requires reboot
+  ansible.builtin.find:
+    paths: /var/lib/openstack/reboot_required/
+  register: reboot_files
+
+- name: Check if node has a nova.conf config
+  ansible.builtin.stat:
+    path: "{{ edpm_reboot_nova_compute_config_dir }}/01-nova.conf"
+  register: nova_conf_check
+
+- name: Set reboot_required fact
+  ansible.builtin.set_fact:
+    reboot_required: true
+  when: reboot_files.matched > 0
+
+- name: Print message if reboot is required, but is not going to be started
+  ansible.builtin.debug:
+    msg: "Reboot is required but was not started. User has to plan the reboot and set edpm_reboot_force_reboot to true"
+  when:
+    - reboot_required|default(false)
+    - nova_conf_check.stat.exists
+    - not edpm_reboot_force_reboot|bool
+
+- name: Run reboot nodes actions
+  when:
+    - reboot_required is defined and reboot_required|bool
+    - edpm_reboot_force_reboot|bool or not nova_conf_check.stat.exists
+  block:
+    - name: Reboot tasks
+      ansible.builtin.include_tasks: reboot.yaml

--- a/roles/edpm_reboot/tasks/reboot.yaml
+++ b/roles/edpm_reboot/tasks/reboot.yaml
@@ -1,0 +1,25 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Reboot nodes
+  ansible.builtin.reboot:
+    post_reboot_delay: "{{ edpm_reboot_post_reboot_delay }}"
+    reboot_timeout: "{{ edpm_reboot_timeout_reboot }}"
+
+- name: Remove reboot_required directory
+  ansible.builtin.file:
+    path: /var/lib/openstack/reboot_required
+    state: absent


### PR DESCRIPTION
    There are steps in EDPM deployment and re-configuration that require
    EDPM node reboot to take effect. Also reboot might be required due to
    package updates.
    
    This role runs need-restarting command and checks if any file exists
    under /var/lib/openstack/reboot_required. If reboot is required and there
    are no nova configuration files reboot is performed.
    When nova files exist on a node reboot is performed only when
    edpm_reboot_force_reboot is set to true.