### PR TITLE
ADD tls-e support for edpm_nova

### DIFF
--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -31,6 +31,11 @@ edpm_nova_compute_image: "quay.io/podified-antelope-centos9/openstack-nova-compu
 
 # certs
 edpm_nova_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
+# NOTE(sean-k-mooney): nova will use unix sockets for libvirt and communicate with ovs via tcp
+# so we will not need the libvirt or ovs client certs or ca. nova will communicate other services
+# via there api endpoints and will connect to rabbitmq. To support this we will need to trust
+# the general ca root cert.
+edpm_nova_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('nova') }}"
 
 # list of services to stop during adoption
 edpm_old_tripleo_compute_sevices:

--- a/roles/edpm_nova/molecule/default/collections.yml
+++ b/roles/edpm_nova/molecule/default/collections.yml
@@ -1,0 +1,4 @@
+
+collections:
+  - name: community.crypto
+    type: galaxy

--- a/roles/edpm_nova/molecule/default/converge.yml
+++ b/roles/edpm_nova/molecule/default/converge.yml
@@ -15,3 +15,5 @@
     - role: osp.edpm.edpm_nova
       vars:
         edpm_nova_config_src: "{{lookup('env', 'MOLECULE_PROJECT_DIRECTORY')}}/molecule/default/test-data"
+        edpm_nova_tls_ca_src_dir: /tmp/pki
+        edpm_nova_tls_certs_enabled: true

--- a/roles/edpm_nova/molecule/default/prepare.yml
+++ b/roles/edpm_nova/molecule/default/prepare.yml
@@ -23,6 +23,8 @@
 
 - name: Setup DUT
   hosts: all
+  vars:
+    edpm_nova_tls_ca_src_dir: /tmp/pki
   pre_tasks:
     - name: set basic user fact
       set_fact:
@@ -107,3 +109,48 @@
         owner: root
         group: root
         mode: '0655'
+
+    - name: create pki temp directory
+      become: true
+      ansible.builtin.file:
+        path: "{{ edpm_nova_tls_ca_src_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: 0777
+
+    - name: Create private key (RSA, 4096 bits)
+      community.crypto.openssl_privatekey:
+        path: "{{ edpm_nova_tls_ca_src_dir }}/ca.key"
+
+    - name: Create a certificate signing request for ca
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: "{{ edpm_nova_tls_ca_src_dir }}/ca.key"
+        organization_name: fake-corp
+        basic_constraints:
+          - 'CA:TRUE'
+        subject_alt_name:
+          - "DNS:compute-1.example.com"
+          - "DNS:compute-1"
+          - "DNS:{{ inventory_hostname }}"
+        key_usage:
+          - keyCertSign
+      register: csr
+
+    - name: Create a certificate athority
+      community.crypto.x509_certificate:
+        path: "{{ edpm_nova_tls_ca_src_dir }}/tls-ca-bundle.pem"
+        privatekey_path: "{{ edpm_nova_tls_ca_src_dir }}/ca.key"
+        csr_content: "{{ csr.csr }}"
+        provider: selfsigned
+
+    # FIXME(sean-k-mooney): this is a hack to work around the fact that we dont
+    # currently manage the hostname on the DUT via boostrap or a dedicated role
+    # in the molecule test. This is needed to ensure the hostname is resolvable
+    # when executing virsh commands. remove this when we have a proper solution
+    - name: Ensure hostname is resolvable in /etc/hosts
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "{{ ansible_default_ipv4.address | default('127.0.0.1') }} {{ ansible_fqdn }} {{ inventory_hostname }}"
+        state: present

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -6,6 +6,7 @@
   gather_facts: false
   vars:
     test_helper_dir: "../../../../molecule/test-helpers"
+    edpm_nova_tls_ca_src_dir: /tmp/pki
   tasks:
     - name: ensure expected directories exist
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_dir.yaml"
@@ -25,6 +26,9 @@
         - "/var/lib/_nova_secontext"
         - "/var/lib/nova/instances"
         - "/var/log/containers/nova"
+        # NOTE(sean-k-mooney): this directory is normaly created by the edpm_install_cert role
+        # in molecule we create it in prepare so lets just assert it exists
+        - "{{ edpm_nova_tls_ca_src_dir }}"
     - name: ensure systemd services are defined and functional
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_systemd_unit.yaml"
       loop:
@@ -55,6 +59,12 @@
       ansible.builtin.assert:
         that:
           - "'10.0.0.3' in host_specific_config.content | b64decode"
+
+    - name: Assert libvirt is configured to use tls for live migration
+      ansible.builtin.assert:
+        that:
+          - "'live_migration_with_native_tls = true' in host_specific_config.content | b64decode"
+          - "'live_migration_scheme = tls' in host_specific_config.content | b64decode"
 
     - name: Check if user exists
       ansible.builtin.getent:

--- a/roles/edpm_nova/molecule/vagrant/collections.yml
+++ b/roles/edpm_nova/molecule/vagrant/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
+++ b/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
@@ -1,2 +1,7 @@
 [DEFAULT]
 my_ip = {{ ctlplane_ip }}
+{% if edpm_nova_tls_certs_enabled | bool %}
+[libvirt]
+live_migration_with_native_tls = true
+live_migration_scheme = tls
+{% endif %}

--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -10,10 +10,12 @@
     },
     "volumes": [
         "/var/lib/openstack/config/nova:/var/lib/kolla/config_files:ro",
+{% if edpm_nova_tls_certs_enabled %}
+	"{{ edpm_nova_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro",
+{% endif %}
         "/etc/localtime:/etc/localtime:ro",
         "/lib/modules:/lib/modules:ro",
         "/dev:/dev",
-        "/run/openvswitch:/run/openvswitch",
         "/var/log/containers/nova:/var/log/containers/nova",
         "/var/lib/libvirt:/var/lib/libvirt",
         "/run/libvirt:/run/libvirt:shared",


### PR DESCRIPTION
Nova already connected to libvirt via unix socket so it does not
need the libvirt tls certs for local communcitaiton. nova does
not need to connect to remote libvirt, as a result we do not need
to provide access to the libvirt client cert.
The 02-nova-host-specific.conf.j2 template has been updated to
enable libvirt native tls for live migration when tls is enabled.

molecule test coverage is added for the above changes.

Closes: [OSPRH-5053](https://issues.redhat.com//browse/OSPRH-5053)

