### PR TITLE
Use journald as log_driver for the containers

### DIFF
--- a/molecule/test-helpers/verify_podman.yaml
+++ b/molecule/test-helpers/verify_podman.yaml
@@ -23,13 +23,3 @@
           - running_containers.stdout_lines | length == 1
           - "'Up' in running_containers.stdout_lines | first"
         fail_msg: "Podman container {{ item }} is not running"
-    - name: Check the container stdout log exists {{ item }}
-      become: true
-      ansible.builtin.stat:
-        path: "/var/log/containers/stdouts/{{ item }}.log"
-      register: log_exists
-    - name: Assert the container stdout log exists {{ item }}
-      ansible.builtin.assert:
-        that:
-          - log_exists.stat.exists
-        fail_msg: "Container stdout log for {{ item }} does not exist"

--- a/plugins/modules/edpm_container_manage.py
+++ b/plugins/modules/edpm_container_manage.py
@@ -292,7 +292,7 @@ class EdpmContainerManage:
             },
             'conmon_pidfile': f"/run/{name}.pid",
             'debug': self.debug,
-            'log_driver': 'k8s-file',
+            'log_driver': 'journald',
             'log_level': 'info',
             'log_opt': {"path": f"{self.log_base_path}/{name}.log"},
         }

--- a/roles/edpm_ovn_bgp_agent/molecule/default/verify.yml
+++ b/roles/edpm_ovn_bgp_agent/molecule/default/verify.yml
@@ -22,20 +22,6 @@
       loop:
         - {"name": "edpm_ovn_bgp_agent.service"}
 
-    - name: ensure that log file for ovn_bgp_agent exist
-      become: true
-      block:
-        - name: Check if file /var/log/containers/stdouts/ovn_bgp_agent.log exist
-          ansible.builtin.stat:
-            path: /var/log/containers/stdouts/ovn_bgp_agent.log
-          register: log_file
-        - name: Assert file /var/log/containers/stdouts/ovn_bgp_agent.log exist
-          ansible.builtin.assert:
-            that:
-              - log_file.stat.exists
-            fail_msg: "File /var/log/containers/stdouts/ovn_bgp_agent.log does not exist"
-
-
     - name: ensure kolla_set_configs copied the expected files
       become: true
       ansible.builtin.shell: |


### PR DESCRIPTION
As highlighted by @SeanMooney on https://issues.redhat.com/browse/OSPRH-153, we would like Podman log behaviour to be the one provided by the journald log_driver, which has been the default for a while.

The centralized logging retrieval system for the EDPM will expect the logs for all the containers to be stored in the journal.