### PR TITLE
Fix swift config files and permissions

### DIFF
--- a/roles/edpm_swift/tasks/disks.yml
+++ b/roles/edpm_swift/tasks/disks.yml
@@ -25,13 +25,10 @@
         number: 1
       loop: "{{ hostvars[inventory_hostname]['edpm_swift_disks'] }}"
 
-    - name: Create Swift mountpoints
-      ansible.builtin.file:
-        path: "{{ item.path }}"
-        state: directory
-        owner: swift
-        group: swift
-        mode: 0700
+    - name: Create XFS filesystem for Swift
+      community.general.filesystem:
+        fstype: xfs
+        dev: "{{ item.device }}1"
       loop: "{{ hostvars[inventory_hostname]['edpm_swift_disks'] }}"
 
     - name: Mount Swift filesystems
@@ -40,4 +37,13 @@
         path: "{{ item.path }}"
         state: mounted
         fstype: xfs
+      loop: "{{ hostvars[inventory_hostname]['edpm_swift_disks'] }}"
+
+    - name: Set Swift mountpoint permissions
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        owner: swift
+        group: swift
+        mode: 0700
       loop: "{{ hostvars[inventory_hostname]['edpm_swift_disks'] }}"

--- a/roles/edpm_swift/templates/kolla_config/swift_account_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_account_auditor.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-account-auditor /etc/swift/account-server.conf"
+command: "/usr/bin/swift-account-auditor /etc/swift/account-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*account-server*.conf
+    dest: /etc/swift/account-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_account_reaper.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_account_reaper.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-account-reaper /etc/swift/account-server.conf"
+command: "/usr/bin/swift-account-reaper /etc/swift/account-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*account-server*.conf
+    dest: /etc/swift/account-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_account_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_account_replicator.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-account-replicator /etc/swift/account-server.conf"
+command: "/usr/bin/swift-account-replicator /etc/swift/account-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*account-server*.conf
+    dest: /etc/swift/account-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_account_server.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_account_server.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-account-server /etc/swift/account-server.conf"
+command: "/usr/bin/swift-account-server /etc/swift/account-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*account-server*.conf
+    dest: /etc/swift/account-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_container_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_container_auditor.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-container-auditor /etc/swift/container-server.conf"
+command: "/usr/bin/swift-container-auditor /etc/swift/container-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*container-server*.conf
+    dest: /etc/swift/container-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_container_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_container_replicator.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-container-replicator /etc/swift/container-server.conf"
+command: "/usr/bin/swift-container-replicator /etc/swift/container-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*container-server*.conf
+    dest: /etc/swift/container-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_container_server.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_container_server.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-container-server /etc/swift/container-server.conf"
+command: "/usr/bin/swift-container-server /etc/swift/container-server.conf.d"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*container-server*.conf
+    dest: /etc/swift/container-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_container_updater.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_container_updater.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-container-updater /etc/swift/container-server.conf"
+command: "/usr/bin/swift-container-updater /etc/swift/container-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*container-server*.conf
+    dest: /etc/swift/container-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_auditor.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-object-auditor /etc/swift/object-server.conf"
+command: "/usr/bin/swift-object-auditor /etc/swift/object-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*object-server*.conf
+    dest: /etc/swift/object-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_expirer.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_expirer.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-object-expirer /etc/swift/object-expirer.conf"
+command: "/usr/bin/swift-object-expirer /etc/swift/object-expirer.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*object-expirer*.conf
+    dest: /etc/swift/object-expirer.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_replicator.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-object-replicator /etc/swift/object-server.conf"
+command: "/usr/bin/swift-object-replicator /etc/swift/object-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*object-server*.conf
+    dest: /etc/swift/object-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_server.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_server.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-object-server /etc/swift/object-server.conf"
+command: "/usr/bin/swift-object-server /etc/swift/object-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*object-server*.conf
+    dest: /etc/swift/object-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/kolla_config/swift_object_updater.yaml.j2
+++ b/roles/edpm_swift/templates/kolla_config/swift_object_updater.yaml.j2
@@ -1,6 +1,14 @@
-command: "/usr/bin/swift-object-updater /etc/swift/object-server.conf"
+command: "/usr/bin/swift-object-updater /etc/swift/object-server.conf.d/"
 config_files:
-  - source: /var/lib/kolla/config_files/src/*
+  - source: /var/lib/kolla/config_files/src/swift.conf
     dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*.ring.gz
+    dest: /etc/swift/
+    merge: true
+    preserve_properties: true
+  - source: /var/lib/kolla/config_files/src/*object-server*.conf
+    dest: /etc/swift/object-server.conf.d/
     merge: true
     preserve_properties: true

--- a/roles/edpm_swift/templates/rsync.yaml.j2
+++ b/roles/edpm_swift/templates/rsync.yaml.j2
@@ -4,7 +4,7 @@ net: host
 pid: host
 cgroupns: host
 privileged: true
-user: root
+user: swift
 restart: always
 volumes:
   {% set edpm_swift_volumes = [] %}


### PR DESCRIPTION
There were a couple of changes in swift-operator and its configuration files recently, and changes need to be applied to EDPM as well. Also fixing permissions on the created disks.