### PR TITLE
Add tasks to login to kube registry with a service account to edpm_podman

### DIFF
--- a/roles/edpm_podman/defaults/main.yml
+++ b/roles/edpm_podman/defaults/main.yml
@@ -94,3 +94,7 @@ edpm_podman_systemd_drop_in_dependencies: true
 edpm_podman_service_unit_name: "edpm_podman.service"
 edpm_podman_service_unit_description: "Podman API service for EDPM purposes"
 edpm_podman_socket_path: /var/lib/edpm-podman/podman.sock
+
+edpm_podman_login_kube_registry: false
+edpm_podman_kube_sa_path: /run/secrets/kubernetes.io/serviceaccount
+edpm_podman_kube_registry_url: default-route-openshift-image-registry.apps-crc.testing

--- a/roles/edpm_podman/meta/argument_specs.yml
+++ b/roles/edpm_podman/meta/argument_specs.yml
@@ -132,3 +132,20 @@ argument_specs:
       edpm_podman_socket_path:
         type: path
         default: /var/lib/edpm-podman/podman.sock
+      edpm_podman_login_kube_registry:
+        type: bool
+        default: false
+        description: >
+          Enable or disable logging into a kubernetes registry using service
+          account credentials on the ansible controller node.
+      edpm_podman_kube_sa_path:
+        type: str
+        default: /run/secrets/kubernetes.io/serviceaccount
+        description: >
+          The path to the serviceaccount directory on the ansible controller node.
+      edpm_podman_kube_registry_url:
+        type: str
+        default: default-route-openshift-image-registry.apps-crc.testing
+        description: >
+          The kubernetes registry URL that will be used for login when
+          edpm_podman_login_kube_registry is true.

--- a/roles/edpm_podman/tasks/configure.yml
+++ b/roles/edpm_podman/tasks/configure.yml
@@ -16,6 +16,9 @@
 
 - name: Import login.yml tasks
   ansible.builtin.import_tasks: login.yml
+- name: Import login-kube-registry.yml tasks
+  ansible.builtin.import_tasks: login-kube-registry.yml
+  when: edpm_podman_login_kube_registry|bool
 - name: Configure edpm_container_manage to generate systemd drop-in dependencies
   ansible.builtin.copy:
     dest: /etc/sysconfig/podman_drop_in

--- a/roles/edpm_podman/tasks/login-kube-registry.yml
+++ b/roles/edpm_podman/tasks/login-kube-registry.yml
@@ -1,0 +1,49 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Copy service account ca.crt to /etc/pki/ca-trust/source/anchors/kubernetes-ca.crt
+  become: true
+  ansible.builtin.copy:
+    src: "{{ edpm_podman_kube_sa_path }}/ca.crt"
+    dest: /etc/pki/ca-trust/source/anchors/kubernetes-ca.crt
+    mode: 0600
+  register: ca_copy
+
+- name: Run update-ca-trust
+  become: true
+  ansible.builtin.shell: update-ca-trust
+  when: ca_copy.changed|bool  # noqa: no-handler
+  changed_when: true
+
+- name: Create containers dir for authfile
+  become: true
+  ansible.builtin.file:
+    path: /root/containers
+    state: directory
+    mode: 0700
+
+- name: Perform container registry login(s) with podman to kubernetes registry
+  become: true
+  ansible.builtin.shell: >
+    podman login
+      --authfile ~/.config/containers/auth.json
+      --username={{ edpm_nodeset_name }}
+      --password={{ lookup('ansible.builtin.file', edpm_podman_kube_sa_path + '/token') }}
+      {{ edpm_podman_kube_registry_url }}
+  register: kube_registry_login_podman
+  changed_when: kube_registry_login_podman.rc == 0
+  failed_when: kube_registry_login_podman.rc != 0

--- a/roles/edpm_podman/tasks/login.yml
+++ b/roles/edpm_podman/tasks/login.yml
@@ -18,7 +18,7 @@
 - name: Perform container registry login(s) with podman
   become: true
   ansible.builtin.shell: >
-    podman login --username=$REGISTRY_USERNAME --password=$REGISTRY_PASSWORD $REGISTRY
+    podman login --authfile ~/.config/containers/auth.json --username=$REGISTRY_USERNAME --password=$REGISTRY_PASSWORD $REGISTRY
   environment:
     REGISTRY_USERNAME: "{{ lookup('dict', item.value).key }}"
     REGISTRY_PASSWORD: "{{ lookup('dict', item.value).value }}"


### PR DESCRIPTION
Adds a new tasks file, roles/edpm_podman/tasks/login-kube-registry.yml.
The tasks login to a kubernetes registry using service account
credentials that are read from a known location made available by the
service account associated with the ansible pod.

The podman login command uses
"--authfile ~/.config/containers/auth.json" to override the default
authfile location of $XDG_RUNTIME_DIR/containers/auth.json. This
override is needed since $XDG_RUNTIME_DIR is not defined when using
"become: true" with ansible, which results in the podman logins not
actually being persisted anywhere. Overriding the location also persists
the logins across reboots. The authfile override is also added to the
existing podman login task in login.yml

Signed-off-by: James Slagle <jslagle@redhat.com>
