### PR TITLE
[edpm_libvirt]Make sure that /run/libvirt is relabelled

### DIFF
--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -85,7 +85,7 @@
     - libvirt
   ansible.builtin.shell: |
     set -o pipefail
-    ls -lZ /run/libvirt | grep container_file_t
+    ls -lRZ /run/libvirt | grep container_*_t
   register: run_libvirt
   failed_when: run_libvirt.rc not in [0, 1]
   changed_when: false


### PR DESCRIPTION
Previously the role only relabelled /run/libvirt if that dir itself had
wrong labels, but we need to do the relabeling also if any of the stuff
in that directory still has container_t label. During adoption we can
have a situation where /run/libvirt/common has a wrong label but
/run/libvirt has the correct one.

So this patch checks /run/libvirt recursively
