### PR TITLE
Add handler and tags for Swift ring updates

### DIFF
--- a/roles/edpm_swift/defaults/main.yml
+++ b/roles/edpm_swift/defaults/main.yml
@@ -87,3 +87,19 @@ edpm_swift_object_updater_volumes:
 
 edpm_swift_rsync_volumes:
   - /var/lib/kolla/config_files/rsync.json:/var/lib/kolla/config_files/config.json:ro
+
+edpm_swift_services:
+  - edpm_rsync
+  - edpm_swift_account_auditor
+  - edpm_swift_account_reaper
+  - edpm_swift_account_replicator
+  - edpm_swift_account_server
+  - edpm_swift_container_auditor
+  - edpm_swift_container_replicator
+  - edpm_swift_container_server
+  - edpm_swift_container_updater
+  - edpm_swift_object_auditor
+  - edpm_swift_object_expirer
+  - edpm_swift_object_replicator
+  - edpm_swift_object_server
+  - edpm_swift_object_updater

--- a/roles/edpm_swift/handlers/main.yml
+++ b/roles/edpm_swift/handlers/main.yml
@@ -13,3 +13,12 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+
+- name: Restart swift services
+  become: true
+  ansible.builtin.systemd:
+    name: "{{ item }}.service"
+    state: restarted
+    daemon_reload: true
+  loop: "{{ edpm_swift_services }}"
+  listen: "Restart swift"

--- a/roles/edpm_swift/tasks/configure.yml
+++ b/roles/edpm_swift/tasks/configure.yml
@@ -67,11 +67,14 @@
   check_mode: false
   delegate_to: localhost
   become: false
+  tags:
+    - swiftrings
 
 - name: Flatten configmaps into {{ edpm_swift_config_dest }}
   tags:
     - configure
     - swift
+    - swiftrings
   ansible.builtin.copy:
     src: "{{ item.path }}"
     dest: "{{ edpm_swift_config_dest }}/{{ item.path | basename }}"
@@ -84,7 +87,10 @@
   tags:
     - install
     - swift
+    - swiftrings
   ansible.builtin.unarchive:
     src: "{{ edpm_swift_config_dest }}/swiftrings.tar.gz"
     dest: "{{ edpm_swift_config_dest }}/"
     remote_src: true
+  notify:
+    - Restart swift

--- a/roles/edpm_swift/tasks/main.yml
+++ b/roles/edpm_swift/tasks/main.yml
@@ -18,13 +18,13 @@
 # "edpm_swift" will search for and load any operating system variable file
 
 - name: Configure swift
-  ansible.builtin.include_tasks: configure.yml
+  ansible.builtin.import_tasks: configure.yml
 
 - name: Setup disks for swift
-  ansible.builtin.include_tasks: disks.yml
+  ansible.builtin.import_tasks: disks.yml
 
 - name: Configure firewall rules
-  ansible.builtin.include_tasks: firewall.yml
+  ansible.builtin.import_tasks: firewall.yml
 
 - name: Run swift
-  ansible.builtin.include_tasks: run.yml
+  ansible.builtin.import_tasks: run.yml


### PR DESCRIPTION
Makes it possible to selectively apply updates to the Swift rings only, which require a service restart in this case.