### PR TITLE
Add libvirt certs

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -51,3 +51,8 @@ edpm_libvirt_packages:
   # for qemu and the ceph udev rules
   - ceph-common
 edpm_libvirt_ceph_path: /var/lib/openstack/config/ceph
+
+# certs
+edpm_libvirt_certs_src: /var/lib/openstack/certs
+edpm_libvirt_cacerts_src: /var/lib/openstack/cacerts
+edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"

--- a/roles/edpm_libvirt/meta/argument_specs.yml
+++ b/roles/edpm_libvirt/meta/argument_specs.yml
@@ -40,3 +40,21 @@ argument_specs:
         type: str
         description: The path to the ceph config files.
         default: "/var/lib/openstack/config/ceph"
+      edpm_libvirt_certs_src:
+        type: str
+        default: /var/lib/openstack/certs
+        description: |
+          The path to the directory containing the libvirt cert and key files
+          in the ansibleEE container. This is the directory
+          where all TLS certs and keys for the libvirt service are mounted.
+      edpm_libvirt_cacerts_src:
+        type: str
+        default: /var/lib/openstack/cacerts
+        description: |
+          The path to the directory containing the cacert files
+          in the ansibleEE container. This is the directory
+          where all cacert PEM files for the libvirt service are mounted.
+      edpm_libvirt_tls_certs_enabled:
+        type: bool
+        default: false
+        description: Boolean to specify whether TLS certs are enabled.

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -15,6 +15,9 @@
   loop:
     - {"path": "/etc/tmpfiles.d/", "owner": "root", "group": "root"}
     - {"path": "/var/lib/edpm-config/firewall", "owner": "root", "group": "root"}
+    - {"path": "/etc/pki/libvirt", "owner": "root", "group": "root"}
+    - {"path": "/etc/pki/libvirt/private", "owner": "root", "group": "root"}
+    - {"path": "/etc/pki/CA", "owner": "root", "group": "root"}
 
 - name: Render libvirt config files
   tags:
@@ -86,6 +89,7 @@
   register: run_libvirt
   failed_when: run_libvirt.rc not in [0, 1]
   changed_when: false
+
 - name: Restore selinux label for /run/libvirt to virt_var_run_t
   tags:
     - configure
@@ -94,3 +98,20 @@
   ansible.builtin.command: "restorecon -R /run/libvirt"
   changed_when: true
   when: run_libvirt.rc == 0
+
+- name: Copy TLS files to the compute node
+  tags:
+    - configure
+    - libvirt
+  become: true
+  loop:
+    - {"src": "{{ edpm_libvirt_certs_src }}/{{ inventory_hostname }}-tls.crt", "dest": "/etc/pki/libvirt/server-cert.pem"}
+    - {"src": "{{ edpm_libvirt_certs_src }}/{{ inventory_hostname }}-tls.key", "dest": "{/etc/pki/libvirt/private/server-key.pem"}
+    - {"src": "{{ edpm_libvirt_cacerts_src }}/TLSCABundleFile", "dest": "/etc/pki/CA/cacert.pem"}
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: '0600'
+    owner: "root"
+    group: "root"
+  when: edpm_libvirt_tls_certs_enabled


### PR DESCRIPTION
This follows the same logic as for the nova compute certs.
It does not include any config changes to actually use the certs.  I'm expecting the compute DFG folks will add this logic.