### PR TITLE
[FIPS] Added FIPS related tasks in `edpm_bootstrap` and `edpm_iscsid` roles

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: true
       matrix:
         tested_role:
-        - edpm_bootstrap
         - edpm_ceph_client_files
         - edpm_ceph_hci_pre
         - edpm_container_manage

--- a/playbooks/fips_status.yml
+++ b/playbooks/fips_status.yml
@@ -1,0 +1,11 @@
+---
+- name: FIPS status
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: FIPS status
+      ansible.builtin.include_role:
+        name: edpm_bootstrap
+        tasks_from: fips_status.yml

--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -44,6 +44,8 @@ edpm_bootstrap_packages_bootstrap:
   # instances without this libvirt falls back to a legacy cgroup
   # codepath that is no-longer tested or supported in rhel as of rhel 8...
   - systemd-container
+  - crypto-policies-scripts
+  - grubby
 
 edpm_bootstrap_release_version_package:
   - rhosp-release
@@ -80,3 +82,18 @@ edpm_bootstrap_command: ""
 # The path of the file that will be used as a marker when the edpm_bootstrap_command
 # has been executed on the node.
 edpm_bootstrap_command_done_file: /.bootstrap_command_done
+
+# edpm_bootstrap_fips_mode is used to check fips status or enable/disable it
+# can take on the following values:
+# enabled: Enable FIPS
+# disabled: Disable FIPS
+# check: Check the FIPS status
+# The default is `check` if the top level var `edpm_fips_mode` is not defined
+edpm_bootstrap_fips_mode: "{{ edpm_fips_mode | default('check', true) }}"
+
+# Map between `fips-mode-setup --is-enabled` exit status
+# and messages, as defined in man page fips-mode-setup(8)
+edpm_bootstrap_fips_fms_status:
+  - {exit_code: 0, state: 'enabled', message: 'FIPS is enabled'}
+  - {exit_code: 1, state: 'inconsistent', message: 'FIPS setup is inconsistent'}
+  - {exit_code: 2, state: 'disabled', message: 'FIPS is disabled'}

--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -31,6 +31,8 @@ argument_specs:
           - iproute-tc
           - ksmtuned
           - systemd-container
+          - crypto-policies-scripts
+          - grubby
         description: "List of packages that are requred to bootstrap EDPM."
 
       edpm_bootstrap_release_version_package:
@@ -101,3 +103,29 @@ argument_specs:
         description: |
           The path of the file that will be used as a marker when the edpm_bootstrap_command
           has been executed on the node.
+
+      edpm_bootstrap_fips_mode:
+        type: str
+        default: check
+        description: |
+          edpm_bootstrap_fips_mode is used to check fips status or enable/disable it
+          can take on the following values:
+          enabled: Enable FIPS
+          disabled: Disable FIPS
+          check: Check the FIPS status (this is the default)
+
+      edpm_bootstrap_fips_fms_status:
+        type: list
+        default:
+          - {exit_code: 0, message: 'FIPS is enabled'}
+          - {exit_code: 1, message: 'FIPS setup is inconsistent'}
+          - {exit_code: 2, message: 'FIPS is disabled'}
+        description: |
+          Map between `fips-mode-setup --is-enabled` exit status
+          and messages, as defined in man page fips-mode-setup(8)
+
+      edpm_bootstrap_reboot_dir:
+        type: path
+        default: /var/lib/openstack/reboot_required
+        description: |
+          Path of the reboot_required folder used by `edpm_reboot` role

--- a/roles/edpm_bootstrap/molecule/default/molecule.yml
+++ b/roles/edpm_bootstrap/molecule/default/molecule.yml
@@ -3,8 +3,6 @@ dependency:
   name: galaxy
   options:
     role-file: collections.yml
-driver:
-  name: podman
 platforms:
 - command: /sbin/init
   dockerfile: ../../../../molecule/common/Containerfile.j2
@@ -18,18 +16,25 @@ platforms:
 provisioner:
   config_options:
     defaults:
