### PR TITLE
Add role edpm_install_certs

### DIFF
--- a/docs/source/playbooks/install_certs.rst
+++ b/docs/source/playbooks/install_certs.rst
@@ -1,0 +1,6 @@
+========================
+Playbook - install_certs
+========================
+
+Uses osp.edpm.edpm_install_certs role to install certificates on each compute
+node for all the services that need them.

--- a/docs/source/roles/role-edpm_install_certs.rst
+++ b/docs/source/roles/role-edpm_install_certs.rst
@@ -1,0 +1,6 @@
+=========================
+Role - edpm_install_certs
+=========================
+
+.. include::
+   ../collections/osp/edpm/edpm_install_certs.rst

--- a/docs/source/roles/role-edpm_install_certs.rst
+++ b/docs/source/roles/role-edpm_install_certs.rst
@@ -3,4 +3,4 @@ Role - edpm_install_certs
 =========================
 
 .. include::
-   ../collections/osp/edpm/edpm_install_certs.rst
+   ../collections/osp/edpm/edpm_install_certs_role.rst

--- a/playbooks/install_certs.yml
+++ b/playbooks/install_certs.yml
@@ -1,0 +1,13 @@
+---
+
+- name: EDPM Install Certs
+  hosts: all
+  strategy: free
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Install EDPM Certs
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_install_certs
+      tags:
+        - edpm_install_certs

--- a/roles/edpm_install_certs/meta/argument_specs.yml
+++ b/roles/edpm_install_certs/meta/argument_specs.yml
@@ -1,0 +1,12 @@
+---
+argument_specs:
+  # ./roles/edpm_install_certs/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the osp.edpm.edpm_install_certs role.
+    description:
+      - Role installs the certs and keys for all services under
+        /var/lib/openstack/certs/{service} onto the compute nodes
+      - Role installs the cacert bundles for all services under
+        /var/lib/openstack/cacerts/{service} onto the compute nodes
+      - No arguments are expected or necessary.
+    options: {}

--- a/roles/edpm_install_certs/meta/main.yml
+++ b/roles/edpm_install_certs/meta/main.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  namespace: openstack
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_install_certs
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.9'
+  platforms:
+    - name: 'EL'
+      versions:
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+dependencies: []

--- a/roles/edpm_install_certs/tasks/copy_ca_certs.yaml
+++ b/roles/edpm_install_certs/tasks/copy_ca_certs.yaml
@@ -1,0 +1,42 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Copy over cacerts
+  tags:
+    - certs
+  become: true
+  block:
+    - name: Set paths
+      ansible.builtin.set_fact:
+        cacert_src_path: "/var/lib/openstack/cacerts/{{ service }}"
+        cacert_dest_path: "/var/lib/openstack/cacerts/{{ service }}"
+
+    - name: Ensure that the destination directories exist
+      ansible.builtin.file:
+        path: "{{ cacert_dest_path }}"
+        state: "directory"
+        setype: "container_file_t"
+        owner: "root"
+        group: "root"
+        mode: "0755"
+
+    - name: Copy cacert to the compute node
+      ansible.builtin.copy:
+        src: "{{ cacert_src_path }}/tls-ca-bundle.pem"
+        dest: "{{ cacert_dest_path }}/tls-ca-bundle.pem"
+        mode: '0600'
+        owner: root
+        group: root

--- a/roles/edpm_install_certs/tasks/copy_certs_and_keys.yaml
+++ b/roles/edpm_install_certs/tasks/copy_certs_and_keys.yaml
@@ -1,0 +1,49 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Copy over certs and keys
+  tags:
+    - certs
+  become: true
+  block:
+    - name: Set paths
+      ansible.builtin.set_fact:
+        cert_src_path: "/var/lib/openstack/certs/{{ service }}"
+        cert_dest_path: "/var/lib/openstack/certs/{{ service }}"
+        key_dest_path: "/var/lib/openstack/certs/{{ service }}"
+
+    - name: Ensure that the destination directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: "directory"
+        setype: "container_file_t"
+        owner: "root"
+        group: "root"
+        mode: "0755"
+      loop:
+        - "{{ cert_dest_path }}"
+        - "{{ key_dest_path }}"
+
+    - name: Copy cert and key to the compute node
+      ansible.builtin.copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        mode: '0600'
+        owner: root
+        group: root
+      loop:
+        - {"src": "{{ cert_src_path }}/{{ inventory_hostname }}-tls.crt", "dest": "{{ cert_dest_path }}/tls.crt"}
+        - {"src": "{{ cert_src_path }}/{{ inventory_hostname }}-tls.key", "dest": "{{ key_dest_path }}/tls.key"}

