### PR TITLE
Adoption: fix stopping nova services from tripleo

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -30,6 +30,16 @@ edpm_libvirt_services:
   - virtproxyd
   - virtqemud
   - virtsecretd
+# List of services to stop during adoption
+# (container nova_virtlod is handled separetly)
+edpm_libvirt_old_tripleo_compute_sevices:
+  - tripleo_nova_libvirt.target
+  - tripleo_nova_virtlogd_wrapper.service
+  - tripleo_nova_virtnodedevd.service
+  - tripleo_nova_virtproxyd.service
+  - tripleo_nova_virtqemud.service
+  - tripleo_nova_virtsecretd.service
+  - tripleo_nova_virtstoraged.service
 # TODO: uncap libvirt once libvirt 10 is available
 edpm_libvirt_range: ""
 edpm_libvirt_packages:

--- a/roles/edpm_libvirt/meta/argument_specs.yml
+++ b/roles/edpm_libvirt/meta/argument_specs.yml
@@ -20,6 +20,18 @@ argument_specs:
           - "virtproxyd"
           - "virtqemud"
           - "virtsecretd"
+      edpm_libvirt_old_tripleo_compute_sevices:
+        type: list
+        default:
+          - tripleo_nova_libvirt.target
+          - tripleo_nova_virtlogd_wrapper.service
+          - tripleo_nova_virtnodedevd.service
+          - tripleo_nova_virtproxyd.service
+          - tripleo_nova_virtqemud.service
+          - tripleo_nova_virtsecretd.service
+          - tripleo_nova_virtstoraged.service
+        description: |
+          List of tripleo libvirt services to stop during EDPM adoption
       edpm_libvirt_range:
         type: str
         description: The version range for libvirt package.

--- a/roles/edpm_libvirt/tasks/adoption.yml
+++ b/roles/edpm_libvirt/tasks/adoption.yml
@@ -1,0 +1,32 @@
+---
+- name: Verify and stop nova_virtlogd
+  become: true
+  tags:
+    - adoption
+    - libvirt
+  block:
+    - name: Check if nova_virtlogd container exists
+      ansible.builtin.command: podman ps -a --filter name=^nova_virtlogd$ --format \{\{.Names\}\}
+      register: nova_virtlogd_status
+      failed_when: false
+      changed_when: false
+    - name: Stop nova_virtlogd containers not managed by service units
+      ansible.builtin.command: podman stop nova_virtlogd
+      failed_when: false
+      changed_when: false
+      when: nova_virtlogd_status.stdout_lines | length > 0
+
+- name: Stop and disable libvirt services
+  tags:
+    - adoption
+    - libvirt
+  become: true
+  ansible.builtin.shell: |
+    if systemctl is-active {{ item }}; then
+      systemctl disable --now {{ item }}
+      test -f /etc/systemd/system/{{ item }} || systemctl mask {{ item }}
+    fi
+  loop: "{{ edpm_libvirt_old_tripleo_compute_sevices }}"
+  failed_when: false
+  changed_when: false
+  when: edpm_libvirt_old_tripleo_compute_sevices | default([]) | length > 0

--- a/roles/edpm_libvirt/tasks/main.yml
+++ b/roles/edpm_libvirt/tasks/main.yml
@@ -14,6 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Adopt libvirt from tripleo
+  ansible.builtin.include_tasks: adoption.yml
+
 - name: Ensure libvirt user
   ansible.builtin.include_tasks: user.yml
 

--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -32,14 +32,14 @@ edpm_nova_compute_image: "quay.io/podified-antelope-centos9/openstack-nova-compu
 # certs
 edpm_nova_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 
-# list of services to stop during adoption
-edpm_old_tripleo_compute_sevices:
+# list of tripleo nova services to stop during EDPM adoption
+edpm_nova_old_tripleo_compute_sevices:
   - tripleo_nova_compute.service
-  - tripleo_nova_libvirt.target
   - tripleo_nova_migration_target.service
-  - tripleo_nova_virtlogd_wrapper.service
-  - tripleo_nova_virtnodedevd.service
-  - tripleo_nova_virtproxyd.service
-  - tripleo_nova_virtqemud.service
-  - tripleo_nova_virtsecretd.service
-  - tripleo_nova_virtstoraged.service
+  # Other control plane services, in case of all-in-one overcloud adoption
+  - tripleo_nova_api_cron.service
+  - tripleo_nova_api.service
+  - tripleo_nova_conductor.service
+  - tripleo_nova_metadata.service
+  - tripleo_nova_scheduler.service
+  - tripleo_nova_vnc_proxy.service

--- a/roles/edpm_nova/meta/argument_specs.yml
+++ b/roles/edpm_nova/meta/argument_specs.yml
@@ -37,3 +37,16 @@ argument_specs:
           This image is used to create the nova compute container
           on the compute node and generaly will be set via the container
           bundle by the dataplane operator.
+      edpm_nova_old_tripleo_compute_sevices:
+        type: list
+        default:
+          - tripleo_nova_compute.service
+          - tripleo_nova_migration_target.service
+          - tripleo_nova_api_cron.service
+          - tripleo_nova_api.service
+          - tripleo_nova_conductor.service
+          - tripleo_nova_metadata.service
+          - tripleo_nova_scheduler.service
+          - tripleo_nova_vnc_proxy.service
+        description: |
+          List of tripleo nova services to stop during EDPM adoption

--- a/roles/edpm_nova/tasks/adoption.yml
+++ b/roles/edpm_nova/tasks/adoption.yml
@@ -1,22 +1,4 @@
 ---
-
-- name: Verify and stop nova_virtlogd
-  become: true
-  tags:
-    - adoption
-    - nova
-  block:
-    - name: Check if nova_virtlogd container exists
-      ansible.builtin.command: podman ps -a --filter name=nova_virtlogd --format \{\{.Names\}\}
-      register: nova_virtlogd_status
-      failed_when: false
-      changed_when: false
-    - name: Stop nova_virtlogd containers not managed by service units
-      ansible.builtin.command: podman stop nova_virtlogd
-      failed_when: false
-      changed_when: false
-      when: nova_virtlogd_status.stdout_lines | length == 1
-
 - name: Stop and disable compute services
   tags:
     - adoption
@@ -27,7 +9,7 @@
       systemctl disable --now {{ item }}
       test -f /etc/systemd/system/{{ item }} || systemctl mask {{ item }}
     fi
-  loop: "{{ edpm_old_tripleo_compute_sevices }}"
+  loop: "{{ edpm_nova_old_tripleo_compute_sevices }}"
   failed_when: false
   changed_when: false
-  when: edpm_old_tripleo_compute_sevices | default([]) | length > 0
+  when: edpm_nova_old_tripleo_compute_sevices | default([]) | length > 0

--- a/roles/edpm_nova/tasks/main.yml
+++ b/roles/edpm_nova/tasks/main.yml
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Adoption nova from tripleo
+- name: Adopt nova from tripleo
   ansible.builtin.include_tasks: adoption.yml
 
 - name: Configure nova


### PR DESCRIPTION
Match the target container by a strict name.
Filter unrelated nova_virtlogd_wrapper container
and make the nova_virtlogd stopping condition triggering.

Move the stopping logic for nova_virtlogd_wrapper and nova_virtlogd
into the libvirt role as we need to stop these *before* we start
deploying de-containerized libvirt. While the nova role is called
after the libvirt role, so stopping the tripleo libvirt related
happens too late (libvirt has already failed).

Also stop other Nova control plane services, in case of all-in-one
overcloud adoption.

JIRA [OSPRH-2302](https://issues.redhat.com/browse/OSPRH-2302)