-      callbacks_enabled: profile_tasks, timer, yaml
-      interpreter_python: auto_silent
+      fact_caching: jsonfile
+      fact_caching_connection: /tmp/molecule/facts
+  env:
+    ANSIBLE_FILTER_PLUGINS: ${ANSIBLE_FILTER_PLUGINS:-/usr/share/ansible/plugins/filter}
+    ANSIBLE_LIBRARY: ${ANSIBLE_LIBRARY:-/usr/share/ansible/plugins/modules}
+    ANSIBLE_ROLES_PATH: ${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles
+    ANSIBLE_STDOUT_CALLBACK: yaml
+  inventory:
+    hosts:
+      all:
+        hosts:
+          instance:
+            ansible_host: localhost
   log: true
   name: ansible
 scenario:
   test_sequence:
-  - dependency
-  - destroy
-  - create
   - prepare
   - converge
-  - verify
-  - destroy
+  - check
 verifier:
-  name: ansible
+  name: testinfra

--- a/roles/edpm_bootstrap/molecule/default/prepare.yml
+++ b/roles/edpm_bootstrap/molecule/default/prepare.yml
@@ -23,26 +23,4 @@
       test_deps_setup_stream: true
       test_deps_edpm_packages:
           - openvswitch
-- name: Prepare container
-  hosts: instance
-  roles:
     - role: osp.edpm.env_data
-  tasks:
-    - name: Mock ovs-vswitchd service
-      community.general.ini_file:
-        path: /etc/systemd/system/ovs-vswitchd.service
-        section: Service
-        option: "{{ item.option }}"
-        value: "{{ item.value | default(omit) }}"
-        state: "{{ item.state | default(omit) }}"
-      loop:
-        - { option: 'Type', value: 'exec' }
-        - { option: 'ExecStartPre', state: 'absent' }
-        - { option: 'ExecStart', value: '/bin/true' }
-
-    - name: Mock swapon command
-      ansible.builtin.command: ln -sf /bin/echo /sbin/swapon
-
-    - name: Force systemd to reread configs
-      ansible.builtin.systemd:
-        daemon_reload: true

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -100,3 +100,7 @@
 
 - name: Configure swap
   ansible.builtin.import_tasks: swap.yml
+
+- name: FIPS tasks
+  ansible.builtin.import_tasks: fips.yml
+  when: edpm_bootstrap_fips_mode != 'check'

--- a/roles/edpm_bootstrap/tasks/fips.yml
+++ b/roles/edpm_bootstrap/tasks/fips.yml
@@ -1,0 +1,55 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check FIPS status
+  become: true
+  ansible.builtin.command: fips-mode-setup --is-enabled
+  register: _fips_mode
+  changed_when: false
+  failed_when: false
+
+- name: Change FIPS status
+  when:
+    - edpm_bootstrap_fips_mode != 'check'
+    - >
+      edpm_bootstrap_fips_mode !=
+      edpm_bootstrap_fips_fms_status |
+      selectattr('exit_code', '==', _fips_mode.rc) |
+      map(attribute='state') | first
+  block:
+    - name: Enable FIPS
+      become: true
+      ansible.builtin.command: fips-mode-setup --enable
+      register: _fms_enable
+      changed_when: _fms_enable.rc == 0
+      when: edpm_bootstrap_fips_mode == 'enabled'
+
+    - name: Disable FIPS
+      become: true
+      ansible.builtin.command: fips-mode-setup --disable
+      register: _fms_disable
+      changed_when: _fms_disable.rc == 0
+      when: edpm_bootstrap_fips_mode == 'disabled'
+
+    - name: Enforce a reboot to ensure the change of FIPS status
+      vars:
+        edpm_reboot_force_reboot: true
+      ansible.builtin.include_role:
+        name: edpm_reboot
+      when: _fms_enable.rc == 0 or _fms_disable.rc == 0
+
+    - name: Ensure that the proper FIPS status is enabled
+      ansible.builtin.include_tasks: fips_status.yml

--- a/roles/edpm_bootstrap/tasks/fips_status.yml
+++ b/roles/edpm_bootstrap/tasks/fips_status.yml
@@ -1,0 +1,54 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check FIPS status
+  become: true
+  ansible.builtin.command: fips-mode-setup --is-enabled
+  register: _fips_mode
+  changed_when: false
+  failed_when: false
+
+- name: Show FIPS status on node
+  ansible.builtin.debug:
+    msg: >
+      {{
+        edpm_bootstrap_fips_fms_status |
+        selectattr('exit_code', '==', _fips_mode.rc) |
+        map(attribute='message') | first
+      }}
+
+- name: Assert that we have the wanted status
+  when: edpm_bootstrap_fips_mode != check
+  ansible.builtin.assert:
+    that:
+      - >
+        edpm_bootstrap_fips_mode ==
+        edpm_bootstrap_fips_fms_status |
+        selectattr('exit_code', '==', _fips_mode.rc) |
+        map(attribute='state') | first
+    success_msg: >
+      The current state of FIPS is {{
+        edpm_bootstrap_fips_fms_status |
+        selectattr('exit_code', '==', _fips_mode.rc) |
+        map(attribute='state') | first
+      }} as requested.
+    fail_msg: >
+      The current state of FIPS is {{
+        edpm_bootstrap_fips_fms_status |
+        selectattr('exit_code', '==', _fips_mode.rc) |
+        map(attribute='state') | first
+      }} while the requested state was
+      {{ edpm_bootstrap_fips_mode }}

--- a/roles/edpm_iscsid/defaults/main.yml
+++ b/roles/edpm_iscsid/defaults/main.yml
@@ -38,4 +38,10 @@ edpm_iscsid_volumes:
   - /etc/target:/etc/target:z
   - /var/lib/iscsi:/var/lib/iscsi:z
 
-edpm_iscsid_chap_algs: 'SHA3-256,SHA256,SHA1,MD5'
+edpm_iscsid_chap_algs: >-
+  {{
+    'SHA3-256,SHA256' ~
+    (edpm_fips_mode |
+    default('check', true) == 'enabled') |
+    ternary('', ',SHA1,MD5')
+  }}

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -12,6 +12,11 @@
 
 # non-containerized role jobs
 - job:
+    name: edpm-ansible-molecule-edpm_bootstrap
+    parent: edpm-ansible-molecule-base
+    vars:
+      TEST_RUN: edpm_bootstrap
+- job:
     name: edpm-ansible-molecule-edpm_podman
     parent: edpm-ansible-molecule-base
     vars:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -5,6 +5,7 @@
       - podified-multinode-edpm-baremetal-pipeline
     github-check:
       jobs:
+        - edpm-ansible-molecule-edpm_bootstrap
         - edpm-ansible-molecule-edpm_podman
         - edpm-ansible-molecule-edpm_module_load
         - edpm-ansible-molecule-edpm_kernel


### PR DESCRIPTION
These tasks can be used to check the status, enable or disable FIPS on a node.
    
They rely on `fips-mode-setup` tool provided by the `crypto-policies-scripts` package.

The action is governed by the `edpm_fips_mode` variable which can assumes 3 values:
    
- `enable`, to enable FIPS
- `disable`, to disable FIPS
- `check`, to check the status of FIPS
    
It defaults to `check`.


Closes: https://issues.redhat.com/browse/OSPRH-3071