### PR TITLE
[edpm_ovn] Add support for configuring Availability zones

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -39,6 +39,7 @@ edpm_ovn_encap_type: geneve
 edpm_ovn_dbs: []
 edpm_enable_chassis_gw: false
 edpm_enable_chassis_extport: false
+edpm_ovn_availability_zones: []
 edpm_enable_hw_offload: false
 edpm_ovn_multi_rhel: false
 edpm_enable_internal_tls: false

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -31,6 +31,10 @@ argument_specs:
           Should OVN use tls for default protocol?
           If set to false, the OVN will default to tcp.
         type: bool
+      edpm_ovn_availability_zones:
+        default: []
+        description: Availability zones for the chassis
+        type: list
       edpm_ovn_bridge:
         default: br-int
         description: >

--- a/roles/edpm_ovn/molecule/availability_zones/cleanup.yml
+++ b/roles/edpm_ovn/molecule/availability_zones/cleanup.yml
@@ -1,0 +1,1 @@
+../default/cleanup.yml

--- a/roles/edpm_ovn/molecule/availability_zones/collections.yml
+++ b/roles/edpm_ovn/molecule/availability_zones/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_ovn/molecule/availability_zones/converge.yml
+++ b/roles/edpm_ovn/molecule/availability_zones/converge.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: true
+  become: true
+  tasks:
+    - include_role:
+        name: "osp.edpm.edpm_ovn"
+      vars:
+        tenant_ip: "{{ ansible_host }}"
+        edpm_ovn_dbs:
+          - "{{ ansible_host }}"
+        edpm_ovn_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"
+        edpm_ovn_availability_zones: ["az0", "az2"]

--- a/roles/edpm_ovn/molecule/availability_zones/molecule.yml
+++ b/roles/edpm_ovn/molecule/availability_zones/molecule.yml
@@ -1,0 +1,1 @@
+../default/molecule.yml

--- a/roles/edpm_ovn/molecule/availability_zones/prepare.yml
+++ b/roles/edpm_ovn/molecule/availability_zones/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/roles/edpm_ovn/molecule/availability_zones/test-data
+++ b/roles/edpm_ovn/molecule/availability_zones/test-data
@@ -1,0 +1,1 @@
+../default/test-data

--- a/roles/edpm_ovn/molecule/availability_zones/verify.yml
+++ b/roles/edpm_ovn/molecule/availability_zones/verify.yml
@@ -1,0 +1,13 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Include default tasks
+      ansible.builtin.include_tasks:
+        file: ../default/verify-tasks.yml
+
+    - name: Verify availability-zones
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open_vswitch . external_ids:ovn-cms-options
+      register: output
+      failed_when: output.stdout != "\"availability-zones=az0:az2\""

--- a/roles/edpm_ovn/tasks/cleanup.yml
+++ b/roles/edpm_ovn/tasks/cleanup.yml
@@ -43,6 +43,20 @@
     - not edpm_enable_chassis_extport | bool
     - cleanup_ovn_cms_options.rc == 0
 
+- name: Cleanup availability-zones
+  when:
+    - edpm_ovn_availability_zones | length == 0
+    - cleanup_ovn_cms_options.rc == 0
+  block:
+    - name: Filter out availability-zones from stdout when undefined
+      ansible.builtin.set_fact:
+        filtered_azs:
+          stdout: "{{ cleanup_ovn_cms_options.stdout | regex_replace('availability-zones=[^,]*' ~ ',?', '') }}"
+
+    - name: Update cleanup_ovn_cms_options with filtered azs
+      ansible.builtin.set_fact:
+        cleanup_ovn_cms_options: "{{ cleanup_ovn_cms_options | combine(filtered_azs | default({})) }}"
+
 - name: Set updated OVN CMS Options to the local OVSDB
   ansible.builtin.shell: >
     ovs-vsctl set Open_vSwitch . external_ids:ovn-cms-options={{ cleanup_ovn_cms_options.stdout }}

--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -49,6 +49,11 @@
         chassis_options: "{{ chassis_options | default([]) + ['enable-chassis-as-extport-host'] }}"
       when: edpm_enable_chassis_extport | default(false)
 
+    - name: Configure availability zones for chassis if set
+      ansible.builtin.set_fact:
+        chassis_options: "{{ chassis_options | default([]) + ['availability-zones=' + edpm_ovn_availability_zones | join(':')] }}"
+      when: edpm_ovn_availability_zones | length > 0
+
     - name: Build OVN CMS Options
       ansible.builtin.set_fact:
         ovn_cms_options:


### PR DESCRIPTION
Role var is added to configure availability zones in external-ids:ovn-cms-options.

Related-Issue: [OSPRH-5009](https://issues.redhat.com//browse/OSPRH-5009)