### PR TITLE
WIP: Device profile not found issue

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -30,6 +30,7 @@ edpm_network_config_tool: os-net-config
 # Packages needed by nmstate (via system-role)
 edpm_network_config_systemrole_nmstate_dependencies:
   - NetworkManager-ovs
+  - NetworkManager-wifi
 
 # seconds between retries for download tasks
 edpm_network_config_download_delay: 5


### PR DESCRIPTION
This change is to fix device profile not found issue when using os-net-config network config with
nmstate provider option.