### PR TITLE
Add role/playbook to deploy Swift storage nodes

### DIFF
--- a/playbooks/swift.yml
+++ b/playbooks/swift.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Deploy EDPM Swift
+  hosts: all
+  strategy: linear
+  become: true
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Deploy EDPM Swift
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_swift
+      tags:
+        - edpm_swift

--- a/roles/edpm_swift/defaults/main.yml
+++ b/roles/edpm_swift/defaults/main.yml
@@ -1,0 +1,89 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of "edpm_swift"
+
+# seconds between retries for download tasks
+edpm_swift_images_download_delay: 5
+
+# number of retries for download tasks
+edpm_swift_images_download_retries: 5
+
+# Note that the src dir is in the AEE container but the
+# dest dir is on the target host
+edpm_swift_config_src: /var/lib/openstack/configs
+edpm_swift_config_dest: /var/lib/openstack/config/swift
+
+# We don't deploy the proxy service, but the image is used by some of the
+# storage services, thus defining it here too
+edpm_swift_proxy_image: "quay.io/podified-antelope-centos9/openstack-swift-proxy-server:current-podified"
+edpm_swift_account_image: "quay.io/podified-antelope-centos9/openstack-swift-account:current-podified"
+edpm_swift_container_image: "quay.io/podified-antelope-centos9/openstack-swift-container:current-podified"
+edpm_swift_object_image: "quay.io/podified-antelope-centos9/openstack-swift-object:current-podified"
+
+edpm_swift_disks: []
+
+edpm_swift_storage_volumes:
+  - /srv/node:/srv/node
+  - /dev:/dev
+  - /var/cache/swift:/var/cache/swift
+  - /var/log/containers/swift:/var/log/containers/swift
+  - /var/lib/openstack/config/swift:/var/lib/kolla/config_files/src:ro
+
+edpm_swift_account_auditor_volumes:
+  - /var/lib/kolla/config_files/swift_account_auditor.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_account_reaper_volumes:
+  - /var/lib/kolla/config_files/swift_account_reaper.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_account_replicator_volumes:
+  - /var/lib/kolla/config_files/swift_account_replicator.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_account_server_volumes:
+  - /var/lib/kolla/config_files/swift_account_server.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_container_auditor_volumes:
+  - /var/lib/kolla/config_files/swift_container_auditor.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_container_replicator_volumes:
+  - /var/lib/kolla/config_files/swift_container_replicator.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_container_server_volumes:
+  - /var/lib/kolla/config_files/swift_container_server.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_container_updater_volumes:
+  - /var/lib/kolla/config_files/swift_container_updater.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_object_auditor_volumes:
+  - /var/lib/kolla/config_files/swift_object_auditor.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_object_expirer_volumes:
+  - /var/lib/kolla/config_files/swift_object_expirer.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_object_replicator_volumes:
+  - /var/lib/kolla/config_files/swift_object_replicator.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_object_server_volumes:
+  - /var/lib/kolla/config_files/swift_object_server.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_object_updater_volumes:
+  - /var/lib/kolla/config_files/swift_object_updater.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_rsync_volumes:
+  - /var/lib/kolla/config_files/rsync.json:/var/lib/kolla/config_files/config.json:ro

--- a/roles/edpm_swift/handlers/main.yml
+++ b/roles/edpm_swift/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/roles/edpm_swift/meta/argument_specs.yml
+++ b/roles/edpm_swift/meta/argument_specs.yml
@@ -1,0 +1,7 @@
+---
+argument_specs:
+  # ./roles/edpm_swift/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_swift role.
+    description: Multiple lines description
+    options: {}

--- a/roles/edpm_swift/meta/main.yml
+++ b/roles/edpm_swift/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_swift
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_swift/molecule/default/converge.yml
+++ b/roles/edpm_swift/molecule/default/converge.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "edpm_swift"

--- a/roles/edpm_swift/molecule/default/molecule.yml
+++ b/roles/edpm_swift/molecule/default/molecule.yml
@@ -1,0 +1,28 @@
+---
+driver:
+  name: podman
+
+provisioner:
+  inventory:
+    hosts:
+      all:
+        hosts:
+          centos:
+            ansible_python_interpreter: /usr/bin/python3
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml
+
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - verify
+    - destroy
+
+verifier:
+  name: testinfra

--- a/roles/edpm_swift/molecule/default/prepare.yml
+++ b/roles/edpm_swift/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+    - role: env_data

