### PR TITLE
Create host user and group, if not exists

### DIFF
--- a/roles/edpm_users/tasks/create_users_and_groups.yml
+++ b/roles/edpm_users/tasks/create_users_and_groups.yml
@@ -14,11 +14,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Create host user and group
+- name: Create host user and group, if not exists
   become: true
   tags:
     - edpm_users
   block:
+    - name: Detect when user exists and cannot be created
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ item.name }}"
+  rescue:
     - name: Ensure group is present on the host [ {{ item.name }} ]
       ansible.builtin.group:
         name: "{{ item.name }}"


### PR DESCRIPTION
Create host user and group, if not exists
    
    During Wallaby to Anteleope FFU (EDPM adoption), users that exist
    should not be attempted to get changed IDs, home paths, or the like.
    
    In particular, changing openwswitch user ID to a constant agreed upon
    for OSP-related services use from Kolla, breaks its upgrades.
    
    Use getent to check if a user being created is already exists.
    Only create it in a rescue block (getent fails if user does not exist).
    While the user module is idempotent per se, it doesn't allow changin
    user IDs.
    
    This fixes ovs edpm role during EDPM adoption, in particular.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/702