### PR TITLE
Fixed linting issues in playbooks and task files

### DIFF
--- a/playbooks/telemetry.yml
+++ b/playbooks/telemetry.yml
@@ -15,9 +15,9 @@
 # under the License.
 
 
-- hosts: all
+- name: Deploy EDPM Ceilometer Agent Compute
+  hosts: all
   strategy: linear
-  name: Deploy EDPM Ceilometer Agent Compute
   gather_facts: true
   any_errors_fatal: true
   tasks:

--- a/playbooks/telemetry_logging.yml
+++ b/playbooks/telemetry_logging.yml
@@ -15,9 +15,9 @@
 # under the License.
 
 
-- hosts: all
+- name: Enable logging retrieval in compute node
+  hosts: all
   strategy: linear
-  name: Enable logging retrieval in compute node
   gather_facts: true
   any_errors_fatal: true
   tasks:

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -35,8 +35,7 @@
         network_state: "{{ edpm_network_config_template | from_yaml }}"
     - name: Load system-roles.network tasks [nmstate]
       ansible.builtin.include_role:
-        name: "{{ lookup('ansible.builtin.env', 'EDPM_SYSTEMROLES',  default='fedora.linux_system_roles') + '.network' }}"
-
+        name: "{{ lookup('ansible.builtin.env', 'EDPM_SYSTEMROLES', default='fedora.linux_system_roles') + '.network' }}"
 - name: Load edpm_network_config tasks [os-net-config]
   ansible.builtin.include_tasks:
     file: network_config.yml


### PR DESCRIPTION
- Fixed order of keywords in `telemetry` and `telemetry_logging` playbooks
- Removed extra white space in a role name in `edpm_network_config` role

This is required by newer versions of `ansible-lint` because they have improved checks.