### PR TITLE
Call package update via bootstrap playbook

### DIFF
--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -63,6 +63,9 @@
 - name: Import packages tasks
   ansible.builtin.import_tasks: packages.yml
 
+- name: Import Package update tasks
+  ansible.builtin.import_tasks: update_package.yml
+
 - name: Set selinux state
   ansible.posix.selinux:
     policy: targeted

--- a/roles/edpm_bootstrap/tasks/main.yml
+++ b/roles/edpm_bootstrap/tasks/main.yml
@@ -19,6 +19,3 @@
 
 - name: Import bootstrap tasks
   ansible.builtin.import_tasks: bootstrap.yml
-
-- name: Import Package update tasks
-  ansible.builtin.import_tasks: update_package.yml


### PR DESCRIPTION
Currently tempest tests are failing due to old packages installed on edpm node.

Recently we have added https://github.com/openstack-k8s-operators/edpm-ansible/pull/518 to perform DNF update via edpm_bootstrap role.

But bootstrap-openstack-edpm-ipam pod calls bootstrap.yml playbook not the role that's why update_packages playbook is not called leaving old packages on the node.

Calling update_packages.yml playbook via bootstrap.yml playbook updates the packages and fixes the issue.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/532