### PR TITLE
Use FQDN as sevice hostname

### DIFF
--- a/roles/edpm_neutron_dhcp/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_dhcp/molecule/default/molecule.yml
@@ -18,6 +18,12 @@ platforms:
 provisioner:
   log: true
   name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          fake-networker-1:
+            canonical_hostname: edpm-0.localdomain
 scenario:
   test_sequence:
   - dependency
@@ -29,3 +35,5 @@ scenario:
   - destroy
 verifier:
   name: testinfra
+  options:
+    s: true

--- a/roles/edpm_neutron_dhcp/molecule/default/tests/test_neutron_dhcp.py
+++ b/roles/edpm_neutron_dhcp/molecule/default/tests/test_neutron_dhcp.py
@@ -233,3 +233,9 @@ class TestNeutronDHCP(unittest.TestCase):
             "/usr/bin/podman ps --all --format '{{ '{{' }}.Names{{ '}}' }}'"
         ).stdout
         assert dnsmasq_container_name not in all_containers
+
+    def test_service_host_is_fqdn(self):
+        assert "edpm-0.localdomain" in self.host.run(
+            "cat /var/lib/config-data/ansible-generated/"
+            "neutron-dhcp-agent/01-neutron-dhcp-agent.conf"
+        ).stdout

--- a/roles/edpm_neutron_dhcp/templates/neutron-dhcp-agent.conf.j2
+++ b/roles/edpm_neutron_dhcp/templates/neutron-dhcp-agent.conf.j2
@@ -2,6 +2,7 @@
 interface_driver = openvswitch
 ovs_use_veth = False
 state_path = {{ edpm_neutron_dhcp_agent_DEFAULT_state_path }}
+host = {{ canonical_hostname }}
 resync_interval = {{ edpm_neutron_dhcp_agent_DEFAULT_resync_interval }}
 resync_throttle = {{ edpm_neutron_dhcp_agent_DEFAULT_resync_throttle }}
 dhcp_driver = {{ edpm_neutron_dhcp_agent_DEFAULT_dhcp_driver }}

--- a/roles/edpm_neutron_ovn/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/molecule.yml
@@ -18,6 +18,12 @@ platforms:
 provisioner:
   log: true
   name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          instance:
+            canonical_hostname: edpm-0.localdomain
 scenario:
   test_sequence:
   - dependency

--- a/roles/edpm_neutron_ovn/molecule/default/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/verify.yml
@@ -22,3 +22,13 @@
     - name: Ensure that configured root helper works
       ansible.builtin.shell: |
         podman exec ovn_agent {{ edpm_neutron_ovn_agent_agent_root_helper }} sleep 0
+
+    - name: Slurp host specific config
+      ansible.builtin.slurp:
+        src: /var/lib/config-data/ansible-generated/neutron-ovn-agent/01-neutron-ovn-agent.conf
+      register: host_specific_config
+
+    - name: Assert that host is rendered into the host specific config
+      ansible.builtin.assert:
+        that:
+          - "'edpm-0.localdomain' in host_specific_config.content | b64decode"

--- a/roles/edpm_neutron_ovn/templates/neutron-ovn-agent.conf.j2
+++ b/roles/edpm_neutron_ovn/templates/neutron-ovn-agent.conf.j2
@@ -1,4 +1,5 @@
 [DEFAULT]
+host = {{ canonical_hostname }}
 debug = {{ edpm_neutron_ovn_agent_DEFAULT_debug }}
 
 [agent]

--- a/roles/edpm_neutron_sriov/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/molecule.yml
@@ -18,6 +18,12 @@ platforms:
 provisioner:
   log: true
   name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          fake-sriov-compute-1:
+            canonical_hostname: edpm-0.localdomain
 scenario:
   test_sequence:
   - dependency

--- a/roles/edpm_neutron_sriov/molecule/default/verify.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/verify.yml
@@ -58,3 +58,13 @@
     - name: Ensure that configured root helper works
       ansible.builtin.shell: |
         podman exec neutron_sriov_agent {{ edpm_neutron_sriov_agent_AGENT_root_helper }} sleep 0
+
+    - name: Slurp host specific config
+      ansible.builtin.slurp:
+        src: /var/lib/config-data/ansible-generated/neutron-sriov-agent/01-neutron-sriov-agent.conf
+      register: host_specific_config
+
+    - name: Assert that host is rendered into the host specific config
+      ansible.builtin.assert:
+        that:
+          - "'edpm-0.localdomain' in host_specific_config.content | b64decode"

