### PR TITLE
pin libvirt to < 9.10.0

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -30,12 +30,14 @@ edpm_libvirt_services:
   - virtproxyd
   - virtqemud
   - virtsecretd
+# TODO: uncap libvirt once libvirt 10 is available
+edpm_libvirt_range: "<9.10.0"
 edpm_libvirt_packages:
   # main libvirt packages
-  - libvirt
-  - libvirt-admin
-  - libvirt-client
-  - libvirt-daemon
+  - libvirt {{edpm_libvirt_range}}
+  - libvirt-admin {{edpm_libvirt_range}}
+  - libvirt-client {{edpm_libvirt_range}}
+  - libvirt-daemon {{edpm_libvirt_range}}
   # qemu pakcages
   - qemu-kvm
   - qemu-img

--- a/roles/edpm_libvirt/meta/argument_specs.yml
+++ b/roles/edpm_libvirt/meta/argument_specs.yml
@@ -20,14 +20,18 @@ argument_specs:
           - "virtproxyd"
           - "virtqemud"
           - "virtsecretd"
+      edpm_libvirt_range:
+        type: str
+        description: The version range for libvirt package.
+        default: "<9.10.0"
       edpm_libvirt_packages:
         type: list
         description: The list of packages to install for libvirt.
         default:
-          - libvirt
-          - libvirt-admin
-          - libvirt-client
-          - libvirt-daemon
+          - libvirt {{edpm_libvirt_range}}
+          - libvirt-admin {{edpm_libvirt_range}}
+          - libvirt-client {{edpm_libvirt_range}}
+          - libvirt-daemon {{edpm_libvirt_range}}
           - qemu-kvm
           - qemu-img
           - libguestfs


### PR DESCRIPTION
This change forces an older version of libvirt to be used
as 9.10.0 is know to have a parsing bug preventing nova
form working.

A follow up PR will remove the pin once libvirt 10 is aviable in
the centos 9 repos.
