### PR TITLE
[molecule][podman] Drop remote_tmp config_options

### DIFF
--- a/roles/edpm_neutron_dhcp/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/molecule.yml
@@ -16,9 +16,6 @@ platforms:
   ulimits:
   - host
 provisioner:
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
   name: ansible
 scenario:

--- a/roles/edpm_neutron_metadata/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_metadata/molecule/default/molecule.yml
@@ -16,9 +16,6 @@ platforms:
   ulimits:
   - host
 provisioner:
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
   name: ansible
 scenario:

--- a/roles/edpm_telemetry/molecule/default/molecule.yml
+++ b/roles/edpm_telemetry/molecule/default/molecule.yml
@@ -16,9 +16,6 @@ platforms:
   ulimits:
   - host
 provisioner:
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
   name: ansible
 scenario:


### PR DESCRIPTION
Running the scenarios with root user fails with
this config, it works fine without this option set. So let's drop it as it's not necessary like other
molecule podman scenarios.