--- a/roles/edpm_neutron_sriov/templates/neutron-sriov-agent.conf.j2
+++ b/roles/edpm_neutron_sriov/templates/neutron-sriov-agent.conf.j2
@@ -1,4 +1,5 @@
 [DEFAULT]
+host = {{ canonical_hostname }}
 state_path = {{ edpm_neutron_sriov_agent_DEFAULT_state_path }}
 
 [AGENT]

--- a/roles/edpm_nova/molecule/default/molecule.yml
+++ b/roles/edpm_nova/molecule/default/molecule.yml
@@ -19,6 +19,7 @@ provisioner:
         hosts:
           compute-1:
             ctlplane_ip: 10.0.0.3
+            canonical_hostname: edpm-0.localdomain
 
 verifier:
   name: ansible

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -66,6 +66,11 @@
           - "'live_migration_with_native_tls = true' in host_specific_config.content | b64decode"
           - "'live_migration_scheme = tls' in host_specific_config.content | b64decode"
 
+    - name: Assert that host is rendered into the host specific config
+      ansible.builtin.assert:
+        that:
+          - "'edpm-0.localdomain' in host_specific_config.content | b64decode"
+
     - name: Check if user exists
       ansible.builtin.getent:
         database: passwd

--- a/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
+++ b/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
@@ -1,5 +1,7 @@
 [DEFAULT]
 my_ip = {{ ctlplane_ip }}
+host = {{ canonical_hostname }}
+
 {% if edpm_nova_tls_certs_enabled | bool %}
 [libvirt]
 live_migration_with_native_tls = true

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -70,7 +70,7 @@ edpm_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 
 # Set external_id data from provided variables
 edpm_ovn_ovs_external_ids:
-  hostname: "{{ ansible_nodename }}"
+  hostname: "{{ canonical_hostname }}"
   ovn-bridge: "{{ edpm_ovn_bridge }}"
   ovn-bridge-mappings: "{{ edpm_ovn_bridge_mappings | join(',') }}"
   ovn-chassis-mac-mappings: >-

--- a/roles/edpm_ovn/molecule/default/molecule.yml
+++ b/roles/edpm_ovn/molecule/default/molecule.yml
@@ -18,6 +18,12 @@ platforms:
 provisioner:
   log: true
   name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          instance:
+            canonical_hostname: edpm-0.localdomain
 scenario:
   test_sequence:
   - dependency

--- a/roles/edpm_ovn/molecule/default/verify-tasks.yml
+++ b/roles/edpm_ovn/molecule/default/verify-tasks.yml
@@ -94,3 +94,9 @@
           - item.rc == 0
         fail_msg: "rule {{ item.item }} not loaded"
       loop: "{{ notrack_rules_loaded.results }}"
+
+- name: Verify canonical_hostname is in external_id
+  ansible.builtin.shell: >
+    /usr/bin/ovs-vsctl get open_vswitch . external_ids:hostname
+  register: output
+  failed_when: output.stdout != 'edpm-0.localdomain'

--- a/roles/edpm_ovn/molecule/noconfig/molecule.yml
+++ b/roles/edpm_ovn/molecule/noconfig/molecule.yml
@@ -18,6 +18,12 @@ platforms:
 provisioner:
   log: true
   name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          instance-noconfig:
+            canonical_hostname: edpm-0.localdomain
 scenario:
   test_sequence:
   - dependency

--- a/roles/edpm_telemetry/molecule/default/molecule.yml
+++ b/roles/edpm_telemetry/molecule/default/molecule.yml
@@ -18,6 +18,12 @@ platforms:
 provisioner:
   log: true
   name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          instance:
+            canonical_hostname: edpm-0.localdomain
 scenario:
   test_sequence:
   - dependency

--- a/roles/edpm_telemetry/molecule/default/verify.yml
+++ b/roles/edpm_telemetry/molecule/default/verify.yml
@@ -38,6 +38,8 @@
         - "Copying /var/lib/openstack/config/ceilometer.conf to /etc/ceilometer/ceilometer.conf"
         - "Copying /var/lib/openstack/config/polling.yaml to /etc/ceilometer/polling.yaml"
         - "/usr/bin/ceilometer-polling --polling-namespaces compute --logfile /dev/stdout"
+        - "Copying /var/lib/openstack/config/ceilometer-host-specific.conf to /etc/ceilometer/ceilometer.conf.d/02-ceilometer-host-specific.conf"
+
 
     - name: ensure kolla_set_configs copied the expected files and started the correct binary
       become: true
