### PR TITLE
[edpm_nova]Remove certificate mounts when TLS enabled

### DIFF
--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -10,11 +10,6 @@
     },
     "volumes": [
         "/var/lib/openstack/config/nova:/var/lib/kolla/config_files:ro",
-{% if edpm_nova_tls_certs_enabled %}
-	"/var/lib/openstack/certs/nova/tls.crt:/etc/pki/nova/server-cert.pem:ro",
-	"/var/lib/openstack/certs/nova/tls.key:/etc/pki/nova/private/server-key.pem:ro",
-	"/var/lib/openstack/cacerts/nova/tls-ca-bundle.pem:/etc/pki/CA/cacert.pem:ro",
-{% endif %}
         "/etc/localtime:/etc/localtime:ro",
         "/lib/modules:/lib/modules:ro",
         "/dev:/dev",


### PR DESCRIPTION
The feature isn't fully implemented yet and the certificates aren't at the specified location. This means, that the ansible fails when deploying with TLS enabled.