--- a/roles/edpm_swift/tasks/configure.yml
+++ b/roles/edpm_swift/tasks/configure.yml
@@ -1,0 +1,90 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Configure swift user and group on the host
+  ansible.builtin.import_role:
+    name: edpm_users
+  vars:
+    edpm_users_users:
+      # 42445 is matching with the uid and gid created by kolla in the swift containers
+      - {"name": "swift", "uid": "42445", "gid": "42445", "shell": "/bin/sh", "comment": "swift user"}
+    edpm_users_extra_dirs: []
+  tags:
+    - edpm_users
+
+- name: Create container config dirs
+  tags:
+    - configure
+    - swift
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: "directory"
+    setype: "container_file_t"
+    owner: "{{ item.owner | default(ansible_user) }}"
+    group: "{{ item.group | default(ansible_user) }}"
+    mode: "{{ item.mode | default(omit) }}"
+  loop:
+    - {"path": "{{ edpm_swift_config_dest }}", "mode": "0755"}
+
+- name: Create persistent config dirs
+  tags:
+    - configure
+    - swift
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: "directory"
+    setype: "container_file_t"
+    owner: "{{ item.owner | default(ansible_user) }}"
+    group: "{{ item.group | default(ansible_user) }}"
+    mode: "{{ item.mode | default(omit) }}"
+  loop:
+    - {"path": "/srv/node", "mode": "0750", "owner": "swift", "group": "swift"}
+    - {"path": "/var/cache/swift", "mode": "0700", "owner": "swift", "group": "swift"}
+    - {"path": "/var/log/containers/swift", "mode": "0700", "owner": "swift", "group": "swift"}
+
+- name: Discover configmaps in {{ edpm_swift_config_src }}
+  ansible.builtin.find:
+    paths: "{{ edpm_swift_config_src }}"
+    file_type: file
+    recurse: true
+  register: edpm_swift_configmaps
+  changed_when: false
+  check_mode: false
+  delegate_to: localhost
+  become: false
+
+- name: Flatten configmaps into {{ edpm_swift_config_dest }}
+  tags:
+    - configure
+    - swift
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
+    dest: "{{ edpm_swift_config_dest }}/{{ item.path | basename }}"
+    setype: "container_file_t"
+    mode: "0644"
+  loop: "{{ edpm_swift_configmaps.files }}"
+
+- name: Extract swiftrings.tar.gz
+  become: true
+  tags:
+    - install
+    - swift
+  ansible.builtin.unarchive:
+    src: "{{ edpm_swift_config_dest }}/swiftrings.tar.gz"
+    dest: "{{ edpm_swift_config_dest }}/"
+    remote_src: true

--- a/roles/edpm_swift/tasks/disks.yml
+++ b/roles/edpm_swift/tasks/disks.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Setup Swift disks
+  become: true
+  block:
+    - name: Create partitions for Swift
+      community.general.parted:
+        device: "{{ item.device }}"
+        state: present
+        fs_type: xfs
+        number: 1
+      loop: "{{ hostvars[inventory_hostname]['edpm_swift_disks'] }}"
+
+    - name: Create Swift mountpoints
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        owner: swift
+        group: swift
+        mode: 0700
+      loop: "{{ hostvars[inventory_hostname]['edpm_swift_disks'] }}"
+
+    - name: Mount Swift filesystems
+      ansible.posix.mount:
+        src: "{{ item.device }}1"
+        path: "{{ item.path }}"
+        state: mounted
+        fstype: xfs
+      loop: "{{ hostvars[inventory_hostname]['edpm_swift_disks'] }}"

--- a/roles/edpm_swift/tasks/download_cache.yml
+++ b/roles/edpm_swift/tasks/download_cache.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Download needed container images
+  containers.podman.podman_image:
+    name: "{{ item }}"
+  loop:
+    - "{{ edpm_swift_proxy_image }}"
+    - "{{ edpm_swift_account_image }}"
+    - "{{ edpm_swift_container_image }}"
+    - "{{ edpm_swift_object_image }}"
+  become: true
+  register: edpm_swift_images_download
+  until: edpm_swift_images_download.failed == false
+  retries: "{{ edpm_swift_images_download_retries }}"
+  delay: "{{ edpm_swift_images_download_delay }}"

