### PR TITLE
OVN TLS support

### DIFF
--- a/roles/edpm_install_certs/tasks/copy_ca_certs.yaml
+++ b/roles/edpm_install_certs/tasks/copy_ca_certs.yaml
@@ -37,6 +37,6 @@
       ansible.builtin.copy:
         src: "{{ cacert_src_path }}/tls-ca-bundle.pem"
         dest: "{{ cacert_dest_path }}/tls-ca-bundle.pem"
-        mode: '0600'
+        mode: '0644'
         owner: root
         group: root

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -7,7 +7,7 @@ edpm_ovn_images_download_delay: 5
 # number of retries for download tasks
 edpm_ovn_images_download_retries: 5
 
-edpm_ovn_config_src: /var/lib/openstack/configs/ovn
+edpm_ovn_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('ovn') }}"
 edpm_ovn_bridge: br-int
 edpm_ovn_bridge_mappings: ["datacentre:br-ex"]
 
@@ -61,8 +61,12 @@ edpm_ovn_controller_common_volumes:
   - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
 
 edpm_ovn_controller_tls_volumes:
-  - /etc/pki/tls/certs/:/etc/pki/tls/certs/
-  - /etc/pki/tls/private/:/etc/pki/tls/private/
+  - "/var/lib/openstack/certs/{{ edpm_service_name | default('ovn') }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_service_name | default('ovn') }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_service_name | default('ovn') }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('ovn') }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
+
+edpm_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 
 # Set external_id data from provided variables
 edpm_ovn_ovs_external_ids:

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -25,7 +25,7 @@ argument_specs:
         default: false
         description: ''
         type: bool
-      edpm_enable_internal_tls:
+      edpm_ovn_tls_enabled:
         default: false
         description: >
           Should OVN use tls for default protocol?
@@ -61,8 +61,10 @@ argument_specs:
         type: list
       edpm_ovn_controller_tls_volumes:
         default:
-          - /etc/pki/tls/certs/:/etc/pki/tls/certs/
-          - /etc/pki/tls/private/:/etc/pki/tls/private/
+          - /var/lib/openstack/certs/ovn/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z
+          - /var/lib/openstack/certs/ovn/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
+          - /var/lib/openstack/certs/ovn/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
+          - /var/lib/openstack/cacerts/ovn/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z
         description: List of TLS volumes in a mount point form.
         type: list
       edpm_ovn_dbs:

--- a/roles/edpm_ovn/templates/kolla_ovn_controller.yaml.j2
+++ b/roles/edpm_ovn/templates/kolla_ovn_controller.yaml.j2
@@ -1,4 +1,4 @@
-command: "/usr/bin/ovn-controller --pidfile --log-file unix:/run/openvswitch/db.sock {% if edpm_enable_internal_tls | bool %} -p /etc/pki/tls/private/ovn_controller.key -c /etc/pki/tls/certs/ovn_controller.crt -C {{ edpm_internal_tls_ca_file }} {% endif %}"
+command: "/usr/bin/ovn-controller --pidfile --log-file unix:/run/openvswitch/db.sock {% if edpm_ovn_tls_enabled | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% endif %}"
 permissions:
   - path: /var/log/openvswitch
     owner: root:root

--- a/roles/edpm_ovn/templates/ovn_controller.yaml.j2
+++ b/roles/edpm_ovn/templates/ovn_controller.yaml.j2
@@ -6,7 +6,7 @@ user: root
 restart: always
 depends_on:
   - openvswitch.service
-{% if edpm_ovn_cpu_set|default(false) %}
+{% if edpm_ovn_cpu_set | default(false) %}
 cpuset_cpus: "{{ edpm_ovn_cpu_set }}"
 {% endif -%}
 volumes:
@@ -14,7 +14,7 @@ volumes:
   {%- set edpm_ovn_controller_volumes =
           edpm_ovn_controller_volumes +
           edpm_ovn_controller_common_volumes %}
-  {%- if edpm_enable_internal_tls|bool -%}
+  {%- if edpm_ovn_tls_enabled | bool -%}
   {%- set edpm_ovn_controller_volumes =
          edpm_ovn_controller_volumes +
          edpm_ovn_controller_common_volumes +


### PR DESCRIPTION
Update to latest edpm TLS logic.
Use the same key/crt names as control plane for consistency.

Trust the CA bundle. Make it world readable to allow it to be mounted directly.

Expects dataplane-operator to pass edpm_service_name if it's not the default.

Jira: [OSPRH-2191](https://issues.redhat.com//browse/OSPRH-2191)