### PR TITLE
use canonical_hostname not inventory hostname for certs

### DIFF
--- a/roles/edpm_install_certs/tasks/copy_certs_and_keys.yaml
+++ b/roles/edpm_install_certs/tasks/copy_certs_and_keys.yaml
@@ -39,6 +39,8 @@
         - "{{ key_dest_path }}"
 
     - name: Copy cert and key to the compute node
+      vars:
+        basename: "{{ hostvars[inventory_hostname]['canonical_hostname'] }}"
       ansible.builtin.copy:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
@@ -46,6 +48,6 @@
         owner: root
         group: root
       loop:
-        - {"src": "{{ cert_src_path }}/{{ inventory_hostname }}-tls.crt", "dest": "{{ cert_dest_path }}/tls.crt"}
-        - {"src": "{{ cert_src_path }}/{{ inventory_hostname }}-ca.crt", "dest": "{{ cacert_dest_path }}/ca.crt"}
-        - {"src": "{{ cert_src_path }}/{{ inventory_hostname }}-tls.key", "dest": "{{ key_dest_path }}/tls.key"}
+        - {"src": "{{ cert_src_path }}/{{ basename }}-tls.crt", "dest": "{{ cert_dest_path }}/tls.crt"}
+        - {"src": "{{ cert_src_path }}/{{ basename }}-ca.crt", "dest": "{{ cacert_dest_path }}/ca.crt"}
+        - {"src": "{{ cert_src_path }}/{{ basename }}-tls.key", "dest": "{{ key_dest_path }}/tls.key"}


### PR DESCRIPTION
the tls certs are indexed by the node.HostName
when generating the invetory the inventory_hostname is
computed via strings.Split(node.HostName, ".")[0]
node.HostName is stored in the canonical_hostname field
of the host vars.

This change updates edpm_install_certs to align
to the go code by using canonical_hostname instead.

Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/778