### PR TITLE
[edpm_kernel] Improve `edpm_kernel_args` search in `/proc/cmdline`

### DIFF
--- a/roles/edpm_kernel/molecule/kernelargs-update-substring/converge.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-substring/converge.yml
@@ -1,0 +1,63 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  become: true
+  pre_tasks:
+    - name: Backing up /etc/default/grub
+      import_tasks: ../../resources/molecule/backup_grub.yml
+  tasks:
+    - name: First pass with custom variable
+      block:
+        - name: create kernelargs entry with the older name
+          lineinfile:
+            dest: /etc/default/grub
+            regexp: '^EDPM_KERNEL_ARGS.*'
+            insertafter: '^GRUB_CMDLINE_LINUX.*'
+            line: 'EDPM_KERNEL_ARGS=" {{ edpm_kernel_args }} "'
+        - name: create append entry with older name
+          lineinfile:
+            dest: /etc/default/grub
+            line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${EDPM_KERNEL_ARGS}"'
+            insertafter: '^EDPM_KERNEL_ARGS.*'
+        - include_role:
+            name: osp.edpm.edpm_kernel
+            tasks_from: kernelargs.yml
+          vars:
+            edpm_kernel_defer_reboot: true
+      vars:
+        edpm_kernel_args: "isolcpus=1,3,5,7,9,11,13,15"
+    - name: Second pass with custom variable (substring of the first)
+      block:
+        - name: create kernelargs entry with the older name
+          lineinfile:
+            dest: /etc/default/grub
+            regexp: '^EDPM_KERNEL_ARGS.*'
+            insertafter: '^GRUB_CMDLINE_LINUX.*'
+            line: 'EDPM_KERNEL_ARGS=" {{ edpm_kernel_args }} "'
+        - name: create append entry with older name
+          lineinfile:
+            dest: /etc/default/grub
+            line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${EDPM_KERNEL_ARGS}"'
+            insertafter: '^EDPM_KERNEL_ARGS.*'
+        - include_role:
+            name: osp.edpm.edpm_kernel
+            tasks_from: kernelargs.yml
+          vars:
+            edpm_kernel_defer_reboot: true
+      vars:
+        edpm_kernel_args: "isolcpus=1,3,5,7,9"

--- a/roles/edpm_kernel/molecule/kernelargs-update-substring/molecule.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-substring/molecule.yml
@@ -1,0 +1,13 @@
+---
+# inherits .config/molecule/config.yml
+provisioner:
+  inventory:
+    hosts:
+      all:
+        hosts:
+          instance:
+            ansible_connection: local
+            ansible_host: localhost
+  playbooks:
+    prepare: "${MOLECULE_SCENARIO_DIRECTORY}/../../resources/molecule/prepare.yml"
+    cleanup: "${MOLECULE_SCENARIO_DIRECTORY}/../../resources/molecule/cleanup.yml"

--- a/roles/edpm_kernel/molecule/kernelargs-update-substring/verify.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-substring/verify.yml
@@ -1,0 +1,48 @@
+---
+# Copyright 2019 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+  vars:
+    tripleo_kernel_args: "isolcpus=1,3,5,7,9"
+  tasks:
+    - name: Check if the variable is applied to the grub file
+      lineinfile:
+        path: /etc/default/grub
+        line: 'GRUB_EDPM_KERNEL_ARGS=" {{ tripleo_kernel_args }} "'
+        state: present
+      check_mode: true
+      register: grub
+      failed_when: (grub is changed) or (grub is failed)
+    - name: Check if the older name entries are removed
+      lineinfile:
+        path: /etc/default/grub
+        regexp: '^EDPM_KERNEL_ARGS.*'
+        state: absent
+      check_mode: true
+      register: grub
+      failed_when: (grub is changed) or (grub is failed)
+    - name: Check if the older name entries are removed for append
+      lineinfile:
+        path: /etc/default/grub
+        regexp: '.*{EDPM_KERNEL_ARGS}.*'
+        state: absent
+      check_mode: true
+      register: grub
+      failed_when: (grub is changed) or (grub is failed)

--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -133,7 +133,7 @@
   when:
     - cmdline is defined
     - edpm_kernel_args|string
-    - edpm_kernel_args not in cmdline
+    - not (cmdline | regex_search( '^.*' + edpm_kernel_args + '.*$' | string ))
   block:
     # Leapp does not recognise grun entries starting other than GRUB
     # It results wrong formatting of entries in file /etc/default/grub


### PR DESCRIPTION
In kernelargs.yml file we have a block of tasks for the definitions of custom kernel arguments. That block has 3 conditionals checks, one of them is the evaluation of kernel parameters defined in /proc/cmdline using the `edpm_kernel_args not in cmdline` notation. The problem is that this kind of notation will evaluate also partial matches.

E.g. if we first launch a deployment defining

```
edpm_kernel_args="isolcpus=1,3,5,7,9,11,13,15"
```

and then we'll do a deployment defining

```
edpm_kernel_args="isolcpus=1,3,5,7,9"
```

the check will evaluate to false because it matches the substring so the new kernel arguments won't be applied.

Also, a new molecule test for this specific case has been added.