### PR TITLE
Bumping checkout and setup-python actions

### DIFF
--- a/.github/workflows/build-collection.yaml
+++ b/.github/workflows/build-collection.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+      uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Install ansible

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -28,12 +28,12 @@ jobs:
         id: pages
         uses: actions/configure-pages@v3
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1.160.0
         with:
           ruby-version: '3.2'
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -49,8 +49,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+      uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Install ansible

--- a/.github/workflows/openstack-ansibleee-runner.yaml
+++ b/.github/workflows/openstack-ansibleee-runner.yaml
@@ -37,7 +37,7 @@ jobs:
     if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Get branch name
       id: branch-name


### PR DESCRIPTION
EOL of node 16, we ought to move to more recent versions of github actions using node 20.

checkout action was bumped to version 4
setup-python was bumped to version 5

For more information https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20