--- a/roles/edpm_swift/tasks/firewall.yml
+++ b/roles/edpm_swift/tasks/firewall.yml
@@ -1,0 +1,46 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Inject firewall rules for Swift
+  osp.edpm.edpm_nftables_snippet:
+    dest: /var/lib/edpm-config/firewall/swift.yaml
+    content: |
+      - rule_name: 100 swift account server
+        rule:
+          proto: tcp
+          dport: 6202
+      - rule_name: 100 swift container server
+        rule:
+          proto: tcp
+          dport: 6201
+      - rule_name: 100 swift object server
+        rule:
+          proto: tcp
+          dport: 6200
+      - rule_name: 100 swift rsync server
+        rule:
+          proto: tcp
+          dport: 873
+
+- name: Configure firewall for Swift
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_nftables
+    tasks_from: "configure.yml"
+
+- name: Apply firewall for Swift
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_nftables
+    tasks_from: "run.yml"

--- a/roles/edpm_swift/tasks/main.yml
+++ b/roles/edpm_swift/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# "edpm_swift" will search for and load any operating system variable file
+
+- name: Configure swift
+  ansible.builtin.include_tasks: configure.yml
+
+- name: Setup disks for swift
+  ansible.builtin.include_tasks: disks.yml
+
+- name: Configure firewall rules
+  ansible.builtin.include_tasks: firewall.yml
+
+- name: Run swift
+  ansible.builtin.include_tasks: run.yml

--- a/roles/edpm_swift/tasks/run.yml
+++ b/roles/edpm_swift/tasks/run.yml
@@ -1,0 +1,160 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure /usr/libexec/edpm-start-podman-container exists
+  ansible.builtin.import_role:
+    name: edpm_container_manage
+    tasks_from: shutdown.yml
+
+- name: Run swift_account_auditor container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_account_auditor
+    edpm_container_standalone_container_defs:
+      swift_account_auditor: "{{ lookup('template', 'templates/swift_account_auditor.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_account_auditor: "{{ lookup('template', 'templates/kolla_config/swift_account_auditor.yaml.j2') | from_yaml }}"
+
+- name: Run swift_account_reaper container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_account_reaper
+    edpm_container_standalone_container_defs:
+      swift_account_reaper: "{{ lookup('template', 'templates/swift_account_reaper.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_account_reaper: "{{ lookup('template', 'templates/kolla_config/swift_account_reaper.yaml.j2') | from_yaml }}"
+
+- name: Run swift_account_replicator container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_account_replicator
+    edpm_container_standalone_container_defs:
+      swift_account_replicator: "{{ lookup('template', 'templates/swift_account_replicator.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_account_replicator: "{{ lookup('template', 'templates/kolla_config/swift_account_replicator.yaml.j2') | from_yaml }}"
+
+- name: Run swift_account_server container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_account_server
+    edpm_container_standalone_container_defs:
+      swift_account_server: "{{ lookup('template', 'templates/swift_account_server.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_account_server: "{{ lookup('template', 'templates/kolla_config/swift_account_server.yaml.j2') | from_yaml }}"
+
+- name: Run swift_container_auditor container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_container_auditor
+    edpm_container_standalone_container_defs:
+      swift_container_auditor: "{{ lookup('template', 'templates/swift_container_auditor.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_container_auditor: "{{ lookup('template', 'templates/kolla_config/swift_container_auditor.yaml.j2') | from_yaml }}"
+
+- name: Run swift_container_replicator container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_container_replicator
+    edpm_container_standalone_container_defs:
+      swift_container_replicator: "{{ lookup('template', 'templates/swift_container_replicator.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_container_replicator: "{{ lookup('template', 'templates/kolla_config/swift_container_replicator.yaml.j2') | from_yaml }}"
+
+- name: Run swift_container_server container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_container_server
+    edpm_container_standalone_container_defs:
+      swift_container_server: "{{ lookup('template', 'templates/swift_container_server.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_container_server: "{{ lookup('template', 'templates/kolla_config/swift_container_server.yaml.j2') | from_yaml }}"
+
+- name: Run swift_container_updater container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_container_updater
+    edpm_container_standalone_container_defs:
+      swift_container_updater: "{{ lookup('template', 'templates/swift_container_updater.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_container_updater: "{{ lookup('template', 'templates/kolla_config/swift_container_updater.yaml.j2') | from_yaml }}"
+
+- name: Run swift_object_auditor container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_object_auditor
+    edpm_container_standalone_container_defs:
+      swift_object_auditor: "{{ lookup('template', 'templates/swift_object_auditor.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_object_auditor: "{{ lookup('template', 'templates/kolla_config/swift_object_auditor.yaml.j2') | from_yaml }}"
+
+- name: Run swift_object_expirer container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_object_expirer
+    edpm_container_standalone_container_defs:
+      swift_object_expirer: "{{ lookup('template', 'templates/swift_object_expirer.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_object_expirer: "{{ lookup('template', 'templates/kolla_config/swift_object_expirer.yaml.j2') | from_yaml }}"
+
+- name: Run swift_object_replicator container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_object_replicator
+    edpm_container_standalone_container_defs:
+      swift_object_replicator: "{{ lookup('template', 'templates/swift_object_replicator.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_object_replicator: "{{ lookup('template', 'templates/kolla_config/swift_object_replicator.yaml.j2') | from_yaml }}"
+
+- name: Run swift_object_server container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_object_server
+    edpm_container_standalone_container_defs:
+      swift_object_server: "{{ lookup('template', 'templates/swift_object_server.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_object_server: "{{ lookup('template', 'templates/kolla_config/swift_object_server.yaml.j2') | from_yaml }}"
+
+- name: Run swift_object_updater container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: swift_object_updater
+    edpm_container_standalone_container_defs:
+      swift_object_updater: "{{ lookup('template', 'templates/swift_object_updater.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      swift_object_updater: "{{ lookup('template', 'templates/kolla_config/swift_object_updater.yaml.j2') | from_yaml }}"
+
+- name: Run rsync container
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_service: rsync
+    edpm_container_standalone_container_defs:
+      rsync: "{{ lookup('template', 'templates/rsync.yaml.j2') | from_yaml }}"
+    edpm_container_standalone_kolla_config_files:
+      rsync: "{{ lookup('template', 'templates/kolla_config/rsync.yaml.j2') | from_yaml }}"

