### PR TITLE
Ensure hugetlbfs group exists

### DIFF
--- a/roles/edpm_ovs/tasks/user.yml
+++ b/roles/edpm_ovs/tasks/user.yml
@@ -5,6 +5,7 @@
   vars:
     edpm_users_users:
       # 42476 is matching with the uid and gid created by kolla in the openstack containers
+      - {"name": "hugetlbfs", "gid": "42477", "group_only": true}
       - {"name": "openvswitch", "uid": "42476", "gid": "42476", "shell": "/sbin/nologin", groups: "hugetlbfs", "comment": "openvswitch user"}
     edpm_users_extra_dirs: []
   tags:


### PR DESCRIPTION
Due to the changes in [1] the openvswitch user is created before the
openvswitch package is installed. In RHEL systems the edpm_ovs role now
fails with [2]

This patch ensures the hugetlbfs group is created before the openvswitch
users is created and added to the hugetlbfs group.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/532
[2]
```
TASK [osp.edpm.edpm_users : Ensure user is present on the host [ openvswitch ]] ***
task path: /usr/share/ansible/collections/ansible_collections/osp/edpm/roles/edpm_users/tasks/create_users_and_groups.yml:32
fatal: [compute-0]: FAILED! => {"changed": false, "msg": "Group hugetlbfs does not exist"}
```

JIRA: https://issues.redhat.com/browse/OSPCIX-173