### PR TITLE
Add support for TLS to edpm_libvirt

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -56,3 +56,5 @@ edpm_libvirt_ceph_path: /var/lib/openstack/config/ceph
 
 # certs
 edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
+edpm_libvirt_tls_cert_src_dir: /var/lib/openstack/certs/libvirt
+edpm_libvirt_tls_ca_src_dir: /var/lib/openstack/cacerts/libvirt

--- a/roles/edpm_libvirt/molecule/default/collections.yml
+++ b/roles/edpm_libvirt/molecule/default/collections.yml
@@ -1,0 +1,4 @@
+
+collections:
+  - name: community.crypto
+    type: galaxy

--- a/roles/edpm_libvirt/molecule/default/converge.yml
+++ b/roles/edpm_libvirt/molecule/default/converge.yml
@@ -15,3 +15,7 @@
         - ansible_user_dir is undefined
   roles:
     - role: osp.edpm.edpm_libvirt
+      vars:
+        edpm_libvirt_tls_cert_src_dir: /tmp/pki
+        edpm_libvirt_tls_ca_src_dir: /tmp/pki
+        edpm_libvirt_tls_certs_enabled: true

--- a/roles/edpm_libvirt/molecule/default/prepare.yml
+++ b/roles/edpm_libvirt/molecule/default/prepare.yml
@@ -16,6 +16,8 @@
 
 - name: Setup DUT
   hosts: all
+  vars:
+    edpm_libvirt_tls_cert_src_dir: /tmp/pki
   pre_tasks:
     - name: set basic user fact
       set_fact:
@@ -41,12 +43,16 @@
         popd
         rm -rf repo-setup-main
 
-    # NOTE(gibi): this is done by the boostrap role in a real deployment
-    - name: Install openstack-selinux
+    - name: Install host packages
       become: true
       ansible.builtin.dnf:
-        name: "openstack-selinux"
+        name: "{{ item }}"
         state: present
+      loop:
+        # NOTE(gibi): this is done by the boostrap role in a real deployment
+        - openstack-selinux
+        # NOTE(sean-k-mooney): this is needed to generate certs for tls testing
+        - python3-cryptography
 
     - name: set /etc/localtime
       become: true
@@ -125,3 +131,74 @@
                                     'allow rwx pool=\1') | join(', ') }}
       vars:
         pools: ['vms', 'volumes', 'images']
+
+    - name: create pki temp directory
+      become: true
+      ansible.builtin.file:
+        path: "{{ edpm_libvirt_tls_cert_src_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: 0777
+
+    - name: Create private key (RSA, 4096 bits)
+      community.crypto.openssl_privatekey:
+        path: "{{ edpm_libvirt_tls_cert_src_dir }}/ca.key"
+
+    - name: Create a certificate signing request for ca
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: "{{ edpm_libvirt_tls_cert_src_dir }}/ca.key"
+        organization_name: fake-corp
+        basic_constraints:
+          - 'CA:TRUE'
+        subject_alt_name:
+          - "DNS:compute-1.example.com"
+          - "DNS:compute-1"
+          - "DNS:{{ inventory_hostname }}"
+        key_usage:
+          - keyCertSign
+      register: csr
+
+
+    - name: Create a certificate athority
+      community.crypto.x509_certificate:
+        path: "{{ edpm_libvirt_tls_cert_src_dir }}/tls-ca-bundle.pem"
+        privatekey_path: "{{ edpm_libvirt_tls_cert_src_dir }}/ca.key"
+        csr_content: "{{ csr.csr }}"
+        provider: selfsigned
+
+    - name: Create private key (RSA, 4096 bits)
+      community.crypto.openssl_privatekey:
+        path: "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key"
+
+    - name: Create a certificate signing request for libvirt server and client cert
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key"
+        organization_name: fake-corp
+        subject_alt_name:
+          - "DNS:compute-1.example.com"
+          - "DNS:compute-1"
+          - "DNS:{{ inventory_hostname }}"
+        extended_key_usage:
+          - serverAuth
+          - clientAuth
+      register: csr
+
+    - name: Sign the certificate signing request
+      community.crypto.x509_certificate:
+        path: "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt"
+        ownca_path: "{{ edpm_libvirt_tls_cert_src_dir }}/tls-ca-bundle.pem"
+        ownca_privatekey_path: "{{ edpm_libvirt_tls_cert_src_dir }}/ca.key"
+        csr_content: "{{ csr.csr }}"
+        provider: ownca
+
+    # FIXME(sean-k-mooney): this is a hack to work around the fact that we dont
+    # currently manage the hostname on the DUT via boostrap or a dedicated role
+    # in the molecule test. This is needed to ensure the hostname is resolvable
+    # when executing virsh commands. remove this when we have a proper solution
+    - name: Ensure hostname is resolvable in /etc/hosts
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "{{ ansible_default_ipv4.address | default('127.0.0.1') }} {{ ansible_fqdn }} {{ inventory_hostname }}"
+        state: present

