### PR TITLE
Peform DNF update on edpm node via bootstrap_role

### DIFF
--- a/roles/edpm_bootstrap/tasks/download_cache.yml
+++ b/roles/edpm_bootstrap/tasks/download_cache.yml
@@ -34,3 +34,15 @@
   until: edpm_bootstrap_release_version_package_download.rc == 0
   retries: "{{ edpm_bootstrap_download_retries }}"
   delay: "{{ edpm_bootstrap_download_delay }}"
+
+- name: Download updated packages
+  become: true
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest  # noqa: package-latest
+    download_only: true
+    update_cache: true
+  register: edpm_bootstrap_system_updates_download
+  until: edpm_bootstrap_system_updates_download.rc == 0
+  retries: "{{ edpm_bootstrap_download_retries }}"
+  delay: "{{ edpm_bootstrap_download_delay }}"

--- a/roles/edpm_bootstrap/tasks/update_package.yml
+++ b/roles/edpm_bootstrap/tasks/update_package.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2019 Red Hat, Inc.
+# Copyright 2023 Red Hat, Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,11 +14,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Import download_cache tasks
-  ansible.builtin.import_tasks: download_cache.yml
-
-- name: Import bootstrap tasks
-  ansible.builtin.import_tasks: bootstrap.yml
-
-- name: Import Package update tasks
-  ansible.builtin.import_tasks: update_package.yml
+- name: Perform system update
+  become: true
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest  # noqa: package-latest
+    update_cache: true
+    update_only: true
+  register: edpm_bootstrap_system_update
+  until: edpm_bootstrap_system_update.rc == 0
+  retries: "{{ edpm_bootstrap_download_retries }}"
+  delay: "{{ edpm_bootstrap_download_delay }}"


### PR DESCRIPTION
In baremetal EDPM job, we use EDPM image to create EDPM node. it has all the required packages pre-installed during image build process.

If an older version of package got included during the image build process.  Then during edpm_deploy, bootstrap role is not going to update the package to latest.

Performing a dnf update will update all the system packages and avoid such issues.