--- a/roles/edpm_swift/templates/kolla_config/rsync.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/rsync.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/rsync --daemon --no-detach --config=/etc/swift/rsyncd.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_account_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_account_auditor.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-account-auditor /etc/swift/account-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_account_reaper.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_account_reaper.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-account-reaper /etc/swift/account-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_account_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_account_replicator.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-account-replicator /etc/swift/account-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_account_server.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_account_server.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-account-server /etc/swift/account-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_container_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_container_auditor.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-container-auditor /etc/swift/container-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_container_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_container_replicator.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-container-replicator /etc/swift/container-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_container_server.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_container_server.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-container-server /etc/swift/container-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_container_updater.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_container_updater.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-container-updater /etc/swift/container-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_auditor.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-object-auditor /etc/swift/object-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_expirer.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_expirer.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-object-expirer /etc/swift/object-expirer.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_replicator.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-object-replicator /etc/swift/object-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_server.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_server.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-object-server /etc/swift/object-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_updater.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_updater.yaml.j2
@@ -1,0 +1,6 @@
+command: "/usr/bin/swift-object-updater /etc/swift/object-server.conf"
+config_files:
+  - source: /var/lib/kolla/config_files/src/*
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true

--- a/roles/edpm_swift/templates/rsync.yaml.j2
+++ b/roles/edpm_swift/templates/rsync.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_object_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: root
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_rsync_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_account_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/swift_account_auditor.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_account_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_account_auditor_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_account_reaper.yaml.j2
+++ b/roles/edpm_swift/templates/swift_account_reaper.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_account_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_account_reaper_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_account_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/swift_account_replicator.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_account_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_account_replicator_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_account_server.yaml.j2
+++ b/roles/edpm_swift/templates/swift_account_server.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_account_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_account_server_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_container_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/swift_container_auditor.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_container_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_container_auditor_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_container_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/swift_container_replicator.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_container_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_container_replicator_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_container_server.yaml.j2
+++ b/roles/edpm_swift/templates/swift_container_server.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_container_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_container_server_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_container_updater.yaml.j2
+++ b/roles/edpm_swift/templates/swift_container_updater.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_container_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_container_updater_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_object_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_auditor.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_object_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_object_auditor_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_object_expirer.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_expirer.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_proxy_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_object_expirer_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_object_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_replicator.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_object_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_object_replicator_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_object_server.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_server.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_object_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_object_server_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/templates/swift_object_updater.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_updater.yaml.j2
@@ -1,0 +1,16 @@
+start_order: 1
+image: "{{ edpm_swift_object_image }}"
+net: host
+pid: host
+cgroupns: host
+privileged: true
+user: swift
+restart: always
+volumes:
+  {% set edpm_swift_volumes = [] %}
+  {%- set edpm_swift_volumes =
+          edpm_swift_object_updater_volumes +
+          edpm_swift_storage_volumes %}
+  {{ edpm_swift_volumes }}
+environment:
+  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_swift/vars/main.yml
+++ b/roles/edpm_swift/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "edpm_swift"


### PR DESCRIPTION
This deploys and configures Swift storage backend services and adds required firewall rules. Required disks are partitioned, formatted and mounted as well.