--- a/roles/edpm_libvirt/molecule/default/test-helpers/verify_firewall.yaml
+++ b/roles/edpm_libvirt/molecule/default/test-helpers/verify_firewall.yaml
@@ -68,3 +68,33 @@
         that:
           - item | regex_search('\s+tcp dport 61152-61215 ct state new counter packets \d+ bytes \d+ accept comment\s+')
       loop: "{{ migration_chain_exists.stdout_lines }}"
+
+- name: Verify libvirt tls nftables firewall rules
+  block:
+    - name: Check if libvirt tls nftables rule exists in /etc/nftables/edpm-rules.nft
+      become: true
+      ansible.builtin.shell: grep -q "007 Allow libvirt tls" /etc/nftables/edpm-rules.nft
+      register: libvirt_tls_rule_exists
+    - name: Assert libvirt tls nftables rule exists in /etc/nftables/edpm-rules.nft
+      ansible.builtin.assert:
+        that:
+          - libvirt_tls_rule_exists.rc == 0
+        fail_msg: "libvirt tls rule does not exist in /etc/nftables/edpm-rules.nft"
+    - name: libvirt tls rule port range and protocol
+      become: true
+      ansible.builtin.shell: grep -q "EDPM_INPUT tcp dport { 16514 }" /etc/nftables/edpm-rules.nft
+      register: libvirt_tls_rule_content_exists
+    - name: Assert libvirt tls rule port range and protocol
+      ansible.builtin.assert:
+        that:
+          - libvirt_tls_rule_content_exists.rc == 0
+        fail_msg: "libvirt tls rule port range and protocol incorrect in /etc/nftables/edpm-rules.nft"
+    - name: Run nft list command and grep for libvirt tls rule in EDPM_INPUT chain
+      become: true
+      ansible.builtin.shell: nft list table inet filter | awk '/chain EDPM_INPUT {/,/}/' | grep "libvirt tls"
+      register: libvirt_tls_chain_exists
+    - name: Assert that output from grepping for libvirt tls contains the correct rule
+      assert:
+        that:
+          - item | regex_search('\s+tcp dport 16514 ct state new counter packets \d+ bytes \d+ accept comment\s+')
+      loop: "{{ libvirt_tls_chain_exists.stdout_lines }}"

--- a/roles/edpm_libvirt/molecule/default/verify.yml
+++ b/roles/edpm_libvirt/molecule/default/verify.yml
@@ -20,8 +20,6 @@
         - "/etc/libvirt"
     - name: ensure firewall is configured
       ansible.builtin.include_tasks: "test-helpers/verify_firewall.yaml"
-    - name: ensure ceph secret is configured
-      ansible.builtin.include_tasks: "test-helpers/verify_ceph_secret.yaml"
     - name: ensure systemd services are defined and functional
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_systemd_unit.yaml"
       loop:
@@ -33,6 +31,11 @@
         - { "name": "virtproxyd.service", "osp_service": false, "enabled": "enabled", "active": ["active", "inactive"] }
         - { "name": "virtqemud.service", "osp_service": false, "enabled": "enabled", "active": ["active", "inactive"] }
         - { "name": "virtsecretd.service", "osp_service": false, "enabled": "enabled", "active": ["active", "inactive"] }
