### PR TITLE
[edpm_nova]Remove cert copy task

### DIFF
--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -120,23 +120,6 @@
     owner: nova
     group: nova
 
-- name: Copy TLS files to the compute node
-  tags:
-    - configure
-    - nova
-  become: true
-  loop:
-    - {"src": "{{ edpm_nova_certs_src }}/{{ inventory_hostname }}-tls.crt", "dest": "{{ edpm_nova_certs_dest }}/tls.crt"}
-    - {"src": "{{ edpm_nova_certs_src }}/{{ inventory_hostname }}-tls.key", "dest": "{{ edpm_nova_certs_dest }}/tls.key"}
-    - {"src": "{{ edpm_nova_cacerts_src }}/TLSCABundleFile", "dest": "{{ edpm_nova_cacerts_dest }}/TLSCABundleFile"}
-  ansible.builtin.copy:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    mode: '0600'
-    owner: nova
-    group: nova
-  when: edpm_nova_tls_certs_enabled
-
 - name: Check if compute_id exists in state_path
   tags:
     - configure


### PR DESCRIPTION
The cert management is moved to a separate role by #525 but a rebase
mistake in ca102fc reintroduced the task to the nova role.
