### PR TITLE
Revert "Ensure hugetlbfs group exists"

### DIFF
--- a/roles/edpm_ovs/tasks/user.yml
+++ b/roles/edpm_ovs/tasks/user.yml
@@ -5,7 +5,6 @@
   vars:
     edpm_users_users:
       # 42476 is matching with the uid and gid created by kolla in the openstack containers
-      - {"name": "hugetlbfs", "gid": "42477", "group_only": true}
       - {"name": "openvswitch", "uid": "42476", "gid": "42476", "shell": "/sbin/nologin", groups: "hugetlbfs", "comment": "openvswitch user"}
     edpm_users_extra_dirs: []
   tags:


### PR DESCRIPTION
Reverts openstack-k8s-operators/edpm-ansible#545

Real root cause was https://github.com/openstack-k8s-operators/ci-framework/pull/1082