### PR TITLE
[pre-commit] Removed pinning on `ansible-core` version used by `ansible-lint`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,6 @@ repos:
     rev: v6.22.1
     hooks:
       - id: ansible-lint
-        additional_dependencies:
-          - ansible-core>=2.14.0,<2.15.0
   - repo: https://github.com/openstack-dev/bashate.git
     rev: 2.1.1
     hooks:


### PR DESCRIPTION
`ansible-core` was pinned on version `>2.14,<2.15` but it led to failures on environments based on python 3.12