### PR TITLE
Add rdoproject repo to get latest libvirt 10 version

### DIFF
--- a/roles/edpm_libvirt/tasks/install.yml
+++ b/roles/edpm_libvirt/tasks/install.yml
@@ -1,4 +1,11 @@
 ---
+# TODO(arxcruz): Remove this once libvirt 10 is available on centos stream
+- name: Add master repository containing libvirt 10
+  shell:
+    cmd: |
+      dnf config-manager --add-repo https://trunk.rdoproject.org/centos9-master/delorean-deps-test.repo && dnf update -y
+  become: true
+
 - name: Install libvirt packages
   tags:
     - install


### PR DESCRIPTION
There is a bug on libvirt 9.10 and libvirt 10 which fixes this bug is
not yet available. In order to workaround this situation, the rdoproject
build latest libvirt 10 version on their repo and we are adding it here
in order to fix our long standing block on edpm jobs.
I used shell to configure the repo, because I wasn't able to find in the
ansible documentation how to do so with a .repo file.
