### PR TITLE
Replace /var/tmp/edpm-ansible with $REMOTE_SOURCE_DIR

### DIFF
--- a/openstack_ansibleee/Dockerfile
+++ b/openstack_ansibleee/Dockerfile
@@ -4,7 +4,7 @@ ARG REMOTE_SOURCE=.
 ARG REMOTE_SOURCE_DIR=/var/tmp/edpm-ansible
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
-RUN cd /var/tmp/edpm-ansible && \
+RUN cd $REMOTE_SOURCE_DIR && \
     ansible-galaxy collection install -U --timeout 120 -r requirements.yml --collections-path "/usr/share/ansible/collections" && \
     ansible-galaxy collection install -U $REMOTE_SOURCE_DIR --collections-path "/usr/share/ansible/collections"
 


### PR DESCRIPTION
The variable was not used everywhere it could be used.

Signed-off-by: James Slagle <jslagle@redhat.com>
