### PR TITLE
[edpm_libvirt]Enable os_enable_vtpm selinux boolean

### DIFF
--- a/roles/edpm_libvirt/molecule/default/prepare.yml
+++ b/roles/edpm_libvirt/molecule/default/prepare.yml
@@ -41,6 +41,13 @@
         popd
         rm -rf repo-setup-main
 
+    # NOTE(gibi): this is done by the boostrap role in a real deployment
+    - name: Install openstack-selinux
+      become: true
+      ansible.builtin.dnf:
+        name: "openstack-selinux"
+        state: present
+
     - name: set /etc/localtime
       become: true
       ansible.builtin.file:

--- a/roles/edpm_libvirt/molecule/default/verify.yml
+++ b/roles/edpm_libvirt/molecule/default/verify.yml
@@ -101,3 +101,11 @@
         that:
           - "item  == 'migration_port_min = 61152 migration_port_max = 61215 '"
       loop: "{{ qemu_conf_migration_ports.stdout_lines }}"
+
+    - name: Load os_enabled_vtpm selinux boolean
+      ansible.builtin.shell: "getsebool os_enable_vtpm"
+      register: os_enabled_vtpm
+    - name: Assert that os_enabled_vtpm selinux boolean is enabled
+      assert:
+        that:
+          - "os_enabled_vtpm.stdout_lines[0] == 'os_enable_vtpm --> on'"

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -99,6 +99,16 @@
   changed_when: true
   when: run_libvirt.rc == 0
 
+- name: Enable os_enable_vtpm SELinux boolean for vTPM
+  tags:
+    - configure
+    - libvirt
+  become: true
+  ansible.posix.seboolean:
+    name: os_enable_vtpm
+    persistent: true
+    state: true
+
 - name: Move TLS files to the right location on the compute node
   tags:
     - configure

--- a/roles/edpm_nova/molecule/default/prepare.yml
+++ b/roles/edpm_nova/molecule/default/prepare.yml
@@ -47,6 +47,12 @@
         ./venv/bin/repo-setup current-podified -b antelope
         popd
         rm -rf repo-setup-main
+    # NOTE(gibi): this is done by the boostrap role in a real deployment
+    - name: Install openstack-selinux
+      become: true
+      ansible.builtin.dnf:
+        name: "openstack-selinux"
+        state: present
     - name: set /etc/localtime
       become: true
       ansible.builtin.file:


### PR DESCRIPTION
To support VTPM with Selinux we need to enable the policy.

Related: [OSPRH-2449](https://issues.redhat.com//browse/OSPRH-2449)
Related: [OSPRH-2451](https://issues.redhat.com//browse/OSPRH-2451)