--- a/roles/edpm_install_certs/tasks/main.yml
+++ b/roles/edpm_install_certs/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Find certs and keys
+  ansible.builtin.find:
+    paths: /var/lib/openstack/certs
+    recurse: false
+    file_type: directory
+  register: found_certs_services
+  delegate_to: localhost
+
+- name: Copy certs and keys to the correct location
+  ansible.builtin.include_tasks: copy_certs_and_keys.yaml
+  loop:
+    "{{ found_certs_services['files'] | map(attribute='path') | map('basename') | list }}"
+  loop_control:
+    loop_var: service
+
+- name: Find cacerts
+  ansible.builtin.find:
+    paths: /var/lib/openstack/cacerts
+    recurse: false
+    file_type: directory
+  register: found_cacerts_services
+  delegate_to: localhost
+
+- name: Copy cacerts
+  ansible.builtin.include_tasks: copy_ca_certs.yaml
+  loop:
+    "{{ found_cacerts_services['files'] | map(attribute='path') | map('basename') | list }}"
+  loop_control:
+    loop_var: service

--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -53,6 +53,4 @@ edpm_libvirt_packages:
 edpm_libvirt_ceph_path: /var/lib/openstack/config/ceph
 
 # certs
-edpm_libvirt_certs_src: /var/lib/openstack/certs
-edpm_libvirt_cacerts_src: /var/lib/openstack/cacerts
 edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"

--- a/roles/edpm_libvirt/meta/argument_specs.yml
+++ b/roles/edpm_libvirt/meta/argument_specs.yml
@@ -40,20 +40,6 @@ argument_specs:
         type: str
         description: The path to the ceph config files.
         default: "/var/lib/openstack/config/ceph"
-      edpm_libvirt_certs_src:
-        type: str
-        default: /var/lib/openstack/certs
-        description: |
-          The path to the directory containing the libvirt cert and key files
-          in the ansibleEE container. This is the directory
-          where all TLS certs and keys for the libvirt service are mounted.
-      edpm_libvirt_cacerts_src:
-        type: str
-        default: /var/lib/openstack/cacerts
-        description: |
-          The path to the directory containing the cacert files
-          in the ansibleEE container. This is the directory
-          where all cacert PEM files for the libvirt service are mounted.
       edpm_libvirt_tls_certs_enabled:
         type: bool
         default: false

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -17,7 +17,7 @@
     - {"path": "/var/lib/edpm-config/firewall", "owner": "root", "group": "root"}
     - {"path": "/etc/pki/libvirt", "owner": "root", "group": "root"}
     - {"path": "/etc/pki/libvirt/private", "owner": "root", "group": "root"}
-    - {"path": "/etc/pki/CA", "owner": "root", "group": "root"}
+    - {"path": "/etc/pki/CA/libvirt", "owner": "root", "group": "root"}
 
 - name: Render libvirt config files
   tags:
@@ -99,18 +99,19 @@
   changed_when: true
   when: run_libvirt.rc == 0
 
-- name: Copy TLS files to the compute node
+- name: Move TLS files to the right location on the compute node
   tags:
     - configure
     - libvirt
   become: true
   loop:
-    - {"src": "{{ edpm_libvirt_certs_src }}/{{ inventory_hostname }}-tls.crt", "dest": "/etc/pki/libvirt/server-cert.pem"}
-    - {"src": "{{ edpm_libvirt_certs_src }}/{{ inventory_hostname }}-tls.key", "dest": "{/etc/pki/libvirt/private/server-key.pem"}
-    - {"src": "{{ edpm_libvirt_cacerts_src }}/TLSCABundleFile", "dest": "/etc/pki/CA/cacert.pem"}
+    - {"src": "/var/lib/openstack/certs/libvirt/tls.crt", "dest": "/etc/pki/libvirt/tls.crt"}
+    - {"src": "/var/lib/openstack/certs/libvirt/tls.key", "dest": "/etc/pki/libvirt/private/tls.key"}
+    - {"src": "/var/lib/openstack/cacerts/libvirt/tls-ca-bundle.pem", "dest": "/etc/pki/CA/libvirt/tls-ca-bundle.pem"}
   ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