@@ -47,6 +49,7 @@
         - "Copying /var/lib/openstack/config/ceilometer.conf to /etc/ceilometer/ceilometer.conf"
         - "Copying /var/lib/openstack/config/polling.yaml to /etc/ceilometer/polling.yaml"
         - "/usr/bin/ceilometer-polling --polling-namespaces ipmi --logfile /dev/stdout"
+        - "Copying /var/lib/openstack/config/ceilometer-host-specific.conf to /etc/ceilometer/ceilometer.conf.d/02-ceilometer-host-specific.conf"
 
     - name: ensure that the correcty binary started with TLS
       become: true
@@ -55,3 +58,13 @@
       loop:
         - "Starting node_exporter"
         - "TLS is enabled"
+
+    - name: Slurp host specific config
+      ansible.builtin.slurp:
+        src: "{{ edpm_telemetry_config_dest }}/ceilometer-host-specific.conf"
+      register: host_specific_config
+
+    - name: Assert that host is rendered into the host specific config
+      ansible.builtin.assert:
+        that:
+          - "'edpm-0.localdomain' in host_specific_config.content | b64decode"

--- a/roles/edpm_telemetry/tasks/configure.yml
+++ b/roles/edpm_telemetry/tasks/configure.yml
@@ -27,6 +27,17 @@
   loop:
     - {"path": "{{ edpm_telemetry_config_dest }}"}
 
+- name: Render ceilometer config files
+  tags:
+    - edpm_telemetry
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ edpm_telemetry_config_dest }}/{{ item.dest }}"
+    setype: "container_file_t"
+    mode: "0644"
+  loop:
+    - {"src": "ceilometer-host-specific.conf.j2", "dest": "ceilometer-host-specific.conf"}
+
 - name: Configure ceilometer user and group on the host
   ansible.builtin.import_role:
     name: edpm_users

--- a/roles/edpm_telemetry/templates/ceilometer-agent-compute.json.j2
+++ b/roles/edpm_telemetry/templates/ceilometer-agent-compute.json.j2
@@ -19,6 +19,13 @@
         "owner": "ceilometer",
         "perm": "0600",
         "optional": true
+      },
+      {
+        "source": "/var/lib/openstack/config/ceilometer-host-specific.conf",
+        "dest": "/etc/ceilometer/ceilometer.conf.d/02-ceilometer-host-specific.conf",
+        "owner": "ceilometer",
+        "perm": "0600",
+        "optional": true
       }
     ]
   }

--- a/roles/edpm_telemetry/templates/ceilometer-agent-ipmi.json.j2
+++ b/roles/edpm_telemetry/templates/ceilometer-agent-ipmi.json.j2
@@ -19,6 +19,13 @@
         "owner": "ceilometer",
         "perm": "0600",
         "optional": true
+      },
+      {
+        "source": "/var/lib/openstack/config/ceilometer-host-specific.conf",
+        "dest": "/etc/ceilometer/ceilometer.conf.d/02-ceilometer-host-specific.conf",
+        "owner": "ceilometer",
+        "perm": "0600",
+        "optional": true
       }
     ]
   }

--- a/roles/edpm_telemetry/templates/ceilometer-host-specific.conf.j2
+++ b/roles/edpm_telemetry/templates/ceilometer-host-specific.conf.j2
@@ -1,0 +1,2 @@
+[DEFAULT]
+host = {{ canonical_hostname }}


### PR DESCRIPTION
The greenfield deployment sets up host FQDN via IPAM but did not change
the /etc/hostname to FQDN. This causes that libvirt will see and use
FQDN for the node names, but nova-compute uses the sort hostname
returned by socket.gethostname().

In greenfield it causes that the nova-compute host name is different
form the compute nodename. Nova works with this setup, but it will cause
confusion for the users coming from older versions where both names are
FQDN.

During adoption, when the adopted cloud does not have FQDN in the
/etc/hostname, the compute service host name will change as in 18 we are
not yet hardcoding the FQDN in the nova.conf. This results in failed
adoption.

This PR ensures the [DEFAULT]host is set to the FQDN based on the
canonical_hostname variable for all the EDPM openstack services.

This patch does not handle the adoption case where:
* the old cloud had something other than the FQDN set in the service
  host configuration
* the old cloud had a different FQDN set than what is set in the
canonical_host in the new cloud configuration

There will be a separate PR to solve the adoption case via a new pre
adoption validation role.

Fixes: [OSPRH-5197](https://issues.redhat.com//browse/OSPRH-5197)