### PR TITLE
Revert "Added downgrade of crun in molecule scenario where podman is …

### DIFF
--- a/roles/edpm_frr/molecule/default/prepare.yml
+++ b/roles/edpm_frr/molecule/default/prepare.yml
@@ -32,17 +32,6 @@
       when:
         - ansible_user is undefined
   tasks:
-    # needed due to regression in 1.11.1
-    # see https://github.com/containers/crun/issues/1338
-    # fixed with https://github.com/containers/crun/pull/1341
-    # we should wait to crun > 1.11.2
-    - name: Downgrade crun for 1.11.1 regression
-      become: true
-      ansible.builtin.dnf:
-        name: crun < 1.11
-        allow_downgrade: true
-        state: present
-
     - name: Install os-net-config
       ansible.builtin.package:
         name: os-net-config

--- a/roles/edpm_neutron_dhcp/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/prepare.yml
@@ -38,17 +38,6 @@
     - include_role:
         name: osp.edpm.env_data
 
-    # needed due to regression in 1.11.1
-    # see https://github.com/containers/crun/issues/1338
-    # fixed with https://github.com/containers/crun/pull/1341
-    # we should wait to crun > 1.11.2
-    - name: Downgrade crun for 1.11.1 regression
-      become: true
-      ansible.builtin.dnf:
-        name: crun < 1.11
-        allow_downgrade: true
-        state: present
-
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |

--- a/roles/edpm_neutron_metadata/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_metadata/molecule/default/prepare.yml
@@ -39,17 +39,6 @@
     - ansible.builtin.include_role:
         name: osp.edpm.env_data
 
-    # needed due to regression in 1.11.1
-    # see https://github.com/containers/crun/issues/1338
-    # fixed with https://github.com/containers/crun/pull/1341
-    # we should wait to crun > 1.11.2
-    - name: Downgrade crun for 1.11.1 regression
-      become: true
-      ansible.builtin.dnf:
-        name: crun < 1.11
-        allow_downgrade: true
-        state: present
-
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |

--- a/roles/edpm_neutron_ovn/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/prepare.yml
@@ -30,17 +30,6 @@
     - ansible.builtin.include_role:
         name: osp.edpm.env_data
 
-    # needed due to regression in 1.11.1
-    # see https://github.com/containers/crun/issues/1338
-    # fixed with https://github.com/containers/crun/pull/1341
-    # we should wait to crun > 1.11.2
-    - name: Downgrade crun for 1.11.1 regression
-      become: true
-      ansible.builtin.dnf:
-        name: crun < 1.11
-        allow_downgrade: true
-        state: present
-
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |

--- a/roles/edpm_neutron_sriov/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/prepare.yml
@@ -20,14 +20,3 @@
       test_deps_extra_packages:
         - iproute
         - podman
-  tasks:
-    # needed due to regression in 1.11.1
-    # see https://github.com/containers/crun/issues/1338
-    # fixed with https://github.com/containers/crun/pull/1341
-    # we should wait to crun > 1.11.2
-    - name: Downgrade crun for 1.11.1 regression
-      become: true
-      ansible.builtin.dnf:
-        name: crun < 1.11
-        allow_downgrade: true
-        state: present

--- a/roles/edpm_ovn/molecule/default/prepare.yml
+++ b/roles/edpm_ovn/molecule/default/prepare.yml
@@ -30,17 +30,6 @@
     - ansible.builtin.include_role:
         name: osp.edpm.env_data
 
-    # needed due to regression in 1.11.1
-    # see https://github.com/containers/crun/issues/1338
-    # fixed with https://github.com/containers/crun/pull/1341
-    # we should wait to crun > 1.11.2
-    - name: Downgrade crun for 1.11.1 regression
-      become: true
-      ansible.builtin.dnf:
-        name: crun < 1.11
-        allow_downgrade: true
-        state: present
-
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |

--- a/roles/edpm_ovn/molecule/noconfig/prepare.yml
+++ b/roles/edpm_ovn/molecule/noconfig/prepare.yml
@@ -30,17 +30,6 @@
     - include_role:
         name: osp.edpm.env_data
 
-    # needed due to regression in 1.11.1
-    # see https://github.com/containers/crun/issues/1338
-    # fixed with https://github.com/containers/crun/pull/1341
-    # we should wait to crun > 1.11.2
-    - name: Downgrade crun for 1.11.1 regression
-      become: true
-      ansible.builtin.dnf:
-        name: crun < 1.11
-        allow_downgrade: true
-        state: present
-
     # The openvswitch kernel module needs to be loaded on the host
     - name: install and modprobe openvswitch
       shell: |

--- a/roles/edpm_ovn_bgp_agent/molecule/default/prepare.yml
+++ b/roles/edpm_ovn_bgp_agent/molecule/default/prepare.yml
@@ -26,17 +26,6 @@
     - ansible.builtin.include_role:
         name: osp.edpm.env_data
 
-    # needed due to regression in 1.11.1
-    # see https://github.com/containers/crun/issues/1338
-    # fixed with https://github.com/containers/crun/pull/1341
-    # we should wait to crun > 1.11.2
-    - name: Downgrade crun for 1.11.1 regression
-      become: true
-      ansible.builtin.dnf:
-        name: crun < 1.11
-        allow_downgrade: true
-        state: present
-
     # The openvswitch kernel module needs to be loaded on the host
     - name: Install and modprobe openvswitch
       shell: |


### PR DESCRIPTION
…needed"

This reverts commit 2790c02c3c6f12a2282b56f2d9ad1042c5cb9e56.

The original regression in crun ought to be fixed by https://github.com/containers/crun/releases/tag/1.11.2 