+        - { "name": "libvirtd.service", "osp_service": false, "enabled": "masked", "active": ["inactive"] }
+        - { "name": "libvirtd-tcp.socket", "osp_service": false, "enabled": "masked", "active": ["inactive"] }
+        - { "name": "libvirtd-tls.socket", "osp_service": false, "enabled": "masked", "active": ["inactive"] }
+        - { "name": "virtproxyd-tcp.socket", "osp_service": false, "enabled": "masked", "active": ["inactive"] }
+
     - name: ensure libvirt.target exist and are running
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_systemd_unit.yaml"
       loop:
@@ -44,6 +47,21 @@
         database: passwd
         key: libvirt
       register: libvirt_user
+
+    - name: validate tls with virt-pki-validate
+      become: true
+      ansible.builtin.shell: "virt-pki-validate"
+      register: virt_pki_validate
+    - name: Assert that virt-pki-validate returns no errors
+      assert:
+        that:
+          - "virt_pki_validate.rc == 0"
+    - name: ensure we can connect to libvirt with virsh via tls
+      # Note we need become because the client cert is owned by root
+      become: true
+      ansible.builtin.command: "virsh -c qemu+tls://{{ inventory_hostname }}/system version"
+      register: virsh_tls
+      failed_when: virsh_tls.rc != 0
     - name: Assert that libvirt user is created with kolla uid and gid
       ansible.builtin.assert:
         that:
@@ -68,7 +86,6 @@
         - { "name": "virtsecretd-admin.socket", "osp_service": false }
         - { "name": "virtsecretd-ro.socket", "osp_service": false }
         - { "name": "virtsecretd.socket", "osp_service": false }
-
 
     - name: ensure libvirt socket activation drop-in directories exist
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_sockets_exits.yaml"
@@ -110,3 +127,6 @@
       assert:
         that:
           - "os_enabled_vtpm.stdout_lines[0] == 'os_enable_vtpm --> on'"
+
+    - name: ensure ceph secret is configured
+      ansible.builtin.include_tasks: "test-helpers/verify_ceph_secret.yaml"

--- a/roles/edpm_libvirt/molecule/vagrant/collections.yml
+++ b/roles/edpm_libvirt/molecule/vagrant/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -115,14 +115,16 @@
     - libvirt
   become: true
   loop:
-    - {"src": "/var/lib/openstack/certs/libvirt/tls.crt", "dest": "/etc/pki/libvirt/tls.crt"}
-    - {"src": "/var/lib/openstack/certs/libvirt/tls.key", "dest": "/etc/pki/libvirt/private/tls.key"}
-    - {"src": "/var/lib/openstack/cacerts/libvirt/tls-ca-bundle.pem", "dest": "/etc/pki/CA/libvirt/tls-ca-bundle.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt", "dest": "/etc/pki/libvirt/servercert.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/libvirt/private/serverkey.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt", "dest": "/etc/pki/libvirt/clientcert.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/libvirt/private/clientkey.pem"}
+    - {"src": "{{ edpm_libvirt_tls_ca_src_dir }}/tls-ca-bundle.pem", "dest": "/etc/pki/CA/cacert.pem"}
   ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     remote_src: true
-    mode: '0600'
+    mode: "0600"
     owner: "root"
     group: "root"
   when: edpm_libvirt_tls_certs_enabled

--- a/roles/edpm_libvirt/tasks/install.yml
+++ b/roles/edpm_libvirt/tasks/install.yml
@@ -11,16 +11,21 @@
   notify:
     - Restart libvirt
 
-- name: Ensure monolithic libvirt is not enabled or running
+- name: Ensure monolithic libvirt and tcp socket activation is not enabled or running
   tags:
     - install
     - libvirt
   become: true
   ansible.builtin.systemd:
-    name: "libvirtd"
+    name: "{{ item }}"
     enabled: false
     masked: true
     state: stopped
+  loop:
+    - "libvirtd"
+    - "libvirtd-tcp.socket"
+    - "libvirtd-tls.socket"
+    - "virtproxyd-tcp.socket"
 
 - name: Ensure libvirt services are enabled and running
   tags:
@@ -32,6 +37,17 @@
     enabled: true
     masked: false
   loop: "{{ edpm_libvirt_services }}"
