### PR TITLE
Remove edpm_ssh_known_hosts role from configure_os.yml

### DIFF
--- a/playbooks/configure_os.yml
+++ b/playbooks/configure_os.yml
@@ -39,11 +39,6 @@
         tasks_from: configure.yml
       tags:
         - edpm_timezone
-    - name: Configure edpm_ssh_known_hosts
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_ssh_known_hosts
-      tags:
-        - edpm_ssh_known_hosts
     - name: Configure edpm_logrotate_crond
       ansible.builtin.import_role:
         name: osp.edpm.edpm_logrotate_crond


### PR DESCRIPTION
The role can be removed from configure_os.yml once the
dataplane-operator PR merges to use the new playbook.

Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/712
Signed-off-by: James Slagle <jslagle@redhat.com>
