### PR TITLE
Libvirt qemu group config changes

### DIFF
--- a/roles/edpm_libvirt/meta/argument_specs.yml
+++ b/roles/edpm_libvirt/meta/argument_specs.yml
@@ -44,3 +44,7 @@ argument_specs:
         type: bool
         default: false
         description: Boolean to specify whether TLS certs are enabled.
+      edpm_nova_libvirt_qemu_group:
+        type: str
+        description: The vhost user socket directory group name.
+        default: ''

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -36,7 +36,7 @@
     - {"src": "virtnodedevd.conf", "dest": "virtnodedevd.conf"}
     - {"src": "virtproxyd.conf", "dest": "virtproxyd.conf"}
     - {"src": "virtqemud.conf", "dest": "virtqemud.conf"}
-    - {"src": "qemu.conf", "dest": "qemu.conf"}
+    - {"src": "qemu.conf.j2", "dest": "qemu.conf"}
     - {"src": "virtsecretd.conf", "dest": "virtsecretd.conf"}
   notify:
     - Restart libvirt

--- a/roles/edpm_libvirt/templates/qemu.conf.j2
+++ b/roles/edpm_libvirt/templates/qemu.conf.j2
@@ -8,3 +8,6 @@ nbd_tls = 0
 # port usage conflicts. See https://review.openstack.org/#/c/561784
 migration_port_min = 61152
 migration_port_max = 61215
+{% if edpm_nova_libvirt_qemu_group is defined%}
+group = "{{ edpm_nova_libvirt_qemu_group }}"
+{% endif %}

--- a/roles/edpm_ovs_dpdk/defaults/main.yml
+++ b/roles/edpm_ovs_dpdk/defaults/main.yml
@@ -33,3 +33,5 @@ edpm_ovs_dpdk_pmd_improvement_threshold: ""
 edpm_ovs_dpdk_pmd_rebal_interval: ""
 edpm_ovs_dpdk_vhost_postcopy_support: false
 edpm_ovs_dpdk_vhost_postcopy_ovs_options: "--mlockall=no"
+# OVN bridge datapath type
+edpm_ovn_datapath_type: "netdev"

--- a/roles/edpm_ovs_dpdk/meta/argument_specs.yml
+++ b/roles/edpm_ovs_dpdk/meta/argument_specs.yml
@@ -64,3 +64,7 @@ argument_specs:
         type: str
         default: ""
         description: OvS DPDK vhost postcopy ovs options
+      edpm_ovn_datapath_type:
+        type: str
+        default: "netdev"
+        description: OVN bridge datapath type

--- a/roles/edpm_ovs_dpdk/tasks/configure.yml
+++ b/roles/edpm_ovs_dpdk/tasks/configure.yml
@@ -196,9 +196,30 @@
       ansible.builtin.set_fact:
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(pmd_auto_lb_rebal_interval) }}"
 
+- name: OVN bridge datapath type config
+  when: edpm_ovn_datapath_type|string
+  block:
+    - name: Apply PMD cores config
+      ansible.builtin.set_fact:
+        ovn_bridge_datapath_type:
+          ovn-bridge-datapath-type: "{{ edpm_ovn_datapath_type }}"
+
+    - name: Append external_ids with ovn datapath type
+      ansible.builtin.set_fact:
+        edpm_ovs_external_ids: "{{ {} | combine(ovn_bridge_datapath_type) }}"
+
 - name: Configure OVS other_config
   ansible.builtin.shell: >
     ovs-vsctl set open . {% for key, value in edpm_ovs_other_config.items() %} other_config:{{ key }}={{ value }} {% endfor %}
   register: ovs_other_config
   changed_when: ovs_other_config.rc == 0
   failed_when: ovs_other_config.rc != 0
+  when: edpm_ovs_other_config | length > 0
+
+- name: Configure OVS external_ids
+  ansible.builtin.shell: >
+    ovs-vsctl set open . {% for key, value in edpm_ovs_external_ids.items() -%} external_ids:{{ key }}={{ value }} {% endfor %}
+  register: ovs_external_ids
+  changed_when: ovs_external_ids.rc == 0
+  failed_when: ovs_external_ids.rc != 0
+  when: edpm_ovs_external_ids | length > 0


### PR DESCRIPTION
Missing libvirt qemu group config and ovn bridge
datapath type is not updated correctly.