### PR TITLE
Allow hosts override from extra vars

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -25,6 +25,7 @@ check to avoid needless issues with style, such as indentation.
 
    contributing_roles
    contributing_plugins
+   contributing_playbooks
    testing_roles
    testing_with_ansibleee
 

--- a/docs/source/contributing_playbooks.rst
+++ b/docs/source/contributing_playbooks.rst
@@ -1,0 +1,88 @@
+Contributing Playbooks
+----------------------
+
+Addition of new playbooks to the edpm-ansible collection is easy,
+thanks to specialized development tooling and CI pipeline.
+However, certain requirements must be met by any new playbook,
+in order to ensure quality of the collection and a smooth operation
+of software consuming it.
+
+These requirements, outlined in the following document, go beyond
+syntactic and functional correctness of the code.
+
+Where there isn't an explicit requirement, or recommendation,
+provided by this document, the primary `Ansible documentation`_ is considered
+to be the source of truth. When this document and official Ansible docs
+are in substantial conflict, an issue should be raised.
+
+Playbook design principles
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Playbook must not duplicate other playbooks.
+
+If a newly developed playbook requires functionality not already present in existing
+roles, a new role should be submitted in the same PR implementing it.
+
+If possible, playbooks should not use tasks directly, only trough a role.
+
+Playbooks must use following basic layout. Exposing variables, `edpm_override_hosts`,
+`edpm_max_fail_percentage` and `edpm_any_errors_fatal`.
+
+.. code-block:: YAML
+
+    - name: NEWPLAYNAME
+      hosts: "{{ edpm_override_hosts | default('all') }}"
+      strategy: linear
+      become: true
+      any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+      max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+
+This allows for more granular error handling and playbook application by operators.
+
+Error handling
+++++++++++++++
+
+Errors encountered while executing playbooks should be handled in roles which
+caused them.
+
+Playbook test development
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Playbooks themselves don't require tests. However, all of the roles they invoke do.
+For further information about testing roles, please refer to the role contribution
+section of this guide.
+
+
+Documenting a new playbook
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Playbooks must accurately explain their effects in their documentation, with in-line
+comments serving only as a supplement. In complex cases the documentation should link
+to other material, but only as a source of additional information.
+
+
+Primary playbook documentation file must reside at `docs/source/playbooks/<NEWPLAYBOOKNAME>.rst`
+and must be a valid, readable rst document.
+
+This file must contain a title and a `literalinclude` directive of the playbook itself
+at the `../../../playbooks/<NEWPLAYBOOKNAME>.yml` path.
+
+
+.. code-block:: rst
+
+    .. literalinclude:: ../../../playbooks/bootstrap.yml
+       :language: YAML
+
+Optionally, you can write further information about the playbook,
+such as section of examples, in the `docs/source/playbooks/<NEWPLAYBOOKNAME>.rst`.
+However, this documentation must be updated manually, together with the playbook.
+
+Create a new playbook
+~~~~~~~~~~~~~~~~~~~~~
+
+Each new playbook must follow form and basic outline of existing playbooks.
+
+Before submitting a playbook for review, don't forget to run pre-commit hooks,
+as well as molecule tests, if possible.
+
+.. _`Ansible documentation`: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks.html

--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Bootstrap node
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/ceph_client.yml
+++ b/playbooks/ceph_client.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Configure EDPM as client of Ceph
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/ceph_hci_pre.yml
+++ b/playbooks/ceph_hci_pre.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Prepare EDPM to Host Ceph
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"

--- a/playbooks/configure_network.yml
+++ b/playbooks/configure_network.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM Network
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/configure_os.yml
+++ b/playbooks/configure_os.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM Operating System Configure
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/configure_ovs_dpdk.yml
+++ b/playbooks/configure_ovs_dpdk.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Configure OvS DPDK
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   tasks:

--- a/playbooks/download_cache.yml
+++ b/playbooks/download_cache.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: EDPM Download cache
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"

--- a/playbooks/frr.yml
+++ b/playbooks/frr.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM FRR
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/install_certs.yml
+++ b/playbooks/install_certs.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: EDPM Install Certs
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: free
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"

--- a/playbooks/install_os.yml
+++ b/playbooks/install_os.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM Operating System Install
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/libvirt.yml
+++ b/playbooks/libvirt.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM libvirt
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"

--- a/playbooks/neutron_dhcp.yml
+++ b/playbooks/neutron_dhcp.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM Neutron DHCP agent
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/neutron_metadata.yaml
+++ b/playbooks/neutron_metadata.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy EDPM Neutron OVN Metadata agent
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/neutron_ovn.yaml
+++ b/playbooks/neutron_ovn.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy EDPM Neutron OVN agent
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/neutron_sriov.yml
+++ b/playbooks/neutron_sriov.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM Neutron SR-IOV agent
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/nova.yml
+++ b/playbooks/nova.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM Nova
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"

--- a/playbooks/ovn.yml
+++ b/playbooks/ovn.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM OVN
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/ovn_bgp_agent.yml
+++ b/playbooks/ovn_bgp_agent.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM OVN BGP Agent
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/reboot.yml
+++ b/playbooks/reboot.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Reboot nodes if reboot is required
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   tasks:

--- a/playbooks/run_os.yml
+++ b/playbooks/run_os.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Deploy EDPM Operating System Run
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/select_kernel_ddp_package.yml
+++ b/playbooks/select_kernel_ddp_package.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Select Kernel DDP Package
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/telemetry.yml
+++ b/playbooks/telemetry.yml
@@ -16,7 +16,7 @@
 
 
 - name: Deploy EDPM Ceilometer Agent Compute
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   gather_facts: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"

--- a/playbooks/telemetry_logging.yml
+++ b/playbooks/telemetry_logging.yml
@@ -16,7 +16,7 @@
 
 
 - name: Enable logging retrieval in compute node
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   gather_facts: true
   any_errors_fatal: true

--- a/playbooks/validate_network.yml
+++ b/playbooks/validate_network.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: EDPM Node validation
-  hosts: all
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"


### PR DESCRIPTION
Sometimes we may want to apply our play to a subset of nodes, or to all nodes, even though it was originally targeting 'all' or just some of them.

Right now, all of our playbooks target all hosts by default, so the override can be hypothetically used to target subset of nodes. But eventually, when we have playbooks for specific groups in inventory, this will allow us to instead go for all of them.

We just need to document it.