### PR TITLE
 Add new ssh_known_hosts.yml playbook 

### DIFF
--- a/docs/source/playbooks/ssh_known_hosts.rst
+++ b/docs/source/playbooks/ssh_known_hosts.rst
@@ -1,0 +1,6 @@
+==========================
+Playbook - ssh_known_hosts
+==========================
+
+.. literalinclude:: ../../../playbooks/ssh_known_hosts.yml
+   :language: YAML

--- a/playbooks/ssh_known_hosts.yml
+++ b/playbooks/ssh_known_hosts.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Deploy EDPM SSH Known Hosts
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  become: true
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Configure edpm_ssh_known_hosts
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_ssh_known_hosts
+      tags:
+        - edpm_ssh_known_hosts


### PR DESCRIPTION
The playbook will be run by a dedicated dataplane-operator service that
will be executed across all nodes.

Signed-off-by: James Slagle <jslagle@redhat.com>