+    remote_src: true
     mode: '0600'
     owner: "root"
     group: "root"

--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -30,8 +30,4 @@ edpm_nova_config_dest: /var/lib/openstack/config/nova
 edpm_nova_compute_image: "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"
 
 # certs
-edpm_nova_certs_src: /var/lib/openstack/certs
-edpm_nova_certs_dest: /var/lib/openstack/certs/nova
-edpm_nova_cacerts_src: /var/lib/openstack/cacerts
-edpm_nova_cacerts_dest: /var/lib/openstack/cacerts/nova
 edpm_nova_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"

--- a/roles/edpm_nova/meta/argument_specs.yml
+++ b/roles/edpm_nova/meta/argument_specs.yml
@@ -25,32 +25,6 @@ argument_specs:
         description: |
           The path to the directory where the nova config files
           will be rendered on the compute node.
-      edpm_nova_certs_src:
-        type: str
-        default: /var/lib/openstack/certs
-        description: |
-          The path to the directory containing the nova cert and key files
-          in the ansibleEE container. This is the directory
-          where all TLS certs and keys for the nova service are mounted.
-      edpm_nova_certs_dest:
-        type: str
-        default: /var/lib/openstack/certs/nova
-        description: |
-          The path to the directory where the nova cert and key files
-          will be rendered on the compute node.
-      edpm_nova_cacerts_src:
-        type: str
-        default: /var/lib/openstack/cacerts
-        description: |
-          The path to the directory containing the cacert files
-          in the ansibleEE container. This is the directory
-          where all cacert PEM files for the nova service are mounted.
-      edpm_nova_cacerts_dest:
-        type: str
-        default: /var/lib/openstack/cacerts/nova
-        description: |
-          The path to the directory where the cacert PEM files
-          for the nova service will be rendered on the compute node.
       edpm_nova_tls_certs_enabled:
         type: bool
         default: false

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -15,8 +15,6 @@
   loop:
     - {"path": "{{ edpm_nova_config_dest }}", "mode": "0755"}
     - {"path": "/var/lib/openstack/config/containers", "mode": "0755"}
-    - {"path": "{{ edpm_nova_certs_dest }}", "mode": "0755"}
-    - {"path": "{{ edpm_nova_cacerts_dest }}", "mode": "0755"}
 - name: Create persistent directories
   tags:
     - configure
@@ -120,20 +118,3 @@
     mode: '0600'
     owner: nova
     group: nova
-
-- name: Copy TLS files to the compute node
-  tags:
-    - configure
-    - nova
-  become: true
-  loop:
-    - {"src": "{{ edpm_nova_certs_src }}/{{ inventory_hostname }}-tls.crt", "dest": "{{ edpm_nova_certs_dest }}/tls.crt"}
-    - {"src": "{{ edpm_nova_certs_src }}/{{ inventory_hostname }}-tls.key", "dest": "{{ edpm_nova_certs_dest }}/tls.key"}
-    - {"src": "{{ edpm_nova_cacerts_src }}/TLSCABundleFile", "dest": "{{ edpm_nova_cacerts_dest }}/TLSCABundleFile"}
-  ansible.builtin.copy:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    mode: '0600'
-    owner: nova
-    group: nova
-  when: edpm_nova_tls_certs_enabled

--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -13,7 +13,7 @@
 {% if edpm_nova_tls_certs_enabled %}
 	"/var/lib/openstack/certs/nova/tls.crt:/etc/pki/nova/server-cert.pem:ro",
 	"/var/lib/openstack/certs/nova/tls.key:/etc/pki/nova/private/server-key.pem:ro",
-	"/var/lib/openstack/cacerts/nova/TLSCABundleFile:/etc/pki/CA/cacert.pem:ro",
+	"/var/lib/openstack/cacerts/nova/tls-ca-bundle.pem:/etc/pki/CA/cacert.pem:ro",
 {% endif %}
         "/etc/localtime:/etc/localtime:ro",
         "/lib/modules:/lib/modules:ro",


### PR DESCRIPTION
This is a role that moves certs into the right locations for all the services.  This is executed by a service early in the cycle, so that the services can have all the certs available.  So nova, for example, will be able to use the libvirt certs.