+
+- name: Configure virtproxyd-tls.socket
+  tags:
+    - install
+    - libvirt
+  become: true
+  ansible.builtin.systemd:
+    name: "virtproxyd-tls.socket"
+    enabled: "{{ edpm_libvirt_tls_certs_enabled | default(False) | bool }}"
+    masked: "{{ edpm_libvirt_tls_certs_enabled | ternary(False, True) }}"
+    state: "{{ edpm_libvirt_tls_certs_enabled | default(False) | ternary('started', 'stopped') }}"
 
 - name: Configure socket activation for libvirt services
   tags:

--- a/roles/edpm_libvirt/tasks/post-install.yml
+++ b/roles/edpm_libvirt/tasks/post-install.yml
@@ -96,7 +96,7 @@
     - post-libvirt
   become: true
   ansible.builtin.template:
-    src: "firewall.yaml"
+    src: "firewall.yaml.j2"
     dest: "/var/lib/edpm-config/firewall/libvirt.yaml"
     mode: "0640"
 - name: Configure firewall for the libvirt

--- a/roles/edpm_libvirt/templates/firewall.yaml.j2
+++ b/roles/edpm_libvirt/templates/firewall.yaml.j2
@@ -10,3 +10,10 @@
     proto: tcp
     dport:
      - "61152-61215"
+{% if edpm_libvirt_tls_certs_enabled %}
+- rule_name: 007 Allow libvirt tls
+  rule:
+    proto: tcp
+    dport:
+     - "16514"
+{% endif %}

--- a/roles/edpm_libvirt/templates/qemu.conf.j2
+++ b/roles/edpm_libvirt/templates/qemu.conf.j2
@@ -11,3 +11,7 @@ migration_port_max = 61215
 {% if edpm_nova_libvirt_qemu_group is defined%}
 group = "{{ edpm_nova_libvirt_qemu_group }}"
 {% endif %}
+{% if edpm_libvirt_tls_certs_enabled | bool %}
+default_tls_x509_cert_dir = "/etc/pki/libvirt"
+default_tls_x509_verify = 1
+{% endif %}

--- a/roles/edpm_libvirt/templates/virtnodedevd.conf
+++ b/roles/edpm_libvirt/templates/virtnodedevd.conf
@@ -1,4 +1,3 @@
-unix_sock_group="libvirt"
 unix_sock_ro_perms="0444"
 unix_sock_rw_perms="0770"
 auth_unix_ro="none"

--- a/roles/edpm_libvirt/templates/virtproxyd.conf
+++ b/roles/edpm_libvirt/templates/virtproxyd.conf
@@ -1,6 +1,3 @@
-listen_tls=0
-listen_tcp=0
-unix_sock_group="libvirt"
 unix_sock_ro_perms="0444"
 unix_sock_rw_perms="0770"
 auth_unix_ro="none"

--- a/roles/edpm_libvirt/templates/virtqemud.conf
+++ b/roles/edpm_libvirt/templates/virtqemud.conf
@@ -1,4 +1,3 @@
-unix_sock_group="libvirt"
 unix_sock_ro_perms="0444"
 unix_sock_rw_perms="0770"
 auth_unix_ro="none"

--- a/roles/edpm_libvirt/templates/virtsecretd.conf
+++ b/roles/edpm_libvirt/templates/virtsecretd.conf
@@ -1,4 +1,3 @@
-unix_sock_group="libvirt"
 unix_sock_ro_perms="0444"
 unix_sock_rw_perms="0770"
 auth_unix_ro="none"


### PR DESCRIPTION
This change adds molecule testing for deploying libvirt
with tls. to enable this the prepare playbook is enhanced
to generate a ca and issue client and server certs to mimic
what will be generated by cert manager.

The edpm_libvirt role is updated to use the defualt locations
expect by libvirt as documented in https://libvirt.org/kbase/tlscerts.html
This is done to ensure that virsh and other clients automaticaly work
and to avoid overriding the libvirt socket activation files to use custom
values.

Closes: [OSPRH-2387](https://issues.redhat.com//browse/OSPRH-2387)
