### PR TITLE
Asciidocs build procedure

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -29,6 +29,9 @@ jobs:
         uses: actions/configure-pages@v3
       - name: Checkout
         uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1.160.0
+        with:
+          ruby-version: '3.2'
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ tests/output/**
 
 # Dynamic antsibull-docs source
 docs/source/collections/**
+
+# ASCIIDOC
+.bundle
+docs_build
+Gemfile.lock
+.ruby

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'asciidoctor', '~> 2.0', '>= 2.0.20'
+
+# Uncomment for ability to render pdf:
+# gem 'asciidoctor-pdf', '~> 2.0', '>= 2.0.20'

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -34,5 +34,26 @@ doc8 --config ${DOCS_DIR}/doc8.ini ${DOCS_DIR}/source
 
 sphinx-build -a -E -W -d ${DOCS_DIR}/build/doctrees --keep-going -b html ${DOCS_DIR}/source ${DOCS_DIR}/build/html -T
 
+## ASCIIDocs
+# Dependencies
+if ! type bundle; then \
+    echo "Bundler not found. On Linux run 'sudo dnf install /usr/bin/bundle' to install it."; \
+    exit 1; \
+fi
+
+bundle config set path .ruby/.bundle
+bundle install --gemfile=${DOCS_DIR}/Gemfile --binstubs=.ruby
+
+# Build
+${DOCS_DIR}/.ruby/asciidoctor -a source-highlighter=highlightjs \
+            -a highlightjs-languages="yaml,bash" \
+            -a highlightjs-theme="monokai" \
+            --failure-level WARN \
+            -a build=build \
+            -b xhtml5 \
+            -d book \
+            -o ${DOCS_DIR}/build/html/index-asciidoc.html \
+            ${DOCS_DIR}/source/main.adoc
+
 deactivate
 rm -fr ${TEMP_VENV_ENV}

--- a/docs/source/main.adoc
+++ b/docs/source/main.adoc
@@ -1,0 +1,1 @@
+== EDPM ansible


### PR DESCRIPTION
Putting infrastructure in place for future move to asciidocs. At this time we only have the build itself and an empty index page, until there is a procedure to convert existing documentation, or part of it, to asciidocs.
