### PR TITLE
Libvirt must not trust the CA bundle

### DIFF
--- a/roles/edpm_install_certs/meta/argument_specs.yml
+++ b/roles/edpm_install_certs/meta/argument_specs.yml
@@ -4,7 +4,7 @@ argument_specs:
   main:
     short_description: The main entry point for the osp.edpm.edpm_install_certs role.
     description:
-      - Role installs the certs and keys for all services under
+      - Role installs the certs, keys, and cacert for all services under
         /var/lib/openstack/certs/{service} onto the compute nodes
       - Role installs the cacert bundles for all services under
         /var/lib/openstack/cacerts/{service} onto the compute nodes

--- a/roles/edpm_install_certs/tasks/copy_certs_and_keys.yaml
+++ b/roles/edpm_install_certs/tasks/copy_certs_and_keys.yaml
@@ -22,6 +22,7 @@
     - name: Set paths
       ansible.builtin.set_fact:
         cert_src_path: "/var/lib/openstack/certs/{{ service }}"
+        cacert_dest_path: "/var/lib/openstack/certs/{{ service }}"
         cert_dest_path: "/var/lib/openstack/certs/{{ service }}"
         key_dest_path: "/var/lib/openstack/certs/{{ service }}"
 
@@ -46,4 +47,5 @@
         group: root
       loop:
         - {"src": "{{ cert_src_path }}/{{ inventory_hostname }}-tls.crt", "dest": "{{ cert_dest_path }}/tls.crt"}
+        - {"src": "{{ cert_src_path }}/{{ inventory_hostname }}-ca.crt", "dest": "{{ cacert_dest_path }}/ca.crt"}
         - {"src": "{{ cert_src_path }}/{{ inventory_hostname }}-tls.key", "dest": "{{ key_dest_path }}/tls.key"}

--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -57,4 +57,4 @@ edpm_libvirt_ceph_path: /var/lib/openstack/config/ceph
 # certs
 edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 edpm_libvirt_tls_cert_src_dir: /var/lib/openstack/certs/libvirt
-edpm_libvirt_tls_ca_src_dir: /var/lib/openstack/cacerts/libvirt
+edpm_libvirt_tls_ca_src_dir: /var/lib/openstack/certs/libvirt

--- a/roles/edpm_libvirt/molecule/default/prepare.yml
+++ b/roles/edpm_libvirt/molecule/default/prepare.yml
@@ -162,7 +162,7 @@
 
     - name: Create a certificate athority
       community.crypto.x509_certificate:
-        path: "{{ edpm_libvirt_tls_cert_src_dir }}/tls-ca-bundle.pem"
+        path: "{{ edpm_libvirt_tls_cert_src_dir }}/ca.crt"
         privatekey_path: "{{ edpm_libvirt_tls_cert_src_dir }}/ca.key"
         csr_content: "{{ csr.csr }}"
         provider: selfsigned
@@ -187,7 +187,7 @@
     - name: Sign the certificate signing request
       community.crypto.x509_certificate:
         path: "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt"
-        ownca_path: "{{ edpm_libvirt_tls_cert_src_dir }}/tls-ca-bundle.pem"
+        ownca_path: "{{ edpm_libvirt_tls_cert_src_dir }}/ca.crt"
         ownca_privatekey_path: "{{ edpm_libvirt_tls_cert_src_dir }}/ca.key"
         csr_content: "{{ csr.csr }}"
         provider: ownca

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -119,7 +119,7 @@
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/libvirt/private/serverkey.pem"}
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt", "dest": "/etc/pki/libvirt/clientcert.pem"}
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/libvirt/private/clientkey.pem"}
-    - {"src": "{{ edpm_libvirt_tls_ca_src_dir }}/tls-ca-bundle.pem", "dest": "/etc/pki/CA/cacert.pem"}
+    - {"src": "{{ edpm_libvirt_tls_ca_src_dir }}/ca.crt", "dest": "/etc/pki/CA/cacert.pem"}
   ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"


### PR DESCRIPTION
The CA bundle includes all of the standard root CAs. Libvirt must only trust the specific CA.

Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/731