### PR TITLE
Update dns_search_domains and add default

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -50,3 +50,4 @@ edpm_network_config_os_net_config_mappings: {}
 edpm_network_config_safe_defaults: true
 edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"
+edpm_dns_search_domains: []

--- a/roles/edpm_network_config/templates/2_linux_bonds_vlans/2_linux_bonds_vlans.j2
+++ b/roles/edpm_network_config/templates/2_linux_bonds_vlans/2_linux_bonds_vlans.j2
@@ -34,7 +34,7 @@ network_config:
   use_dhcp: false
   bonding_options: {{ edpm_bond_interface_ovs_options }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
   - type: interface
     name: nic2

--- a/roles/edpm_network_config/templates/2_linux_bonds_vlans/2_linux_bonds_vlans_dpdk.j2
+++ b/roles/edpm_network_config/templates/2_linux_bonds_vlans/2_linux_bonds_vlans_dpdk.j2
@@ -23,7 +23,7 @@ network_config:
   use_dhcp: false
   bonding_options: {{ edpm_bond_interface_ovs_options }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
   - type: interface
     name: nic2

--- a/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans.j2
+++ b/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans.j2
@@ -15,7 +15,7 @@ network_config:
 - type: ovs_bridge
   name: {{ neutron_physical_bridge_name }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
   - type: ovs_bond
     name: bond1

--- a/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans_storage.j2
+++ b/roles/edpm_network_config/templates/bonds_vlans/bonds_vlans_storage.j2
@@ -15,7 +15,7 @@ network_config:
 - type: ovs_bridge
   name: br-bond
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
   - type: ovs_bond
     name: bond1

--- a/roles/edpm_network_config/templates/bonds_vlans/controller_no_external.j2
+++ b/roles/edpm_network_config/templates/bonds_vlans/controller_no_external.j2
@@ -15,7 +15,7 @@ network_config:
 - type: ovs_bridge
   name: {{ neutron_physical_bridge_name }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
   - type: ovs_bond
     name: bond1

--- a/roles/edpm_network_config/templates/ci/custom_network_multiple_nics.j2
+++ b/roles/edpm_network_config/templates/ci/custom_network_multiple_nics.j2
@@ -15,7 +15,7 @@ network_config:
 - type: ovs_bridge
   name: br-ex
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   use_dhcp: false
   members:
   - type: interface

--- a/roles/edpm_network_config/templates/ci/multiple_nics.j2
+++ b/roles/edpm_network_config/templates/ci/multiple_nics.j2
@@ -15,7 +15,7 @@ network_config:
 - type: ovs_bridge
   name: br-ex
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   use_dhcp: false
   members:
   - type: interface

--- a/roles/edpm_network_config/templates/ci/multiple_nics_ipv6.j2
+++ b/roles/edpm_network_config/templates/ci/multiple_nics_ipv6.j2
@@ -13,7 +13,7 @@ network_config:
 - type: ovs_bridge
   name: br-ex
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   use_dhcp: false
   routes:
   - ip_netmask: ::/0

--- a/roles/edpm_network_config/templates/ci/public_bond.j2
+++ b/roles/edpm_network_config/templates/ci/public_bond.j2
@@ -13,7 +13,7 @@ network_config:
 - type: ovs_bridge
   name: br-ex
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   use_dhcp: false
   routes:
   - ip_netmask: 0.0.0.0/0

--- a/roles/edpm_network_config/templates/multiple_nics/multiple_nics.j2
+++ b/roles/edpm_network_config/templates/multiple_nics/multiple_nics.j2
@@ -4,7 +4,7 @@ network_config:
   name: nic1
   mtu: {{ ctlplane_mtu }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   routes: {{ ctlplane_host_routes }}
   use_dhcp: false
   addresses:

--- a/roles/edpm_network_config/templates/multiple_nics/multiple_nics_dpdk.j2
+++ b/roles/edpm_network_config/templates/multiple_nics/multiple_nics_dpdk.j2
@@ -4,7 +4,7 @@ network_config:
   name: nic1
   mtu: {{ ctlplane_mtu }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   routes: {{ ctlplane_host_routes }}
   use_dhcp: false
   addresses:

--- a/roles/edpm_network_config/templates/multiple_nics/multiple_nics_dvr.j2
+++ b/roles/edpm_network_config/templates/multiple_nics/multiple_nics_dvr.j2
@@ -4,7 +4,7 @@ network_config:
   name: nic1
   mtu: {{ ctlplane_mtu }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   routes: {{ ctlplane_host_routes }}
   use_dhcp: false
   addresses:

--- a/roles/edpm_network_config/templates/multiple_nics_vlans/multiple_nics_vlans.j2
+++ b/roles/edpm_network_config/templates/multiple_nics_vlans/multiple_nics_vlans.j2
@@ -4,7 +4,7 @@ network_config:
   name: nic1
   mtu: {{ ctlplane_mtu }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   routes: {{ ctlplane_host_routes }}
   use_dhcp: false
   addresses:

--- a/roles/edpm_network_config/templates/multiple_nics_vlans/multiple_nics_vlans_dpdk.j2
+++ b/roles/edpm_network_config/templates/multiple_nics_vlans/multiple_nics_vlans_dpdk.j2
@@ -4,7 +4,7 @@ network_config:
   name: nic1
   mtu: {{ ctlplane_mtu }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   routes: {{ ctlplane_host_routes }}
   use_dhcp: false
   addresses:

--- a/roles/edpm_network_config/templates/multiple_nics_vlans/multiple_nics_vlans_dvr.j2
+++ b/roles/edpm_network_config/templates/multiple_nics_vlans/multiple_nics_vlans_dvr.j2
@@ -4,7 +4,7 @@ network_config:
   name: nic1
   mtu: {{ ctlplane_mtu }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   routes: {{ ctlplane_host_routes }}
   use_dhcp: false
   addresses:

--- a/roles/edpm_network_config/templates/net_config_bond.j2
+++ b/roles/edpm_network_config/templates/net_config_bond.j2
@@ -4,7 +4,7 @@ network_config:
   name: {{ neutron_physical_bridge_name }}
   use_dhcp: true
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
   - type: ovs_bond
     name: bond1

--- a/roles/edpm_network_config/templates/net_config_bridge.j2
+++ b/roles/edpm_network_config/templates/net_config_bridge.j2
@@ -4,7 +4,7 @@ network_config:
   name: {{ neutron_physical_bridge_name }}
   use_dhcp: true
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
   - type: interface
     name: {{ neutron_public_interface_name }}

--- a/roles/edpm_network_config/templates/net_config_static.j2
+++ b/roles/edpm_network_config/templates/net_config_static.j2
@@ -4,7 +4,7 @@ network_config:
   name: {{ neutron_public_interface_name }}
   use_dhcp: false
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   addresses:
   - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
   routes:

--- a/roles/edpm_network_config/templates/net_config_static_bridge.j2
+++ b/roles/edpm_network_config/templates/net_config_static_bridge.j2
@@ -4,7 +4,7 @@ network_config:
   name: {{ neutron_physical_bridge_name }}
   use_dhcp: false
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   addresses:
   - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
   routes:

--- a/roles/edpm_network_config/templates/net_config_static_bridge_with_external_dhcp.j2
+++ b/roles/edpm_network_config/templates/net_config_static_bridge_with_external_dhcp.j2
@@ -4,7 +4,7 @@ network_config:
   name: {{ neutron_physical_bridge_name }}
   use_dhcp: true
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
   - type: interface
     name: {{ neutron_public_interface_name }}

--- a/roles/edpm_network_config/templates/single_nic_vlans/controller_no_external.j2
+++ b/roles/edpm_network_config/templates/single_nic_vlans/controller_no_external.j2
@@ -10,7 +10,7 @@ network_config:
   mtu: {{ min_viable_mtu }}
   use_dhcp: false
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   addresses:
   - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
   routes: {{ ctlplane_host_routes }}

--- a/roles/edpm_network_config/templates/single_nic_vlans/single_nic_vlans.j2
+++ b/roles/edpm_network_config/templates/single_nic_vlans/single_nic_vlans.j2
@@ -10,7 +10,7 @@ network_config:
   mtu: {{ min_viable_mtu }}
   use_dhcp: false
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   addresses:
   - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
   routes: {{ ctlplane_host_routes }}

--- a/roles/edpm_network_config/templates/single_nic_vlans/single_nic_vlans_bgp.j2
+++ b/roles/edpm_network_config/templates/single_nic_vlans/single_nic_vlans_bgp.j2
@@ -9,7 +9,7 @@ network_config:
   name: nic1
   mtu: {{ ctlplane_mtu }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   routes: {{ ctlplane_host_routes }}
   use_dhcp: false
   addresses:

--- a/roles/edpm_network_config/templates/single_nic_vlans/single_nic_vlans_storage.j2
+++ b/roles/edpm_network_config/templates/single_nic_vlans/single_nic_vlans_storage.j2
@@ -10,7 +10,7 @@ network_config:
   mtu: {{ min_viable_mtu }}
   use_dhcp: false
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   addresses:
   - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
   routes: {{ ctlplane_host_routes }}

--- a/roles/edpm_network_config/templates/standalone.j2
+++ b/roles/edpm_network_config/templates/standalone.j2
@@ -24,7 +24,7 @@ network_config:
   - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
   routes: {{ ctlplane_host_routes }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
     - type: interface
       name: {{ neutron_public_interface_name }}

--- a/roles/edpm_network_config/templates/undercloud.j2
+++ b/roles/edpm_network_config/templates/undercloud.j2
@@ -23,7 +23,7 @@ network_config:
   - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
   routes: {{ ctlplane_host_routes }}
   dns_servers: {{ ctlplane_dns_nameservers }}
-  domain: {{ dns_search_domains }}
+  domain: {{ edpm_dns_search_domains }}
   members:
     - type: interface
       name: {{ neutron_public_interface_name }}


### PR DESCRIPTION
This change renames the `dns_search_domains` variable in-line with the variable naming convention of the repo. We then set a default value for this variable.