### PR TITLE
[edpm_nova]Support provider*.yaml custom config

### DIFF
--- a/roles/edpm_nova/molecule/default/test-data/provider1.yaml
+++ b/roles/edpm_nova/molecule/default/test-data/provider1.yaml
@@ -1,0 +1,8 @@
+meta:
+  schema_version: '1.0'
+providers:
+  - identification:
+      uuid: '$COMPUTE_NODE'
+    traits:
+      additional:
+        - 'CUSTOM_FOO'

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -44,6 +44,7 @@
         - "Copying /var/lib/kolla/config_files/ssh-config to /var/lib/nova/.ssh/config"
         - "Copying /var/lib/kolla/config_files/ssh-privatekey to /var/lib/nova/.ssh/ssh-privatekey"
         - "Copying /var/lib/kolla/config_files/02-nova-host-specific.conf to /etc/nova/nova.conf.d/02-nova-host-specific.conf"
+        - "Copying /var/lib/kolla/config_files/provider1.yaml to /etc/nova/provider_config/provider1.yaml"
 
     - name: slurp host specific config
       ansible.builtin.slurp:

--- a/roles/edpm_nova/templates/config.json.j2
+++ b/roles/edpm_nova/templates/config.json.j2
@@ -32,6 +32,13 @@
             "dest": "/var/lib/nova/.ssh/config",
             "owner": "nova",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/kolla/config_files/provider*.yaml",
+            "dest": "/etc/nova/provider_config/",
+            "owner": "nova",
+            "perm": "0600",
+            "optional": true
         }
     ],
     "permissions": [


### PR DESCRIPTION
The kolla config of the nova-compute container is extended to move the provider*.yaml files to /etc/nova/provider_config/

Implements: [OSPRH-2503](https://issues.redhat.com//browse/OSPRH-2503)