### PR TITLE
Set some neutron-ovn-metadata agent options only if necessary

### DIFF
--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -48,13 +48,9 @@ edpm_neutron_metadata_agent_rootwrap_DEFAULT_rlimit_nofile: '1024'
 
 # neutron-ovn-metadata-agent.conf
 edpm_neutron_metadata_agent_DEFAULT_debug: 'True'
-edpm_neutron_metadata_agent_DEFAULT_nova_metadata_host: '{{ edpm_neutron_metadata_agent_DEFAULT_host }}'
-edpm_neutron_metadata_agent_DEFAULT_nova_metadata_protocol: 'http'
-edpm_neutron_metadata_agent_DEFAULT_metadata_proxy_shared_secret: ''
 edpm_neutron_metadata_agent_DEFAULT_metadata_workers: '2'
 edpm_neutron_metadata_agent_DEFAULT_state_path: '/var/lib/neutron'
 edpm_neutron_metadata_agent_agent_root_helper: 'sudo neutron-rootwrap /etc/neutron.conf.d/01-rootwrap.conf'
 edpm_neutron_metadata_agent_ovs_ovsdb_connection: 'tcp:127.0.0.1:6640'
 edpm_neutron_metadata_agent_ovs_ovsdb_connection_timeout: '180'
 edpm_neutron_metadata_agent_ovn_ovsdb_probe_interval: '60000'
-edpm_neutron_metadata_agent_ovn_ovn_sb_connection: ''

--- a/roles/edpm_neutron_metadata/templates/neutron-ovn-metadata-agent.conf.j2
+++ b/roles/edpm_neutron_metadata/templates/neutron-ovn-metadata-agent.conf.j2
@@ -1,8 +1,18 @@
 [DEFAULT]
 debug = {{ edpm_neutron_metadata_agent_DEFAULT_debug }}
+
+{% if edpm_neutron_metadata_agent_DEFAULT_nova_metadata_host is defined %}
 nova_metadata_host = {{ edpm_neutron_metadata_agent_DEFAULT_nova_metadata_host }}
+{% endif %}
+
+{% if edpm_neutron_metadata_agent_DEFAULT_nova_metadata_protocol is defined %}
 nova_metadata_protocol = {{ edpm_neutron_metadata_agent_DEFAULT_nova_metadata_protocol }}
+{% endif %}
+
+{% if edpm_neutron_metadata_agent_DEFAULT_metadata_proxy_shared_secret is defined %}
 metadata_proxy_shared_secret = {{ edpm_neutron_metadata_agent_DEFAULT_metadata_proxy_shared_secret }}
+{% endif %}
+
 metadata_workers = {{ edpm_neutron_metadata_agent_DEFAULT_metadata_workers }}
 state_path = {{ edpm_neutron_metadata_agent_DEFAULT_state_path }}
 
@@ -15,4 +25,7 @@ ovsdb_connection_timeout = {{ edpm_neutron_metadata_agent_ovs_ovsdb_connection_t
 
 [ovn]
 ovsdb_probe_interval = {{ edpm_neutron_metadata_agent_ovn_ovsdb_probe_interval }}
+
+{% if edpm_neutron_metadata_agent_ovn_ovn_sb_connection is defined %}
 ovn_sb_connection = {{ edpm_neutron_metadata_agent_ovn_ovn_sb_connection }}
+{% endif %}


### PR DESCRIPTION
Some metadata agent config options are usually provided by the nova and ovn operators and are set in separate config files.
To avoid confusion with empty values in the main config file used by the neutron-ovn-metadata-agent, those options will be set there only if the are provided in the role's parameters.
