### PR TITLE
WIP - Allow for multiple inventory files to be passed to ansibleee

### DIFF
--- a/openstack_ansibleee/edpm_entrypoint.sh
+++ b/openstack_ansibleee/edpm_entrypoint.sh
@@ -4,6 +4,14 @@
 # Expand the variables
 eval "echo \"$(cat /runner/env/settings)\"" > /runner/env/settings
 
+# Create symlinks to mounted inventories in the general inventory dir
+# This will treat all files in designated paths as if they were inventories
+if [ -n "$RUNNER_INVENTORY_PATHS" ]; then
+    for inv_path in $RUNNER_INVENTORY_PATHS; do
+        ln -s $inv_path/** /runner/inventory/
+    done
+fi
+
 if [ -n "$RUNNER_INVENTORY" ]; then
     echo "---" > /runner/inventory/inventory.yaml
     echo "$RUNNER_INVENTORY" >> /runner/inventory/inventory.yaml


### PR DESCRIPTION
Ansibleee operator will fill the `RUNNER_INVENTORY_PATHS` with newline separated list of mount paths. These will be expected to contain only inventory files and nothing else. Entry point will then create symbolic links to these.

As the ansibleee runner is capable of using multiple inventory files at once we don't have to worry about merging inventories ourselves. This also means that we inherit all possible failure modes. However, debugging and potentially fixing them will be far easier.

Depends-On: https://github.com/openstack-k8s-operators/openstack-ansibleee-operator/pull/300 