### PR TITLE
add optional vagrant senairo for local testing and development.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,6 +13,7 @@ exclude_paths:
   - tests
   - plugins/tests/molecule
   - contribute
+  - .venv
 parseable: true
 quiet: false
 verbosity: 1

--- a/.yamllint
+++ b/.yamllint
@@ -8,3 +8,4 @@ rules:
 
 ignore: |
   zuul.d/*.yaml
+  .venv

--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -1,6 +1,6 @@
 ansible-core==2.14.6
 molecule>=5.1.0,<6.0.0
-molecule-plugins[podman]>=23.4.0
+molecule-plugins[podman,vagrant]>=23.5.0
 pytest-testinfra
 # this is required for the molecule jobs
 ansi2html

--- a/roles/edpm_libvirt/molecule/default/molecule.yml
+++ b/roles/edpm_libvirt/molecule/default/molecule.yml
@@ -17,6 +17,8 @@ verifier:
   name: ansible
 scenario:
   test_sequence:
+     - destroy
+     - create
      - prepare
      - converge
      - verify

--- a/roles/edpm_libvirt/molecule/vagrant/README.md
+++ b/roles/edpm_libvirt/molecule/vagrant/README.md
@@ -1,0 +1,27 @@
+*********************************
+Vagrant driver installation guide
+*********************************
+
+Requirements
+============
+
+* Vagrant
+* Libvirt
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule-plugins[vagrant]\>=23.5.0'
+
+23.5.0+ is required to avoid a bug in the vagrant driver where molecule utils were not being imported correctly.
+This molecule env will be used for local development only and the default delegated env will be used for ci. As
+As a result, it's important that this scenario merely contains the info required to prepare the VM and calls the prepare, converge, and verify playbooks from default to keep them in sync.

--- a/roles/edpm_libvirt/molecule/vagrant/molecule.yml
+++ b/roles/edpm_libvirt/molecule/vagrant/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+  provision: no
+  parallel: true
+  # default_box: 'generic/rocky9'
+  default_box: 'generic/centos9s'
+platforms:
+- name: compute-1
+  memory: 8192
+  cpus: 8
+  provider_options:
+    cpu_mode: 'host-passthrough'
+    nested: true
+    machine_type: 'q35'
+  groups:
+    - compute
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../default/converge.yml
+    prepare: ../default/prepare.yml
+verifier:
+  name: ansible
+scenario:
+  # we disable all tests so that we dont
+  # run this in ci.
+  test_sequence: []

--- a/roles/edpm_libvirt/molecule/vagrant/verify.yml
+++ b/roles/edpm_libvirt/molecule/vagrant/verify.yml
@@ -1,0 +1,4 @@
+---
+
+- name: run default scenario verify playbooks
+  ansible.builtin.import_playbook: ../default/verify.yml

--- a/roles/edpm_nova/molecule/default/converge.yml
+++ b/roles/edpm_nova/molecule/default/converge.yml
@@ -14,4 +14,4 @@
   roles:
     - role: osp.edpm.edpm_nova
       vars:
-      edpm_nova_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"
+        edpm_nova_config_src: "{{lookup('env', 'MOLECULE_PROJECT_DIRECTORY')}}/molecule/default/test-data"

--- a/roles/edpm_nova/molecule/default/molecule.yml
+++ b/roles/edpm_nova/molecule/default/molecule.yml
@@ -24,6 +24,8 @@ verifier:
   name: ansible
 scenario:
   test_sequence:
+     - destroy
+     - create
      - prepare
      - converge
      - verify

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -45,10 +45,15 @@
         - "Copying /var/lib/kolla/config_files/ssh-privatekey to /var/lib/nova/.ssh/ssh-privatekey"
         - "Copying /var/lib/kolla/config_files/02-nova-host-specific.conf to /etc/nova/nova.conf.d/02-nova-host-specific.conf"
 
+    - name: slurp host specific config
+      ansible.builtin.slurp:
+        src: /var/lib/openstack/config/nova/02-nova-host-specific.conf
+      register: host_specific_config
+
     - name: Assert that my_ip is rendered into the host specific config
       ansible.builtin.assert:
         that:
-          - "'10.0.0.3' in lookup('ansible.builtin.file', '/var/lib/openstack/config/nova/02-nova-host-specific.conf')"
+          - "'10.0.0.3' in host_specific_config.content | b64decode"
 
     - name: Check if user exists
       ansible.builtin.getent:

--- a/roles/edpm_nova/molecule/vagrant/README.md
+++ b/roles/edpm_nova/molecule/vagrant/README.md
@@ -1,0 +1,27 @@
+*********************************
+Vagrant driver installation guide
+*********************************
+
+Requirements
+============
+
+* Vagrant
+* Libvirt
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule-plugins[vagrant]\>=23.5.0'
+
+23.5.0+ is required to avoid a bug in the vagrant driver where molecule utils were not being imported correctly.
+This molecule env will be used for local development only and the default delegated env will be used for ci. As
+As a result, it's important that this scenario merely contains the info required to prepare the VM and calls the prepare, converge, and verify playbooks from default to keep them in sync.

--- a/roles/edpm_nova/molecule/vagrant/molecule.yml
+++ b/roles/edpm_nova/molecule/vagrant/molecule.yml
@@ -1,0 +1,38 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+  provision: no
+  parallel: true
+  # default_box: 'generic/rocky9'
+  default_box: 'generic/centos9s'
+platforms:
+- name: compute-1
+  memory: 8192
+  cpus: 8
+  provider_options:
+    cpu_mode: 'host-passthrough'
+    nested: true
+    machine_type: 'q35'
+  groups:
+    - compute
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../default/converge.yml
+    prepare: ../default/prepare.yml
+  inventory:
+    hosts:
+      all:
+        hosts:
+          compute-1:
+            ctlplane_ip: 10.0.0.3
+verifier:
+  name: ansible
+scenario:
+  # we disable all tests so that we dont
+  # run this in ci.
+  test_sequence: []

--- a/roles/edpm_nova/molecule/vagrant/verify.yml
+++ b/roles/edpm_nova/molecule/vagrant/verify.yml
@@ -1,0 +1,4 @@
+---
+
+- name: run default scenario verify playbooks
+  ansible.builtin.import_playbook: ../default/verify.yml


### PR DESCRIPTION
The libvirt and nova roles currently uses the delegated driver
which runs molecule against localhost. This is required for
ci as the podman driver cannot be used with this role however
it also means you must use a separate development vm.

This change readds support for using the molecule vagrant plugin
for this role and configures the vagrant scenario to use the
prepare, converge and verify playbooks from the default delegated
scenario.

Additionally this change updates yamllint and ansible-lint to not
scan files in a venv i.e. .venv in the root of the edpm-ansible
repo. .venv is already ignored by .gitignore so this also only
affects local development.
