### PR TITLE
Support NVMEe-oF storage protocols

### DIFF
--- a/playbooks/configure_os.yml
+++ b/playbooks/configure_os.yml
@@ -50,18 +50,6 @@
         tasks_from: configure.yml
       tags:
         - edpm_logrotate_crond
-    - name: Configure edpm_iscsid
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_iscsid
-        tasks_from: configure.yml
-      tags:
-        - edpm_iscsid
-    - name: Configure edpm_multipathd
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_multipathd
-        tasks_from: configure.yml
-      tags:
-        - edpm_multipathd
     - name: Configure nftables
       ansible.builtin.import_role:
         name: osp.edpm.edpm_nftables

--- a/playbooks/install_os.yml
+++ b/playbooks/install_os.yml
@@ -33,15 +33,3 @@
         tasks_from: install.yml
       tags:
         - edpm_logrotate_crond
-    - name: Install edpm_iscsid
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_iscsid
-        tasks_from: install.yml
-      tags:
-        - edpm_iscsid
-    - name: Install edpm_multipathd
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_multipathd
-        tasks_from: install.yml
-      tags:
-        - edpm_multipathd

--- a/playbooks/nova.yml
+++ b/playbooks/nova.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Deploy EDPM Nova storage infrastructure
+  ansible.builtin.import_playbook: nova_storage.yml
+
 - name: Deploy EDPM Nova
   hosts: all
   strategy: linear

--- a/playbooks/nova_storage.yml
+++ b/playbooks/nova_storage.yml
@@ -18,3 +18,9 @@
         name: osp.edpm.edpm_multipathd
       tags:
         - edpm_multipathd
+
+    - name: Support NVMe-oF protocols
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_nvmeof
+      tags:
+        - edpm_nvmeof

--- a/playbooks/nova_storage.yml
+++ b/playbooks/nova_storage.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Deploy Nova storage infrastructure
+  hosts: all
+  become: true
+  strategy: linear
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Deploy iSCSI daemon
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_iscsid
+      tags:
+        - edpm_iscsid
+
+    - name: Deploy multipath daemon
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_multipathd
+      tags:
+        - edpm_multipathd

--- a/playbooks/run_os.yml
+++ b/playbooks/run_os.yml
@@ -32,15 +32,3 @@
         tasks_from: run.yml
       tags:
         - edpm_logrotate_crond
-    - name: Run edpm_iscsid
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_iscsid
-        tasks_from: run.yml
-      tags:
-        - edpm_iscsid
-    - name: Run edpm_multipathd
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_multipathd
-        tasks_from: run.yml
-      tags:
-        - edpm_multipathd

--- a/roles/edpm_iscsid/tasks/main.yml
+++ b/roles/edpm_iscsid/tasks/main.yml
@@ -14,20 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Install iscsid
+  ansible.builtin.include_tasks: install.yml
 
-# "iscsid" will search for and load any operating system variable file
+- name: Configure iscsid
+  ansible.builtin.include_tasks: configure.yml
 
-# found within the "vars/" path. If no OS files are found the task will skip.
-- name: Gather variables for each operating system
-  ansible.builtin.include_vars: "{{ item }}"
-  with_first_found:
-    - skip: true
-      files:
-        - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_version'] | lower }}.yml"
-        - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
-        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
-        - "{{ ansible_facts['distribution'] | lower }}.yml"
-        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_version'].split('.')[0] }}.yml"
-        - "{{ ansible_facts['os_family'] | lower }}.yml"
-  tags:
-    - always
+- name: Run iscsid
+  ansible.builtin.include_tasks: run.yml

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -37,6 +37,7 @@
     - {"path": "/etc/multipath"}
     - {"path": "/etc/iscsi"}
     - {"path": "/var/lib/iscsi"}
+    - {"path": "/etc/nvme"}
     - {"path": "/run/openvswitch"}
 - name: Render nova config files
   tags:

--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -27,6 +27,7 @@
         "/etc/multipath:/etc/multipath:z",
         "/etc/multipath.conf:/etc/multipath.conf:ro",
         "/etc/iscsi:/etc/iscsi:ro",
+        "/etc/nvme:/etc/nvme",
         "/var/lib/openstack/config/ceph:/var/lib/kolla/config_files/ceph:ro",
         "/etc/ssh/ssh_known_hosts:/etc/ssh/ssh_known_hosts:ro"
     ]

--- a/roles/edpm_nvmeof/meta/argument_specs.yml
+++ b/roles/edpm_nvmeof/meta/argument_specs.yml
@@ -1,0 +1,6 @@
+---
+argument_specs:
+  # ./roles/edpm_nvmeof/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_nvmeof role.
+    options: {}

--- a/roles/edpm_nvmeof/meta/main.yml
+++ b/roles/edpm_nvmeof/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_nvmeof
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_nvmeof/molecule/default/collections.yml
+++ b/roles/edpm_nvmeof/molecule/default/collections.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+collections:
+- name: community.general

--- a/roles/edpm_nvmeof/molecule/default/converge.yml
+++ b/roles/edpm_nvmeof/molecule/default/converge.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "edpm_nvmeof"

--- a/roles/edpm_nvmeof/molecule/default/molecule.yml
+++ b/roles/edpm_nvmeof/molecule/default/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  pre_build_image: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - destroy
+  - create
+  - prepare
+  - converge
+  - check
+  - verify
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_nvmeof/molecule/default/prepare.yml
+++ b/roles/edpm_nvmeof/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+    - role: env_data

--- a/roles/edpm_nvmeof/molecule/default/verify.yml
+++ b/roles/edpm_nvmeof/molecule/default/verify.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Verify the nvme-fabrics module will be loaded at boot
+      ansible.builtin.command: grep -q ^nvme-fabrics$ /etc/modules-load.d/nvme-fabrics.conf
+
+    - name: Verify nvme-fabrics has been loaded
+      ansible.builtin.command: grep -q nvme_fabrics /proc/modules
+
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+
+    - name: Verify the nvme-cli package is installed
+      ansible.builtin.debug:
+        msg: "testing if nvme-cli installed"
+      failed_when: nvme-cli not in ansible_facts['packages']

--- a/roles/edpm_nvmeof/tasks/install.yml
+++ b/roles/edpm_nvmeof/tasks/install.yml
@@ -1,0 +1,31 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Load nvme-fabrics
+  become: true
+  ansible.builtin.import_role:
+    name: edpm_module_load
+  vars:
+    modules:
+      - name: nvme-fabrics
+
+- name: Install nvme-cli
+  # The nvme-cli package is installed because it creates udev rules and some
+  # files in /etc/nvme.
+  become: true
+  ansible.builtin.package:
+    name: nvme-cli
+    state: present

--- a/roles/edpm_nvmeof/tasks/main.yml
+++ b/roles/edpm_nvmeof/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Install support for NVMe-oF storage
+  ansible.builtin.include_tasks: install.yml


### PR DESCRIPTION
First commit:

Revamp deploying storage services required by nova
    
    Storage services (namely the iSCSI and multipath daemons) required
    by nova are now deployed using a dedicated playbook, which in turn
    is imported by the nova playbook. This ensures the services only
    get installed on EDPM nodes hosting nova.

Second commit:

NVMe-oF support has these components:
- Load the nvme-fabrics kernel module
- Install the nvme-cli package on the host (which initializes several files in /etc/nvme, and also some udev rules)
- Bind mount /etc/nvme into the nova-compute container

Jira: [OSPRH-1579](https://issues.redhat.com//browse/OSPRH-1579)