### PR TITLE
Drop edpm_ssh_known_hosts role from configure_os.yml playbook

### DIFF
--- a/playbooks/configure_os.yml
+++ b/playbooks/configure_os.yml
@@ -39,11 +39,6 @@
         tasks_from: configure.yml
       tags:
         - edpm_timezone
-    - name: Configure edpm_ssh_known_hosts
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_ssh_known_hosts
-      tags:
-        - edpm_ssh_known_hosts
     - name: Configure edpm_logrotate_crond
       ansible.builtin.import_role:
         name: osp.edpm.edpm_logrotate_crond


### PR DESCRIPTION
Drop edpm_ssh_known_hosts role from configure_os.yml playbook

The role is now run from playbooks/ssh_known_hosts.yml, which is used by
the ssh-known-hosts DataPlaneService, which has been included by default
on the NodeSet since dataplane-operator commit
73064d451ea4a23cce919d47e1a866ad79506b43.

Signed-off-by: James Slagle <jslagle@redhat.com>