### PR TITLE
Derive pci device_spec edpm_derive_pci_device_spec

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -24,6 +24,7 @@ jobs:
         - edpm_container_rm
         - edpm_container_standalone
         - edpm_ddp_package
+        - edpm_derive_pci_device_spec
         - edpm_download_cache
         - edpm_growvols
         - edpm_logrotate_crond

--- a/docs/source/playbooks/sriov_derive_device_spec.rst
+++ b/docs/source/playbooks/sriov_derive_device_spec.rst
@@ -1,0 +1,13 @@
+=======================================
+Playbook - sriov_derive_device_spec.yml
+=======================================
+
+Derive the pci device_spec using edpm_derive_pci_device_spec role.
+
+The user will specify the SR-IOV device_spec as a list, for this playbook
+execution.
+There will be a output conf file generated, which contains the allowed
+device_spec configmap
+
+.. literalinclude:: ../../../playbooks/sriov_derive_device_spec.yml
+   :language: YAML

--- a/docs/source/roles/role-edpm_derive_pci_device_spec.rst
+++ b/docs/source/roles/role-edpm_derive_pci_device_spec.rst
@@ -1,0 +1,26 @@
+==================================
+Role - edpm_derive_pci_device_spec
+==================================
+
+Usage
+~~~~~
+
+This Ansible role allows to do the following tasks:
+
+* Derives the config map pci device_spec
+
+* Using the user provided device_spec list and sriov-phys_dev_map,
+  derive the pci device_spec config map for a
+  nic-partitioned deployment
+
+  Here is an example of the playbook:
+
+.. code-block:: YAML
+
+    - name: "Derive the NIC partition config map of pci device_spec"
+      include_role:
+        name: "osp.edpm.edpm_derive_pci_device_spec"
+      vars:
+        edpm_derive_sriov_device_spec_list: [{"address": "0000:17:00.*", "trusted": "true"}]
+        sriov_phydev_map: ''
+        sriov_nova_conf_file: 20-sriov-nova.conf

--- a/playbooks/sriov_derive_device_spec.yml
+++ b/playbooks/sriov_derive_device_spec.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Derive sriov device_spec
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  become: true
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Run edpm_derive_pci_device_spec
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_derive_pci_device_spec
+      tags:
+        - edpm_derive_pci_device_spec

--- a/plugins/modules/edpm_derive_pci_passthrough_devicespec.py
+++ b/plugins/modules/edpm_derive_pci_passthrough_devicespec.py
@@ -1,0 +1,654 @@
+#!/usr/bin/python3
+
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+__metaclass__ = type
+
+import json
+import os
+import re
+import yaml
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: edpm_derive_pci_passthrough_devicespec
+author:
+    - OpenStack EDPM Contributors
+version_added: '1.0'
+short_description: Derive list of pci device_spec for sriov nic-partition
+notes: []
+description:
+  - This module generates the pci device_spec addr list for nova configmap,
+    when sriov nic partitioning is configured in EDPM nodes.
+    See openstack user guide for details of PCI passthrough formats.
+options:
+  sriov_device_spec_map:
+    description:
+      - List of SR-IOV device_spec
+    type: list
+    elements: dict
+    required: true
+  sriov_phydev_map:
+    description:
+      -  Comma seperated SR-IOV <-> phydev mappings
+    type: str
+    required: false
+    default: ''
+  sriov_device_spec_out_file:
+    description:
+      - ConfigMap file to be used in nic-partitioned deployment
+    type: str
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Create pci device_spec from defaults
+  edpm_derive_pci_passthrough_devicespec:
+    sriov_device_spec_map:
+      - "address" : "0000:06:00.2"
+        "truested" : "true"
+    sriov_device_spec_out_file: 20-sriov-nova.conf
+    sriov_phydev_map: 'sriov1:ens2f0np0,sriov2:ens2f1np1'
+'''
+
+RETURN = '''
+rc:
+  description:
+    - Integer for the return code
+  returned: always
+  type: int
+device_spec:
+  description:
+    - Dict of device_spec
+  type: dict
+'''
+
+PASSTHROUGH_DEVSPEC_KEY = 'device_spec'
+PCI_DEVICES_PATH = '/sys/bus/pci/devices'
+SYS_CLASS_NET_PATH = '/sys/class/net'
+
+MAX_FUNC = 0x7
+MAX_DOMAIN = 0xFFFF
+MAX_BUS = 0xFF
+MAX_SLOT = 0x1F
+ANY = '*'
+REGEX_ANY = '.*'
+
+ADD_PF_PCI_ADDRESS = 0x1
+ADD_VF_PCI_ADDRESS = 0x2
+DEL_USER_CONFIG = 0x3
+KEEP_USER_CONFIG = 0x4
+
+
+class InvalidConfigException(ValueError):
+    pass
+
+
+def get_pci_field_val(prop, maxval, hex_value):
+    """
+    Verify the pci regex
+    """
+    if prop == ANY:
+        return REGEX_ANY
+    try:
+        v = int(prop, 16)
+    except ValueError:
+        raise InvalidConfigException('Invalid PCI address specififed {!r}'.format(prop))
+    if v > maxval:
+        raise InvalidConfigException('PCI address specififed {!r} is out of range'.format(prop))
+    return hex_value % v
+
+
+def get_pciaddr_dict_from_usraddr(pci_addr):
+    """Convert PCI address in STRING format to DICT
+    (this is done for uniformity in PCI address)
+    """
+    pci_dict = {}
+    dbs, sep, func = pci_addr.partition('.')
+    pci_dict['function'] = ANY
+    if func:
+        func = func.strip()
+        pci_dict['function'] = func
+    if dbs:
+        dbs_fields = dbs.split(':')
+        if len(dbs_fields) > 3:
+            raise InvalidConfigException('Invalid PCI address specififed {!r}'.format(pci_addr))
+        # If we got a partial address like ":00.", we need to turn this
+        # into a domain of ANY, a bus of ANY, and a slot of 00. This code
+        # allows the address,bus and/or domain to be left off
+        dbs_all = [ANY] * (3 - len(dbs_fields))
+        dbs_all.extend(dbs_fields)
+        dbs_checked = [s.strip() or ANY for s in dbs_all]
+
+        ''' domain, bus, slot = dbs_checked '''
+        pci_dict['domain'], pci_dict['bus'], pci_dict['slot'] = dbs_checked
+
+    pci_dict['domain'] = get_pci_field_val(pci_dict['domain'], MAX_DOMAIN, '%04x')
+    pci_dict['slot'] = get_pci_field_val(pci_dict['slot'], MAX_SLOT, '%02x')
+    pci_dict['bus'] = get_pci_field_val(pci_dict['bus'], MAX_BUS, '%02x')
+    pci_dict['function'] = get_pci_field_val(pci_dict['function'], MAX_FUNC, '%1x')
+    return pci_dict
+
+
+def get_pci_regex_pattern(config_regex, size, maxval, hex_value):
+    """
+    Get the the pci regex based on user value
+    """
+    if config_regex in [ANY, REGEX_ANY]:
+        config_regex = "[0-9a-fA-F]{%d}" % size
+
+    try:
+        re.compile(config_regex)
+    except re.error:
+        msg = "Invalid regex pattern identified %s" % config_regex
+        raise InvalidConfigException(msg)
+    try:
+        v = int(config_regex, 16)
+    except ValueError:
+        return config_regex
+    if v > maxval:
+        msg = "Invalid pci address"
+        raise InvalidConfigException(msg)
+    return hex_value % v
+
+
+def get_user_regex_from_addrdict(addr_dict):
+    """
+    Get the the pci regex based on user dict
+    """
+    if isinstance(addr_dict, dict):
+        domain_regex = get_pci_regex_pattern(addr_dict['domain'], 4, MAX_DOMAIN, '%04x')
+        bus_regex = get_pci_regex_pattern(addr_dict['bus'], 2, MAX_BUS, '%02x')
+        slot_regex = get_pci_regex_pattern(addr_dict['slot'], 2, MAX_SLOT, '%02x')
+        function_regex = get_pci_regex_pattern(addr_dict['function'], 1, MAX_FUNC, '%1x')
+
+        user_address_regex = '%s:%s:%s.%s' % (
+            domain_regex, bus_regex, slot_regex,
+            function_regex)
+        return user_address_regex
+    else:
+        return None
+
+
+def get_pci_addr_from_ifname(ifname):
+    """Given the device name, returns the PCI address of a device
+    and returns True if the address is in a physical function.
+    """
+    dev_path = os.path.join(SYS_CLASS_NET_PATH, ifname, "device")
+    if os.path.isdir(dev_path):
+        try:
+            return (os.readlink(dev_path).strip("./"))
+        except OSError:
+            raise
+    return None
+
+
+def get_sriov_configs():
+    """
+    Read nic partitioned sriov host config
+    """
+    configs = []
+    try:
+        with open('/var/lib/os-net-config/sriov_config.yaml') as sriov_config:
+            configs = yaml.safe_load(sriov_config)
+            # Check the data type of first json decode
+    except IOError:
+        configs = []
+    return configs
+
+
+def get_sriov_nic_partition_pfs(configs):
+    pfs = []
+    for config in configs:
+        device_type = config.get('device_type', None)
+        if device_type and 'vf' in device_type:
+            device = config.get('device', None)
+            if device:
+                dev_name = device.get('name', None)
+                if dev_name and dev_name not in pfs:
+                    pfs.append(dev_name)
+    return pfs
+
+
+def get_sriov_non_nic_partition_pfs(configs):
+    all_pfs = []
+    non_nicp_pfs = []
+    nicp_pfs = get_sriov_nic_partition_pfs(configs)
+
+    for config in configs:
+        device_type = config.get('device_type', None)
+        if device_type and 'pf' in device_type:
+            name = config.get('name', None)
+            if name and name not in all_pfs:
+                all_pfs.append(name)
+    non_nicp_pfs = [x for x in all_pfs if x not in nicp_pfs]
+    return non_nicp_pfs
+
+
+def get_pci_device_info_by_ifname(pci_dir, sub_dir):
+    if not os.path.isdir(os.path.join(pci_dir, sub_dir)):
+        return None
+    try:
+        # ids located in files inside PCI devices
+        # directory are stored in hex format (0x1234 for example)
+        with open(os.path.join(pci_dir, sub_dir,
+                               'vendor')) as vendor_file:
+            vendor = vendor_file.read().strip()
+        with open(os.path.join(pci_dir, sub_dir,
+                               'device')) as product_file:
+            product = product_file.read().strip()
+        return vendor, product
+    except IOError:
+        return None
+
+
+def get_available_vf_pci_addresses_by_ifname(pf_name, allocated_pci):
+    """It gets the list of all VF's of a PF minus the VFs allocated for
+    NIC Partitioning. If the PF has 10 VFs and VFs 0,1 are allocated then
+    the PCI address of VFs from 2 to 9 along with the device info wout be returned
+    """
+    vf_pci_addresses = {}
+    pci_dir = PCI_DEVICES_PATH
+    if os.path.isdir(pci_dir):
+        for sub_dir in os.listdir(pci_dir):
+            if sub_dir in allocated_pci:
+                continue
+            pci_phyfn_dir = os.path.join(pci_dir, sub_dir, 'physfn/net')
+            if os.path.isdir(pci_phyfn_dir):
+                phyfn_dirs = os.listdir(pci_phyfn_dir)
+                for phyfn in phyfn_dirs:
+                    if phyfn in pf_name:
+                        if phyfn not in vf_pci_addresses:
+                            vf_pci_addresses[phyfn] = [sub_dir]
+                        else:
+                            vf_pci_addresses[phyfn].append(sub_dir)
+    return vf_pci_addresses
+
+
+def get_allocated_pci_addresses(configs):
+    """ Get host allocated PCI addresses
+    """
+    alloc_pci_info = []
+    for config in configs:
+        pci = config.get('pci_address', None)
+        if pci:
+            alloc_pci_info.append(pci)
+    return alloc_pci_info
+
+
+def get_pci_passthrough_devicespec(user_config, pf, pci_addresses):
+    """ Replace devname in user_config with pci addresses
+    """
+    pci_passthrough_list = []
+
+    for pci in pci_addresses:
+        pci_passthrough = dict(user_config)
+        pci_passthrough['address'] = str(pci)
+
+        # devname and address fields can't co exist
+        if 'devname' in pci_passthrough:
+            del pci_passthrough['devname']
+
+        pci_passthrough_list.append(pci_passthrough)
+    return pci_passthrough_list
+
+
+def match_pf_details(user_config, pf_name, is_non_nic_pf):
+    """Decide the action for devicespec_pci_addr, based on user config
+
+    :param user_configs: THT param NovaPCIPassthrough
+    :param pf_name: Interface/device name (str)
+    :param is_non_nic_pf: Indicates whether the PF is noc-partitioned or not
+    :return: Return the actions to be done, based on match criteria
+    """
+
+    # get the vendor and product id of the PF and VF
+    pf_path = os.path.join(SYS_CLASS_NET_PATH, pf_name, "device")
+    vendor, vf_product = get_pci_device_info_by_ifname(pf_path, 'virtfn0')
+    vendor, pf_product = get_pci_device_info_by_ifname(pf_path, '')
+
+    if ('product_id' not in user_config
+            or vf_product[-4:] == user_config['product_id'][-4:]):
+        if is_non_nic_pf:
+            # If NON NIC Part PF matches, then add the complete device
+            return ADD_PF_PCI_ADDRESS
+        else:
+            """ In case of NIC Partitioning PF, add the VFs only (excluding NIC Part VFs)
+                when the product id is not given or product_id matches that of VF
+            """
+            return ADD_VF_PCI_ADDRESS
+    elif ('product_id' not in user_config
+          or pf_product[-4:] == user_config['product_id'][-4:]):
+        if is_non_nic_pf:
+            # If product id of NON NIC Part VF matches, then add the complete device
+            return ADD_PF_PCI_ADDRESS
+        else:
+            """ When the user_config address matches that of the NIC Partitioned PF,
+                the PF must be removed from the user_config. So return the status such
+                that the caller ignores this user_config if this user_config is very
+                specific to the NIC Partitioned PF
+            """
+            return DEL_USER_CONFIG
+    else:
+        """ The Product ID neither belongs to VF nor PF, simply ignore matching
+        """
+        return KEEP_USER_CONFIG
+
+
+# +------------+-----------------------+---------------------------+-------------------+
+# |   USER     |     product_id        |       product_id          |  Product ID       |
+# |   CONFIG   |     is VF             |       is PF               |  NOT mentioned    |
+# +------------+-----------------------+---------------------------+-------------------+
+# |   PCI addr |                       |                           |                   |
+# |   is VF    |     Matching VF       |       INVALID             |  add only VFs     |
+# |            |                       |                           |                   |
+# |            |                       |                           |                   |
+# +------------+-----------------------+---------------------------+-------------------+
+# |            |                       |                           |                   |
+# |   PCI addr |     ALL VFs of this   |       Matching PFs        | Add both PF and   |
+# |   is PF    |     addr -            |      - NIC Part PFs       | available VFs     |
+# |            |     NIC Part VFs      |                           |                   |
+# |            |                       |                           |                   |
+# +------------+-----------------------+---------------------------+-------------------+
+# |            |                       |                           |                   |
+# |  PCI addr  |     All matching      |       All matching        |  INVALID CASE     |
+# |     not    |     VFs               |       PFs - NIC Part PF   |                   |
+# |  specified |     NIC Part VFs      |                           |                   |
+# |            |                       |                           |                   |
+# +------------+-----------------------+---------------------------+-------------------+
+def get_passthrough_config(user_config, pf_name,
+                           allocated_pci, is_non_nic_pf):
+    """Handle all variations of user specified pci addr format
+
+    Arrive at the address fields of the devicespec. Check the address fields of
+    the pci.passthrough_devicespec configuration option, validating the address fields.
+
+    :param user_configs: THT param NovaPCIPassthrough
+    :param pf_name: Interface/device name (str)
+    :param allocated_pci: List of VFs (for nic-partitioned PF), which are used by host
+    :param is_non_nic_pf: Indicates whether the PF is non-partitioned or not
+    :return: pci_passthrough: Derived config list
+    :return del_user_config: Flag to state if the user_config is to be deleted or not
+
+    Example format for user_config:
+    | [pci] in standard string format
+    | passthrough_devicespec = {"address":"*:0a:00.*",
+                          "physical_network":"physnet1"}
+    | passthrough_devicespec = {"address": {"domain": ".*",
+                                       "bus": "02",
+                                       "slot": "01",
+                                       "function": "[0-2]"},
+                            "physical_network":"net1"}
+    """
+    sel_addr = []
+    pci_passthrough = []
+    del_user_config = False
+
+    """ Get the regex of the address fields """
+    if 'address' in user_config:
+        if isinstance(user_config['address'], dict):
+            addr_dict = user_config['address']
+        elif isinstance(user_config['address'], str):
+            addr_dict = get_pciaddr_dict_from_usraddr(user_config['address'])
+        user_address_pattern = get_user_regex_from_addrdict(addr_dict)
+    else:
+        user_address_pattern = ("[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:"
+                                "[0-9a-fA-F]{2}.[0-7]")
+
+    """ If address mentioned in user_config is PF, then get all VFs belonging to that PF
+    """
+    available_vfs = get_available_vf_pci_addresses_by_ifname(pf_name, allocated_pci)
+
+    # get the pci address of the PF
+    parent_pci_address = get_pci_addr_from_ifname(pf_name)
+    user_address_regex = re.compile(user_address_pattern)
+
+    # Match the user_config address with the PF's address
+    if user_address_regex.match(parent_pci_address):
+        match_id = match_pf_details(user_config, pf_name, is_non_nic_pf)
+        """ if the address matches and there is no mismatch in
+        product id's of PF, then add the PF's provided its not a
+        NIC Partitioning PF
+        """
+        if match_id == ADD_PF_PCI_ADDRESS:
+            sel_addr.append(parent_pci_address)
+        elif match_id == ADD_VF_PCI_ADDRESS:
+            if pf_name in available_vfs:
+                for vf_addr in available_vfs[pf_name]:
+                    sel_addr.append(vf_addr)
+            if not sel_addr:
+                del_user_config = True
+        elif match_id == DEL_USER_CONFIG:
+            del_user_config = True
+
+        """ Match the user_config address with the VF's address
+        A Regex of addresses could match both the VF and PF's.
+        If it matches the PF, all available VFs would be included anyway,
+        so it will be inclusive even if the address matches the VFs of the same PF
+        Also if product id is specified, it must match that of the VF's.
+        If product id is not mentioned in user_config, its assumed to have
+        matched and is left to address matching for derived configuration.
+        If Address is not mentioned, then all available VF's (excluding NIC partitioned VFs)
+        with the matching product id shall be added to the derived configuration.
+        """
+    else:
+        pf_path = os.path.join(SYS_CLASS_NET_PATH, pf_name, "device")
+        vendor, vf_product = get_pci_device_info_by_ifname(pf_path, 'virtfn0')
+        if (('product_id' not in user_config or user_config['product_id'][-4:] == vf_product[-4:])
+                and pf_name in available_vfs):
+            for vf_addr in available_vfs[pf_name]:
+                user_address_regex = re.compile(user_address_pattern)
+                if user_address_regex.match(vf_addr):
+                    sel_addr.append(vf_addr)
+            if not sel_addr:
+                for vf_addr in allocated_pci:
+                    if user_address_regex.match(str(vf_addr)):
+                        """ When the user_config address matches that of the NIC Partitioned VF,
+                        the VF must be removed from the user_config. So return the status such
+                        that the caller ignores this user_config if this user_config is very
+                        specific to the NIC Partitioned VF. If the user_config resulted in the
+                        derivations of other configurations, the derived configuration shall
+                        replace the original user_config.
+                        """
+                        del_user_config = True
+
+    if sel_addr:
+        pci_passthrough = get_pci_passthrough_devicespec(
+            user_config, pf_name, sel_addr)
+    return pci_passthrough, del_user_config
+
+
+def get_passthrough_config_for_all_pf(user_config,
+                                      system_configs,
+                                      allocated_pci):
+    """
+    For each user_config, do the matching for NIC Partitioning PFs/VFs
+    """
+    derived_config = []
+    nic_partition_pfs = get_sriov_nic_partition_pfs(system_configs)
+    non_nic_partition_pfs = get_sriov_non_nic_partition_pfs(system_configs)
+    del_user_config = False
+
+    for pf in nic_partition_pfs:
+        passthrough_tmp, status = get_passthrough_config(
+            user_config, pf, allocated_pci, False)
+        del_user_config = del_user_config or status
+        if passthrough_tmp:
+            derived_config.extend(passthrough_tmp)
+
+    """
+    If there is no config added from NIC Part nics, then skip parsing the
+    NON NIC Partitioned PFs.
+    """
+    if (derived_config or del_user_config):
+        for pf in non_nic_partition_pfs:
+            passthrough_tmp, status = get_passthrough_config(
+                user_config, pf, allocated_pci, True)
+            derived_config.extend(passthrough_tmp)
+
+    if derived_config:
+        return derived_config, False
+    else:
+        return derived_config, del_user_config
+
+
+def get_pf_name_from_phy_network(physical_network, phys_map=None):
+    # Read sriov phydev mapping
+    if phys_map and isinstance(phys_map, str):
+        # Need to check if it startswith(valid_spec)
+        phy = phys_map.strip()
+        map = re.split(',', phy)
+        for i in map:
+            net_name, nic_name = i.split(':')
+            if net_name == physical_network:
+                return nic_name
+    return None
+
+
+def generate_combined_configuration(user_configs, system_configs,
+                                    phys_dev_map=None):
+    """Derived configuration = user_config - system_configs
+
+    Identify the user_defined configuration that overlaps with the
+    NIC Partitioned VFs and remove those VFs from the derived configuration
+    In case of no overlap, the user defined configuration shall be used
+    as it is.
+    :param user_configs: device_spec list from nova conf
+    :param system_configs: Derived from sriov-mapping.yaml
+    :param phys_dev_map: Sriov physical device mannping
+    :return user_config_copy: Any non-nic partinioned cfg will be returned in this list
+    :return derived_config: All nic partinioned cfg will be returned after derivation in this list
+    """
+
+    user_config_copy = []
+    derived_config = []
+
+    allocated_pci = get_allocated_pci_addresses(system_configs)
+    nic_partition_pfs = get_sriov_nic_partition_pfs(system_configs)
+
+    for user_config in user_configs:
+        if 'address' in user_config and 'devname' in user_config:
+            msg = f"Both devname and address can't be present in {PASSTHROUGH_DEVSPEC_KEY}"
+            raise InvalidConfigException(msg)
+
+        keys = ['address', 'product_id', 'devname']
+        if not any(k in user_config for k in keys):
+            # address or product_id or devname not present in user_config
+            pf = get_pf_name_from_phy_network(user_config['physical_network'], phys_dev_map)
+            user_config['address'] = get_pci_addr_from_ifname(pf)
+
+        if 'devname' in user_config:
+            if user_config['devname'] in nic_partition_pfs:
+                user_config['address'] = get_pci_addr_from_ifname(user_config['devname'])
+                del user_config['devname']
+            else:
+                user_config_copy.append(user_config)
+                continue
+        if ('address' in user_config
+                or 'product_id' in user_config):
+            passthrough_tmp, del_user_config = get_passthrough_config_for_all_pf(
+                user_config, system_configs, allocated_pci)
+
+            """ If del_user_config is set, do not add to derived_config or
+                user_config_copy
+            """
+            if not del_user_config:
+                if passthrough_tmp:
+                    derived_config.extend(passthrough_tmp)
+                else:
+                    user_config_copy.append(user_config)
+        else:
+            user_config_copy.append(user_config)
+    return (user_config_copy, derived_config)
+
+
+def _run_derive_pci(user_configs,
+                    sriov_nova_conf_file,
+                    sriov_phydev_map=None):
+    pci_passthrough = {}
+    system_configs = get_sriov_configs()
+    changed = False
+
+    # Check if user config list is valid
+    if not isinstance(user_configs, list):
+        raise InvalidConfigException('user_config specified is not a list {!r}'.format(user_configs))
+
+    user_config_copy, derived = generate_combined_configuration(
+        user_configs, system_configs, sriov_phydev_map)
+
+    """ If the derivation does not bring in any changes, the user_config_copy list
+        and user_configs shall be same. The pci_passthrough_devspec
+        shall be updated only when there is a change needed due to NIC Partition
+    """
+    if user_config_copy != user_configs:
+        print("NOTE: user_configs is updated, use this as nova confgmap")
+        pci_passthrough['device_spec'] = (user_config_copy + derived)
+        with open(sriov_nova_conf_file, 'w') as pci_file:
+            json.dump(pci_passthrough, pci_file)
+        changed = True
+    else:
+        print("NOTE: user_configs is good, retaining same for nova confgmap")
+        pci_passthrough['device_spec'] = user_configs
+        with open(sriov_nova_conf_file, 'w') as pci_file:
+            json.dump(pci_passthrough, pci_file)
+    return changed, pci_passthrough
+
+
+def main():
+    derived = {}
+    changed = False
+    result = dict(success=False, message="", changed=False, device_spec={})
+    module = AnsibleModule(
+        argument_spec=yaml.safe_load(DOCUMENTATION)['options'],
+        supports_check_mode=False,
+    )
+
+    # Set parameters
+    sriov_device_spec = module.params.get('sriov_device_spec_map', None)
+    phydev_map = module.params.get('sriov_phydev_map', None)
+    nova_conf = module.params.get('sriov_device_spec_out_file', None)
+
+    if len(sriov_device_spec) == 0:
+        result['error'] = 'Missing required parameter: sriov_nova_conf_file'
+        result['message='] = result['error']
+        result['rc'] = 1
+        module.fail_json(**result)
+    else:
+        # Derive the devicespec from user input
+        changed, derived = _run_derive_pci(sriov_device_spec, nova_conf, phydev_map)
+
+    # The user devspec updated / or not is valid
+    if changed:
+        result['message'] = "PCI device_spec is generated"
+    else:
+        result['message'] = "No change in device_spec or input error"
+    result['device_spec'] = derived
+    result['rc'] = 0
+    result['changed'] = True
+    result['success'] = True
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/tests/molecule/edpm_derive_pci_passthrough_devicespec/test_derive_pci_passthrough_devicespec.py
+++ b/plugins/tests/molecule/edpm_derive_pci_passthrough_devicespec/test_derive_pci_passthrough_devicespec.py
@@ -1,0 +1,1196 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import errno
+import fixtures
+import os
+import shutil
+import sys
+import tempfile
+import testtools
+
+base = os.path.dirname(__file__)
+pci_file = os.path.join(base, "../../../modules/")
+
+sys.path.insert(0, pci_file)
+import edpm_nova_derive_pci_passthrough_devicespec as pci  # noqa: E402
+
+
+class TestDerivePciPassthru(testtools.TestCase):
+
+    def setUp(self):
+        super(TestDerivePciPassthru, self).setUp()
+
+        tmpdir = tempfile.mkdtemp()
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec._PCI_DEVICES_PATH', tmpdir))
+        sys_class_tmpdir = tempfile.mkdtemp()
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec._SYS_CLASS_NET_PATH', sys_class_tmpdir))
+
+    def tearDown(self):
+        super(TestDerivePciPassthru, self).tearDown()
+        shutil.rmtree(pci._PCI_DEVICES_PATH)
+        shutil.rmtree(pci._SYS_CLASS_NET_PATH)
+
+    def write_file(self, path, filename, data):
+        path = os.path.join(path, filename)
+        f = open(path, "w")
+        f.write(data)
+        f.close()
+
+    def create_dirs(self, path):
+        if os.path.isdir(path):
+            return
+        try:
+            os.makedirs(path)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
+    def sysfs_map_create(self, sysfs_map):
+        for entry in sysfs_map:
+            src = os.path.join(pci._PCI_DEVICES_PATH, entry['pci_addr'], 'net', entry['device'])
+            dev = os.path.join(pci._SYS_CLASS_NET_PATH, entry['device'])
+            self.create_dirs(src)
+            os.symlink(src, dev)
+            src = os.path.join(src, 'device')
+            rel_pci_path = os.path.join("../../../", entry['pci_addr'])
+            os.symlink(rel_pci_path, src)
+            self.write_file(src, "device", entry['pf_prod'])
+            self.write_file(src, "vendor", entry['vendor'])
+            self.write_file(src, "sriov_totalvfs", entry['total_vfs'])
+            self.write_file(src, "sriov_numvfs", str(entry['numvfs']))
+
+            vf_id = 0
+            for vf in entry['vf_addr']:
+                vf_pci_path = os.path.join(pci._PCI_DEVICES_PATH, vf)
+                vf_path = os.path.join(src, 'virtfn' + str(vf_id))
+                self.create_dirs(vf_pci_path)
+                os.symlink(vf_pci_path, vf_path)
+                physfn_net_path = os.path.join(vf_path, "physfn/net")
+                self.create_dirs(physfn_net_path)
+                physfn_dev_path = os.path.join(physfn_net_path, entry['device'])
+                os.symlink(dev, physfn_dev_path)
+                self.write_file(vf_pci_path, "device", entry['vf_prod'])
+                self.write_file(vf_pci_path, "vendor", entry['vendor'])
+                vf_id = vf_id + 1
+
+    def test_get_passthrough_prodID_with_sysfsmap(self):
+        system_configs_nicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno2', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno2', 'vfid': 3}, 'device_type': 'vf', 'max_tx_rate': 0,
+                'min_tx_rate': 0, 'name': 'eno4v3', 'pci_address': '0000:18:0c.3', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 2}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        system_configs_nicpart2 = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno2', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno2', 'vfid': 3}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno4v3', 'pci_address': '0000:18:0c.3', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 2}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+        system_configs_nonnicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno2', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 2}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        sysfs_map = [
+            {"device": "eno2", "pci_addr": "0000:18:00.2", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0c.0", "0000:18:0c.1", "0000:18:0c.2", "0000:18:0c.3"]},
+            {"device": "eno3", "pci_addr": "0000:18:00.3", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0a.0", "0000:18:0a.1", "0000:18:0a.2", "0000:18:0a.3"]},
+            {"device": "eno4", "pci_addr": "0000:18:00.4", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0d.0", "0000:18:0d.1", "0000:18:0d.2", "0000:18:0d.3"]}
+        ]
+
+        self.sysfs_map_create(sysfs_map)
+
+        ''' Usecase: ProductID, with nicpart and non-nicpart PFs '''
+
+        user_config1 = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config1, system_configs_nicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, [])
+
+        user_config_pfaddr = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.2'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config_pfaddr, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, user_config_pfaddr)
+
+        user_config_pfaddr = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.3'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config_pfaddr, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, [])
+
+        user_config_pfaddr = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.2'},
+                              {'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.3'}]
+        expected_output = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.2'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config_pfaddr, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, expected_output)
+
+        user_config_pfaddr = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.4'},
+                              {'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.2'}]
+        expected_output = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.4'},
+                           {'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.2'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config_pfaddr, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, expected_output)
+
+        user_config_vfaddr = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.2'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config_vfaddr, system_configs_nicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertEqual(pci_passthro, user_config_vfaddr)
+
+        user_config1 = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config1, system_configs_nicpart2)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.4'}])
+
+    def test_get_passthrough_config_by_product_vf_with_sysfsmap(self):
+        system_configs = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 5, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        sysfs_map = [
+            {"device": "eno3", "pci_addr": "0000:18:00.2", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0a.0", "0000:18:0a.1", "0000:18:0a.2", "0000:18:0a.3"]},
+            {"device": "eno4", "pci_addr": "0000:18:00.3", "numvfs": 5, "total_vfs": "32", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0e.0", "0000:18:0e.1", "0000:18:0e.2", "0000:18:0e.3", "0000:18:0e.4"]}
+        ]
+
+        self.sysfs_map_create(sysfs_map)
+
+        ''' Usecase: ProductID, with nicpart and non-nicpart VFs '''
+        user_config1 = [{'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true'}]
+        expected_output1 = [{'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.1'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.2'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.3'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.3'}]
+
+        non_nicp, nicp = pci.generate_combined_configuration(user_config1, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_output1)
+
+        user_config2 = [{'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.2'}]
+        expected_output2 = [{'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.1'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.2'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.3'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config2, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_output2)
+
+        user_config3 = [{'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.3'}]
+        expected_output3 = [{'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.3'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config3, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_output3)
+
+        user_config4 = [{'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:0a.3'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config4, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, user_config4)
+
+        user_config5 = [{'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:0.3'}]
+        expected_output5 = [{'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:0.3'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config5, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_output5)
+
+        # Special case - VF_product_id, but PCI regex matches both PF and VF
+        user_config6 = [{'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:*.*'}]
+        expected_output6 = [{'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:0a.1'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:0a.2'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:0a.3'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:00.3'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config6, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_output6)
+
+        user_config7 = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true'}]
+        expected_output7 = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.3'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config7, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_output7)
+
+        user_config8 = [{'product_id': '1592', 'vendor_id': '8086', 'trusted': 'true'}]
+        expected_output8 = [{'product_id': '1592', 'vendor_id': '8086', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config8, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_output8)
+
+        user_config9 = [{'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:*.*'},
+                        {'product_id': '1592', 'vendor_id': '8086', 'trusted': 'true'}]
+        expected_output9 = [{'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:0a.1'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:0a.2'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:0a.3'},
+                            {'product_id': '154c', 'vendor_id': '8086', 'address': '0000:18:00.3'},
+                            {'product_id': '1592', 'vendor_id': '8086', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config9, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_output9)
+
+    def test_get_passthrough_config_by_address_sysfsmap(self):
+        system_configs = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 5, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        sysfs_map = [
+            {"device": "eno3", "pci_addr": "0000:18:00.2", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0a.0", "0000:18:0a.1", "0000:18:0a.2", "0000:18:0a.3"]},
+            {"device": "eno4", "pci_addr": "0000:18:00.3", "numvfs": 5, "total_vfs": "32", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0e.0", "0000:18:0e.1", "0000:18:0e.2", "0000:18:0e.3", "0000:18:0e.4"]}
+        ]
+
+        self.sysfs_map_create(sysfs_map)
+
+        ''' Usecase: pci address of PF and physical network - nicpart PFs '''
+        user_config1 = [{'address': '0000:18:00.2', 'physical_network': 'sriov1', 'trusted': 'true'}]
+        expected_list1 = [{'address': '0000:18:0a.1', 'physical_network': 'sriov1', 'trusted': 'true'},
+                          {'address': '0000:18:0a.2', 'physical_network': 'sriov1', 'trusted': 'true'},
+                          {'address': '0000:18:0a.3', 'physical_network': 'sriov1', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config1, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_list1)
+
+        user_config2 = [{'address': '0000:18:00.3', 'physical_network': 'sriov2', 'trusted': 'true'}]
+        expected_list2 = [{'address': '0000:18:00.3', 'physical_network': 'sriov2', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config2, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_list2)
+
+        user_config2 = [{'address': '0000:18:0a.3', 'physical_network': 'sriov1', 'trusted': 'true'}]
+        expected_list2 = [{'address': '0000:18:0a.3', 'physical_network': 'sriov1', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config2, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_list2)
+
+        user_config3 = [{'address': '0000:18:0a.0', 'physical_network': 'sriov1', 'trusted': 'true'},
+                        {'address': '0000:18:0a.1', 'physical_network': 'sriov1', 'trusted': 'true'}]
+        expected_list3 = [{'address': '0000:18:0a.1', 'physical_network': 'sriov1', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config3, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_list3)
+
+        user_config4 = [{'address': '0000:18:0a.0', 'physical_network': 'sriov1', 'trusted': 'true'}]
+        expected_list4 = []
+        non_nicp, nicp = pci.generate_combined_configuration(user_config4, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, expected_list4)
+
+        user_config5 = [
+            {"address": "0000:18:0a.2", "trusted": "true"},
+            {"address": "0000:18:0e.3", "trusted": "true"}
+        ]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config5, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, user_config5)
+
+        user_config6 = [{'address': '0000:18:07.0', 'physical_network': 'sriov1', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config6, system_configs)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, user_config6)
+
+    def test_get_pcidevspec_dict_with_sysfsmap(self):
+        system_configs_nicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 5, 'promisc': 'on'},
+            {'device': {'name': 'eno4', 'vfid': 3}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno4v3', 'pci_address': '0000:18:0e.3', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 2}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        system_configs_nonnicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 5, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 2}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        sysfs_map = [{"device": "eno3", "pci_addr": "0000:18:00.2", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0a.0", "0000:18:0a.1", "0000:18:0a.2", "0000:18:0a.3"]},
+                     {"device": "eno4", "pci_addr": "0000:18:00.3", "numvfs": 5, "total_vfs": "32", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0e.0", "0000:18:0e.1", "0000:18:0e.2", "0000:18:0e.3", "0000:18:0e.4"]}
+                     ]
+
+        self.sysfs_map_create(sysfs_map)
+
+        ''' Usecases: PCI addr in DICT format (regex, range, etc. ), with nicpart and non-nicpart PFs in user config '''
+
+        dict_usrcfg1 = [{"trusted": "true", "address": "0000:18:00.2"},
+                        {"trusted": "true", "address": {"domain": "0000", "bus": "18", "slot": "00", "function": "3"}}]
+
+        dict_output1 = [{"trusted": "true", "address": "0000:18:0a.1"},
+                        {"trusted": "true", "address": "0000:18:0a.3"},
+                        {"trusted": "true", "address": "0000:18:0e.0"},
+                        {"trusted": "true", "address": "0000:18:0e.1"},
+                        {"trusted": "true", "address": "0000:18:0e.2"},
+                        {"trusted": "true", "address": "0000:18:0e.4"}
+                        ]
+        non_nicp, nicp = pci.generate_combined_configuration(dict_usrcfg1, system_configs_nicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, dict_output1)
+
+        dict_output2 = [{"trusted": "true", "address": "0000:18:0a.0"},
+                        {"trusted": "true", "address": "0000:18:0a.1"},
+                        {"trusted": "true", "address": "0000:18:0a.3"},
+                        {"trusted": "true", "address": {"domain": "0000", "bus": "18", "slot": "00", "function": "3"}}
+                        ]
+        non_nicp, nicp = pci.generate_combined_configuration(dict_usrcfg1, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, dict_output2)
+
+        dict_usrcfg3 = [{"trusted": "true", "address": {"domain": "0000", "bus": "18", "slot": "00", "function": ".*"}},
+                        {"trusted": "true", "address": {"domain": "0000", "bus": "18", "slot": ".*", "function": "3"}}]
+
+        dict_output3 = [{"trusted": "true", "address": "0000:18:0a.1"},
+                        {"trusted": "true", "address": "0000:18:0a.3"},
+                        {"trusted": "true", "address": "0000:18:0e.0"},
+                        {"trusted": "true", "address": "0000:18:0e.1"},
+                        {"trusted": "true", "address": "0000:18:0e.2"},
+                        {"trusted": "true", "address": "0000:18:0e.4"}
+                        ]
+        non_nicp, nicp = pci.generate_combined_configuration(dict_usrcfg3, system_configs_nicpart)
+        pci_passthro = (non_nicp + nicp)
+        for pf in pci_passthro:
+            self.assertIn(pf, dict_output3)
+
+        dict_usrcfg4 = [{"trusted": "true", "address": {"domain": "0000", "bus": "18", "slot": "0[0-a]", "function": "3"}}]
+        dict_output4 = [{"trusted": "true", "address": "0000:18:00.3"},
+                        {"trusted": "true", "address": "0000:18:0a.3"}]
+
+        non_nicp, nicp = pci.generate_combined_configuration(dict_usrcfg4, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, dict_output4)
+
+        dict_usrcfg5 = [{"trusted": "true", "address": {"domain": ".*", "bus": "18", "slot": "0[0-e]", "function": "2"}}]
+        dict_output5 = [{"trusted": "true", "address": "0000:18:0a.0"},
+                        {"trusted": "true", "address": "0000:18:0a.1"},
+                        {"trusted": "true", "address": "0000:18:0a.3"},
+                        {"trusted": "true", "address": "0000:18:0e.2"}
+                        ]
+
+        non_nicp, nicp = pci.generate_combined_configuration(dict_usrcfg5, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        for pf in pci_passthro:
+            self.assertIn(pf, dict_output5)
+
+    def test_get_passthrough_devname_with_sysfsmap(self):
+        system_configs_nicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 5, 'promisc': 'on'},
+            {'device': {'name': 'eno4', 'vfid': 3}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno4v3', 'pci_address': '0000:18:0e.3', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 2}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        system_configs_nonnicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 5, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 2}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        sysfs_map = [
+            {"device": "eno3", "pci_addr": "0000:18:00.2", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0a.0", "0000:18:0a.1", "0000:18:0a.2", "0000:18:0a.3"]},
+            {"device": "eno4", "pci_addr": "0000:18:00.3", "numvfs": 5, "total_vfs": "32", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0e.0", "0000:18:0e.1", "0000:18:0e.2", "0000:18:0e.3", "0000:18:0e.4"]}
+        ]
+
+        self.sysfs_map_create(sysfs_map)
+
+        def get_pf_name_from_phy_network_stub(phy_net):
+            if phy_net == 'sriov1':
+                return 'eno3'
+            elif phy_net == 'sriov2':
+                return 'eno4'
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pf_name_from_phy_network', get_pf_name_from_phy_network_stub))
+
+        ''' Usecase: Devname, with nicpart and non-nicpart PFs '''
+        devname_usrcfg1 = [{"devname": "eno3", "physical_network": "sriov1", "trusted": "true"},
+                           {"devname": "eno4", "physical_network": "sriov2", "trusted": "true"}]
+        devname_output1 = [{"physical_network": "sriov1", "trusted": "true", "address": "0000:18:0a.1"},
+                           {"physical_network": "sriov1", "trusted": "true", "address": "0000:18:0a.3"},
+                           {"physical_network": "sriov2", "trusted": "true", "address": "0000:18:0e.0"},
+                           {"physical_network": "sriov2", "trusted": "true", "address": "0000:18:0e.1"},
+                           {"physical_network": "sriov2", "trusted": "true", "address": "0000:18:0e.2"},
+                           {"physical_network": "sriov2", "trusted": "true", "address": "0000:18:0e.4"}
+                           ]
+
+        non_nicp, nicp = pci.generate_combined_configuration(devname_usrcfg1, system_configs_nicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, devname_output1)
+
+        devname_usrcfg2 = [{"devname": "eno3", "physical_network": "sriov1", "trusted": "true"},
+                           {"devname": "eno4", "physical_network": "sriov2", "trusted": "true"}]
+        devname_output2 = [{"physical_network": "sriov1", "trusted": "true", "address": "0000:18:0a.1"},
+                           {"physical_network": "sriov1", "trusted": "true", "address": "0000:18:0a.3"},
+                           {"physical_network": "sriov1", "trusted": "true", "address": "0000:18:0a.0"},
+                           {"devname": "eno4", "physical_network": "sriov2", "trusted": "true"}]
+
+        non_nicp, nicp = pci.generate_combined_configuration(devname_usrcfg2, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, devname_output2)
+
+        user_config3 = [
+            {"address": "0000:18:0a.1", "trusted": "true"},
+            {"address": "0000:18:0e.1", "trusted": "true"}
+        ]
+        user_output3 = [{"trusted": "true", "address": "0000:18:0a.1"},
+                        {"trusted": "true", "address": "0000:18:0e.1"}]
+
+        non_nicp, nicp = pci.generate_combined_configuration(user_config3, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, user_output3)
+
+        devname_usrcfg4 = [{"devname": "eno3", "physical_network": "sriov1", "trusted": "true", "product_id": "1572"},
+                           {"devname": "eno4", "physical_network": "sriov2", "trusted": "true", "product_id": "1572"}]
+        devname_output4 = [{"devname": "eno4", "physical_network": "sriov2", "trusted": "true", "product_id": "1572"}]
+        non_nicp, nicp = pci.generate_combined_configuration(devname_usrcfg4, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, devname_output4)
+
+        devname_usrcfg5 = [{"devname": "eno7", "physical_network": "sriov1", "trusted": "true", "product_id": "1572"},
+                           {"devname": "eno4", "physical_network": "sriov2", "trusted": "true", "product_id": "1572"}]
+        devname_output5 = [{"devname": "eno7", "physical_network": "sriov1", "trusted": "true", "product_id": "1572"},
+                           {"devname": "eno4", "physical_network": "sriov2", "trusted": "true", "product_id": "1572"}]
+        non_nicp, nicp = pci.generate_combined_configuration(devname_usrcfg5, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, devname_output5)
+
+        devname_usrcfg6 = [{"devname": "eno3", "physical_network": "sriov1", "trusted": "true", "product_id": "1572"},
+                           {"devname": "eno4", "physical_network": "sriov2", "trusted": "true", "product_id": "1572"}]
+        devname_output6 = []
+        non_nicp, nicp = pci.generate_combined_configuration(devname_usrcfg6, system_configs_nicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, devname_output6)
+
+        devname_usrcfg7 = [{"devname": "eno3", "physical_network": "sriov1", "trusted": "true", "product_id": "1572", "address": "0000:12:00.1"}]
+        self.assertRaises(pci.InvalidConfigException, pci.generate_combined_configuration, devname_usrcfg7, system_configs_nicpart)
+
+        devname_usrcfg8 = [{"devname": "eno4", "physical_network": "sriov1", "trusted": "true", "product_id": "1572", "address": "0000:12:00.1"}]
+        self.assertRaises(pci.InvalidConfigException, pci.generate_combined_configuration, devname_usrcfg8, system_configs_nonnicpart)
+
+    def test_get_passthrough_config_nonmatch_usrcfgs(self):
+        system_configs_nonnicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 5, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        system_configs_nicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 5, 'promisc': 'on'},
+            {'device': {'name': 'eno4', 'vfid': 5}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno4v5', 'pci_address': '0000:18:0e.5', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 2}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        sysfs_map = [{"device": "eno3", "pci_addr": "0000:18:00.2", "numvfs": "8", "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0a.0", "0000:18:0a.1", "0000:18:0a.2", "0000:18:0a.3", "0000:18:0a.4", "0000:18:0a.5", "0000:18:0a.6", "0000:18:0a.7"]},
+                     {"device": "eno4", "pci_addr": "0000:18:00.3", "numvfs": "6", "total_vfs": "32", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0e.0", "0000:18:0e.1", "0000:18:0e.2", "0000:18:0e.3", "0000:18:0e.4", "0000:18:0e.5"]}
+                     ]
+        self.sysfs_map_create(sysfs_map)
+
+        ''' Usecase: Non-matching PCI-addr and ProductID, with nicpart and non-nicpart VFs '''
+
+        user_config1 = [{'product_id': '134f', 'vendor_id': '8086', 'trusted': 'true'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config1, system_configs_nicpart)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertEqual(pci_passthrough, user_config1)
+        non_nicp, nicp = pci.generate_combined_configuration(user_config1, system_configs_nonnicpart)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertEqual(pci_passthrough, user_config1)
+
+        user_config2 = [{'product_id': '134f', 'vendor_id': '8086', 'address': '4440:22:1f.1', 'trusted': 'true'},
+                        {"trusted": "true", "address": {"domain": "3000", "bus": "08", "slot": "05", "function": "3"}}
+                        ]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config2, system_configs_nicpart)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, user_config2)
+        non_nicp, nicp = pci.generate_combined_configuration(user_config2, system_configs_nonnicpart)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthrough, user_config2)
+
+        user_config3 = [{'product_id': '', 'vendor_id': '8086', 'trusted': 'true'},
+                        {"trusted": "true", "address": {"domain": "3000", "bus": "ff", "slot": "05", "function": "3"}}
+                        ]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config3, system_configs_nicpart)
+        pci_passthrough = (non_nicp + nicp)
+        self.assertEqual(pci_passthrough, user_config3)
+
+    def test_get_allocated_pci_addresses_pass1(self):
+        configs = [
+            {
+                "device_type": "pf",
+                "link_mode": "legacy",
+                "name": "eno3",
+                "numvfs": 5
+            },
+            {
+                "device_type": "vf",
+                "pci_address": "0000:00:01.1"
+            }
+        ]
+        result = pci.get_allocated_pci_addresses(configs)
+        expected = ["0000:00:01.1"]
+        self.assertEqual(result, expected)
+
+    def test_get_pci_regex_pattern_pass1(self):
+        config_regex = '.*'
+
+        result = pci.get_pci_regex_pattern(config_regex, 4, pci.MAX_DOMAIN, '%04x')
+        expected = '[0-9a-fA-F]{4}'
+        self.assertEqual(result, expected)
+
+    def test_get_pci_regex_pattern_pass2(self):
+        config_regex = ['18', '[0-1]', 'aA', '00']
+        config_expected = {"18": "18", "[0-1]": "[0-1]", "aA": "aa", "00": "00"}
+
+        for config in config_regex:
+            result = pci.get_pci_regex_pattern(config, 2, 0xFF, '%02x')
+            self.assertEqual(result, config_expected[config])
+
+    def test_get_sriov_nic_partition_pfs_pass1(self):
+        configs = [
+            {
+                "device": {"name": "eno3"},
+                "device_type": "vf",
+                "name": "eno3v0",
+                "pci_address": "0000:18:0a.0",
+                "trust": "on"
+            }
+        ]
+        result = pci.get_sriov_nic_partition_pfs(configs)
+        expected = ["eno3"]
+        self.assertEqual(result, expected)
+
+    def test_get_sriov_nic_partition_pfs_pass2(self):
+        configs = [
+            {
+                "link_mode": "legacy",
+                "device_type": "pf",
+                "name": "eno4",
+                "pci_address": "0000:18:00.3",
+                "trust": "on"
+            }
+        ]
+        result = pci.get_sriov_nic_partition_pfs(configs)
+        expected = []
+        self.assertEqual(result, expected)
+
+    def test_get_sriov_non_nic_partition_pfs_pass1(self):
+        configs = [
+            {
+                "device": {"name": "eno3"},
+                "device_type": "vf",
+                "name": "eno3v0",
+                "pci_address": "0000:18:0a.0",
+                "trust": "on"
+            },
+            {
+                "link_mode": "legacy",
+                "device_type": "pf",
+                "name": "eno4",
+                "pci_address": "0000:18:00.3",
+                "trust": "on"
+            }
+        ]
+        result = pci.get_sriov_non_nic_partition_pfs(configs)
+        expected = ["eno4"]
+        self.assertEqual(result, expected)
+
+    def test_get_pci_addresses_by_ifname_pass1(self):
+        pfs = ['eno3']
+        allocated_pci = ['0000:18:0a.0']
+        os.makedirs(pci._PCI_DEVICES_PATH + "/0000:18:0a.1/physfn/net/eno3")
+        os.makedirs(pci._PCI_DEVICES_PATH + "/0000:18:0a.2/physfn/net/eno3")
+
+        f = open(pci._PCI_DEVICES_PATH + "/0000:18:0a.1/vendor",
+                 "w+")
+        f.write("0x8086")
+        f.close()
+        f = open(pci._PCI_DEVICES_PATH + "/0000:18:0a.1/device",
+                 "w+")
+        f.write("0x154c")
+        f.close()
+
+        f = open(pci._PCI_DEVICES_PATH + "/0000:18:0a.2/vendor",
+                 "w+")
+        f.write("0x8086")
+        f.close()
+        f = open(pci._PCI_DEVICES_PATH + "/0000:18:0a.2/device",
+                 "w+")
+        f.write("0x154c")
+        f.close()
+        pci_addresses = pci.get_available_vf_pci_addresses_by_ifname(pfs, allocated_pci)
+        expected_pci_addresses = {'eno3': ['0000:18:0a.2', '0000:18:0a.1']}
+        for pf in expected_pci_addresses.keys():
+            for addr in expected_pci_addresses[pf]:
+                self.assertIn(addr, pci_addresses[pf])
+
+    def test_get_passthrough_config_pass1(self):
+        user_config = {'devname': 'eno3', 'physical_network': 'sriov1', 'trusted': 'true'}
+        pf = 'eno3'
+        allocated_pci = ['0000:18:0a.0']
+
+        def get_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': ['0000:18:0a.1', '0000:18:0a.2']}
+            return pci_addresses
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_pci_addresses_by_ifname_stub))
+
+        def get_pci_device_info_by_ifname_stub1(pf_path, subdir):
+            if subdir == 'virtfn0':
+                vendor = '8086'
+                product = '154c'
+                return vendor, product
+            else:
+                vendor = '8086'
+                product = '1572'
+                return vendor, product
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub1))
+
+        def get_addr_from_ifname_stub(str):
+            if (str == 'eno2'):
+                addr = '0000:18:00.1'
+            if (str == 'eno3'):
+                addr = '0000:18:00.2'
+            if (str == 'eno4'):
+                addr = '0000:18:00.3'
+            return addr
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_addr_from_ifname_stub))
+
+        pci_passthro, stats = pci.get_passthrough_config(user_config, pf, allocated_pci, False)
+        expected_pci_passthro = [{'address': '0000:18:0a.1', 'physical_network': 'sriov1', 'trusted': 'true'},
+                                 {'address': '0000:18:0a.2', 'physical_network': 'sriov1', 'trusted': 'true'}
+                                 ]
+        self.assertCountEqual(pci_passthro, expected_pci_passthro)
+
+    def test_get_pci_passthrough_devspec_pass1(self):
+        user_config = {'devname': 'eno3', 'physical_network': 'sriov1', 'trusted': 'true'}
+        pf = 'eno3'
+        pci_addresses = ['0000:18:0a.3', '0000:18:0a.1', '0000:18:0a.2']
+
+        pci_devspec_list = pci.get_pci_passthrough_devicespec(user_config, pf, pci_addresses)
+        expected_pci_devspec_list = [
+            {'address': '0000:18:0a.3', 'physical_network': 'sriov1', 'trusted': 'true'},
+            {'address': '0000:18:0a.1', 'physical_network': 'sriov1', 'trusted': 'true'},
+            {'address': '0000:18:0a.2', 'physical_network': 'sriov1', 'trusted': 'true'}
+        ]
+        self.assertEqual(len(pci_devspec_list), len(expected_pci_devspec_list))
+        for addr in pci_devspec_list:
+            self.assertIn(addr, expected_pci_devspec_list)
+
+    def test_get_pciaddr_dict_from_usraddr_pass(self):
+        pci_addr_1 = "000a:0b:f.5"
+        pci_addr_2 = "000a:*:f.7"
+        pci_addr_3 = "0000:03:*.7"
+        pci_addr_4 = "000c:03:f.*"
+        pci_addr_5 = ":5.7"
+        pci_addr_6 = ":00"
+        pci_addr_7 = ":5:00"
+        pci_addr_8 = "*:0A:*.7"
+        pci_addr_9 = "*:0A:2*.7"
+        addr_0 = {"domain": ".*", "bus": "1f", "slot": "02", "function": "7"}
+        addr_1 = {"domain": ".*", "bus": "0[a-b]", "slot": "0[2-9]", "function": "7"}
+        addr_2 = {"domain": "[", "bus": "0a[", "slot": "0[2-9]", "function": "7"}
+        addr_3 = {"domain": "*", "bus": "0a", "slot": "0[2-9]", "function": "5"}
+        addr_4 = {"domain": "*", "bus": "0", "slot": "0", "function": "5"}
+        addr_5 = {"domain": "*", "bus": "08", "slot": "33", "function": "5"}
+        addr_6 = {"domain": "*", "bus": "08", "slot": "12", "function": "9"}
+        addr_7 = {"domain": "*", "bus": "08", "slot": "2*", "function": "1"}
+        addr_8 = {"domain": "*", "bus": "08", "slot": "1dd", "function": "1"}
+
+        result = pci.get_pciaddr_dict_from_usraddr(pci_addr_1)
+        self.assertEqual({'function': '5', 'domain': '000a', 'bus': '0b', 'slot': '0f'}, result)
+        result = pci.get_pciaddr_dict_from_usraddr(pci_addr_2)
+        self.assertEqual({'function': '7', 'domain': '000a', 'bus': '.*', 'slot': '0f'}, result)
+        result = pci.get_pciaddr_dict_from_usraddr(pci_addr_3)
+        self.assertEqual({'function': '7', 'domain': '0000', 'bus': '03', 'slot': '.*'}, result)
+        result = pci.get_pciaddr_dict_from_usraddr(pci_addr_4)
+        self.assertEqual({'function': '.*', 'domain': '000c', 'bus': '03', 'slot': '0f'}, result)
+        result = pci.get_pciaddr_dict_from_usraddr(pci_addr_5)
+        self.assertEqual({'function': '7', 'domain': '.*', 'bus': '.*', 'slot': '05'}, result)
+        result = pci.get_pciaddr_dict_from_usraddr(pci_addr_6)
+        self.assertEqual({'function': '.*', 'domain': '.*', 'bus': '.*', 'slot': '00'}, result)
+        result = pci.get_pciaddr_dict_from_usraddr(pci_addr_7)
+        self.assertEqual({'function': '.*', 'domain': '.*', 'bus': '05', 'slot': '00'}, result)
+        result = pci.get_pciaddr_dict_from_usraddr(pci_addr_8)
+        self.assertRaises(pci.InvalidConfigException, pci.get_pciaddr_dict_from_usraddr, pci_addr_9)
+
+        self.assertEqual({'function': '7', 'domain': '.*', 'bus': '0a', 'slot': '.*'}, result)
+        result = pci.get_user_regex_from_addrdict(addr_0)
+        self.assertEqual(result, '[0-9a-fA-F]{4}:1f:02.7')
+        result = pci.get_user_regex_from_addrdict(addr_1)
+        self.assertEqual(result, '[0-9a-fA-F]{4}:0[a-b]:0[2-9].7')
+        self.assertRaises(pci.InvalidConfigException, pci.get_user_regex_from_addrdict, addr_2)
+        result = pci.get_user_regex_from_addrdict(addr_3)
+        self.assertEqual(result, '[0-9a-fA-F]{4}:0a:0[2-9].5')
+        result = pci.get_user_regex_from_addrdict(addr_4)
+        self.assertEqual(result, '[0-9a-fA-F]{4}:00:00.5')
+        self.assertRaises(pci.InvalidConfigException, pci.get_user_regex_from_addrdict, addr_5)
+        self.assertRaises(pci.InvalidConfigException, pci.get_user_regex_from_addrdict, addr_6)
+        result = pci.get_user_regex_from_addrdict(addr_7)
+        self.assertEqual(result, '[0-9a-fA-F]{4}:08:2*.1')
+        self.assertRaises(pci.InvalidConfigException, pci.get_user_regex_from_addrdict, addr_8)
+
+    def test_get_passthrough_config_pciformat_basic1(self):
+        user_config1 = {'address': '0000:18:00.2', 'product_id': '154c', 'physical_network': 'sriov1', 'trusted': 'true'}
+
+        allocated_pci = ['0000:18:0a.0']
+
+        def get_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': ['0000:18:0a.1', '0000:18:0a.2']}
+            return pci_addresses
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_pci_addresses_by_ifname_stub))
+
+        def get_pci_device_info_by_ifname_stub1(pf_path, subdir):
+            if subdir == 'virtfn0':
+                vendor = '8086'
+                product = '154c'
+                return vendor, product
+            else:
+                vendor = '8086'
+                product = '1572'
+                return vendor, product
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub1))
+
+        def get_addr_from_ifname_stub(str):
+            if (str == 'eno2'):
+                addr = '0000:18:00.1'
+            if (str == 'eno3'):
+                addr = '0000:18:00.2'
+            if (str == 'eno4'):
+                addr = '0000:18:00.3'
+            return addr
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_addr_from_ifname_stub))
+
+        expected_1 = [{'address': '0000:18:0a.1', 'product_id': '154c', 'physical_network': 'sriov1', 'trusted': 'true'},
+                      {'address': '0000:18:0a.2', 'product_id': '154c', 'physical_network': 'sriov1', 'trusted': 'true'}]
+        pci_passthro, parse_non_nic_pfs = pci.get_passthrough_config(user_config1, 'eno3', allocated_pci, False)
+        self.assertEqual(len(pci_passthro), len(expected_1))
+        for config in pci_passthro:
+            self.assertIn(config, expected_1)
+
+    def test_get_passthrough_config_pciformat_basic2(self):
+        user_config2 = {'address': '0000:18:00.3', 'physical_network': 'sriov2', 'trusted': 'true'}
+        allocated_pci = ['0000:18:0a.0']
+
+        def get_available_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': ['0000:18:0a.1', '0000:18:0a.2']}
+            return pci_addresses
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_available_pci_addresses_by_ifname_stub))
+
+        def get_addr_from_ifname_stub(str):
+            if (str == 'eno2'):
+                addr = '0000:18:00.1'
+            if (str == 'eno3'):
+                addr = '0000:18:00.2'
+            if (str == 'eno4'):
+                addr = '0000:18:00.3'
+            return addr
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_addr_from_ifname_stub))
+
+        def get_pci_device_info_by_ifname_stub(pf_path, subdir):
+            vendor = '8086'
+            product = '154c'
+            return str(vendor), str(product)
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub))
+
+        pci_passthro, parse_non_nic_p = pci.get_passthrough_config(user_config2, 'eno3', allocated_pci, False)
+        self.assertEqual(pci_passthro, [])
+
+    def test_get_passthrough_config_pciformat_basic3(self):
+        user_config3 = {'address': '0000:18:0a.2', 'physical_network': 'sriov1', 'trusted': 'true'}
+        allocated_pci = ['0000:18:0a.0']
+
+        def get_available_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': ['0000:18:0a.1', '0000:18:0a.2']}
+            return pci_addresses
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_available_pci_addresses_by_ifname_stub))
+
+        def get_pci_device_info_by_ifname_stub(pf_path, subdir):
+            vendor = '8086'
+            product = '154c'
+            return str(vendor), str(product)
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub))
+
+        def get_addr_from_ifname_stub(str):
+            addr = '0000:18:00.2'
+            return addr
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_addr_from_ifname_stub))
+
+        pci_passthro, parse_non_nic_p = pci.get_passthrough_config(user_config3, 'eno3', allocated_pci, False)
+        self.assertEqual(pci_passthro, [{'address': '0000:18:0a.2', 'physical_network': 'sriov1', 'trusted': 'true'}])
+
+    def test_get_passthrough_config_by_address_pciaddr_notsingle(self):
+        user_config = {'address': '0000:18:*.*', 'physical_network': 'sriov1', 'trusted': 'true'}
+        system_configs = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+        allocated_pci = ['0000:18:0a.0']
+
+        def get_available_vf_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': ['0000:18:0a.3', '0000:18:0a.2']}
+            return pci_addresses
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_available_vf_pci_addresses_by_ifname_stub))
+
+        def get_pci_addr_from_ifname_stub(str):
+            if (str == 'eno3'):
+                addr = '0000:18:00.2'
+            if (str == 'eno4'):
+                addr = '0000:18:00.3'
+            return addr
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_pci_addr_from_ifname_stub))
+
+        def get_pci_device_info_by_ifname_stub(pf_path, subdir):
+            vendor = '8086'
+            product = '154c'
+            return str(vendor), str(product)
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub))
+
+        pci_passthro, stats = pci.get_passthrough_config_for_all_pf(user_config, system_configs, allocated_pci)
+        expected_pci_passthro = [{'address': '0000:18:0a.3', 'physical_network': 'sriov1', 'trusted': 'true'},
+                                 {'address': '0000:18:0a.2', 'physical_network': 'sriov1', 'trusted': 'true'}
+                                 ]
+        self.assertCountEqual(pci_passthro, expected_pci_passthro)
+
+    def test_get_passthrough_config_by_address_pciaddr_mix_notsingle(self):
+        user_config = {'address': '0000:18:*.3', 'physical_network': 'sriov1', 'trusted': 'true'}
+        system_configs = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+        allocated_pci = ['0000:18:0a.2']
+
+        def get_available_vf_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': ['0000:18:0a.3', '0000:18:0a.2']}
+            return pci_addresses
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_available_vf_pci_addresses_by_ifname_stub))
+
+        def get_pci_device_info_by_ifname_stub1(pf_path, subdir):
+            if subdir == 'virtfn0':
+                vendor = '8086'
+                product = '154c'
+                return vendor, product
+            else:
+                vendor = '8086'
+                product = '1572'
+                return vendor, product
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub1))
+
+        def get_pci_addr_from_ifname_stub(str):
+            return '0000:18:00.2'
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_pci_addr_from_ifname_stub))
+
+        pci_passthro, stats = pci.get_passthrough_config_for_all_pf(user_config, system_configs, allocated_pci)
+        expected_pci_passthro = [{'address': '0000:18:0a.3', 'physical_network': 'sriov1', 'trusted': 'true'}]
+
+        self.assertCountEqual(pci_passthro, expected_pci_passthro)
+
+    def test_get_passthrough_config_by_address_pciaddr_single(self):
+        user_config1 = {'address': '0000:18:0.3', 'physical_network': 'sriov2', 'trusted': 'true'}
+        user_config2 = {'address': '0000:18:0a.2', 'physical_network': 'sriov1', 'trusted': 'true'}
+        system_configs = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+        allocated_pci = ['0000:18:0a.0']
+
+        def get_available_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': ['0000:18:0a.1', '0000:18:0a.2']}
+            return pci_addresses
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_available_pci_addresses_by_ifname_stub))
+
+        def get_addr_from_ifname_stub(str):
+            if (str == 'eno3'):
+                addr = '0000:18:00.2'
+            if (str == 'eno4'):
+                addr = '0000:18:00.3'
+            return addr
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_addr_from_ifname_stub))
+
+        def get_pci_device_info_by_ifname_stub1(pf_path, subdir):
+            if subdir == 'virtfn0':
+                vendor = '8086'
+                product = '154c'
+                return vendor, product
+            else:
+                vendor = '8086'
+                product = '1572'
+                return vendor, product
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub1))
+
+        pci_passthro, stats = pci.get_passthrough_config_for_all_pf(user_config1, system_configs, allocated_pci)
+        self.assertCountEqual(pci_passthro, [])
+        pci_passthro, stats = pci.get_passthrough_config_for_all_pf(user_config2, system_configs, allocated_pci)
+        self.assertCountEqual(pci_passthro, [{'address': '0000:18:0a.2', 'physical_network': 'sriov1', 'trusted': 'true'}])
+
+    def test_get_passthrough_config_by_pciaddr_wildcard_1(self):
+        user_config1 = {'address': '0000:18:0a.*', 'trusted': 'true'}
+        user_config2 = {'address': '0000:18:00.*', 'trusted': 'true'}
+        system_configs = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+        allocated_pci = ['0000:18:0a.0']
+
+        def get_available_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': ['0000:18:0a.1', '0000:18:0a.2', '0000:18:0a.3']}
+            return pci_addresses
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_available_pci_addresses_by_ifname_stub))
+
+        def get_addr_from_ifname_stub(str):
+            if (str == 'eno3'):
+                addr = '0000:18:00.2'
+            if (str == 'eno4'):
+                addr = '0000:18:00.3'
+            return addr
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_addr_from_ifname_stub))
+
+        def get_pci_device_info_by_ifname_stub(pf_path, subdir):
+            vendor = '8086'
+            product = '154c'
+            return str(vendor), str(product)
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub))
+
+        expected_list1 = [{'address': '0000:18:0a.2', 'trusted': 'true'}, {'address': '0000:18:0a.1', 'trusted': 'true'}, {'address': '0000:18:0a.3', 'trusted': 'true'}]
+        pci_passthro, stats = pci.get_passthrough_config_for_all_pf(user_config1, system_configs, allocated_pci)
+        self.assertCountEqual(pci_passthro, expected_list1)
+        pci_passthro, stats = pci.get_passthrough_config_for_all_pf(user_config2, system_configs, allocated_pci)
+        self.assertCountEqual(pci_passthro, expected_list1)
+
+    def test_get_passthrough_config_by_product_vf(self):
+        user_config1 = {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true'}
+        system_configs = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+        allocated_pci = ['0000:18:0a.0']
+
+        def get_sriov_nic_partition_pfs_stub(sys_cfg):
+            return ['eno3']
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_sriov_nic_partition_pfs', get_sriov_nic_partition_pfs_stub))
+
+        def get_pci_device_info_by_ifname_stub1(pf_path, subdir):
+            if subdir == 'virtfn0':
+                vendor = '8086'
+                product = '154c'
+                return vendor, product
+            else:
+                vendor = '8086'
+                product = '1572'
+                return vendor, product
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub1))
+
+        def get_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': ['0000:18:0a.1', '0000:18:0a.2', '0000:18:0a.3']}
+            return pci_addresses
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_pci_addresses_by_ifname_stub))
+
+        def get_addr_from_ifname_stub(str):
+            if (str == 'eno2'):
+                addr = '0000:18:00.1'
+            if (str == 'eno3'):
+                addr = '0000:18:00.2'
+            if (str == 'eno4'):
+                addr = '0000:18:00.3'
+            return addr
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_addr_from_ifname_stub))
+
+        expected_list = [{'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.3'},
+                         {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.1'},
+                         {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.2'}]
+        pci_passthro, status = pci.get_passthrough_config_for_all_pf(user_config1, system_configs, allocated_pci)
+        self.assertCountEqual(pci_passthro, expected_list)
+
+    def test_get_passthrough_config_by_product_pf(self):
+        system_configs = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno2', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno2', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno2v3', 'pci_address': '0000:18:0c.3', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+        allocated_pci = ['0000:18:0a.0', '0000:18:0a.2', '0000:18:0c.3']
+
+        def get_sriov_nic_partition_pfs_stub1(sys_cfg):
+            return ['eno2', 'eno3']
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_sriov_nic_partition_pfs', get_sriov_nic_partition_pfs_stub1))
+
+        def get_pci_device_info_by_ifname_stub1(pf_path, subdir):
+            if subdir == 'virtfn0':
+                vendor = '8086'
+                product = '154c'
+                return vendor, product
+            else:
+                vendor = '8086'
+                product = '1572'
+                return vendor, product
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_device_info_by_ifname', get_pci_device_info_by_ifname_stub1))
+
+        def get_pci_addresses_by_ifname_stub(ifname, allocated_pci):
+            pci_addresses = {'eno3': {'eno3': ['0000:18:0a.1', '0000:18:0a.3']},
+                             'eno2': {'eno2': ['0000:18:0c.0', '0000:18:0c.1', '0000:18:0c.2']},
+                             'eno4': {'eno4': ['0000:18:0e.0', '0000:18:0e.1', '0000:18:0e.2', '0000:18:0e.3']}}
+            return pci_addresses[ifname]
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_available_vf_pci_addresses_by_ifname', get_pci_addresses_by_ifname_stub))
+
+        def get_addr_from_ifname_stub(str):
+            if (str == 'eno2'):
+                addr = '0000:18:00.1'
+            if (str == 'eno3'):
+                addr = '0000:18:00.2'
+            if (str == 'eno4'):
+                addr = '0000:18:00.3'
+            return addr
+        self.useFixture(fixtures.MonkeyPatch('edpm_nova_derive_pci_passthrough_devicespec.get_pci_addr_from_ifname', get_addr_from_ifname_stub))
+
+        user_config1 = {'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true'}
+        user_config2 = {'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.3'}
+        user_config3 = {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.3'}
+        user_config4 = {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.2'}
+        expected1_list = [{'product_id': '1572', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:00.3'}]
+
+        # No need to override the default configuration and hence, empty list is expected
+        expected2_list = []
+        expected3_list = []
+        expected4_list = [{'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.1'},
+                          {'product_id': '154c', 'vendor_id': '8086', 'trusted': 'true', 'address': '0000:18:0a.3'}]
+        pci_passthro, status = pci.get_passthrough_config_for_all_pf(user_config1, system_configs, allocated_pci)
+        self.assertCountEqual(pci_passthro, expected1_list)
+        pci_passthro, status = pci.get_passthrough_config_for_all_pf(user_config2, system_configs, allocated_pci)
+        self.assertCountEqual(pci_passthro, expected2_list)
+        pci_passthro, status = pci.get_passthrough_config_for_all_pf(user_config3, system_configs, allocated_pci)
+        self.assertCountEqual(pci_passthro, expected3_list)
+        pci_passthro, status = pci.get_passthrough_config_for_all_pf(user_config4, system_configs, allocated_pci)
+        self.assertCountEqual(pci_passthro, expected4_list)
+
+    def test_get_passthrough_multiple_vendor_sysfsmap(self):
+        system_configs_nonnicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno1', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno2', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 3}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v3', 'pci_address': '0000:18:0a.3', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno2', 'vfid': 3}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno2v3', 'pci_address': '0000:08:0c.3', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        sysfs_map = [
+            {"device": "eno1", "pci_addr": "0000:18:00.1", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1016", "vendor": "0x15b3", "vf_prod": "0x1013", "vf_addr": ["0000:08:09.0", "0000:08:09.1", "0000:08:09.2", "0000:08:09.3"]},
+            {"device": "eno2", "pci_addr": "0000:18:00.2", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1016", "vendor": "0x15b3", "vf_prod": "0x1013", "vf_addr": ["0000:08:0c.0", "0000:08:0c.1", "0000:08:0c.2", "0000:08:0c.3"]},
+            {"device": "eno3", "pci_addr": "0000:18:00.3", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0a.0", "0000:18:0a.1", "0000:18:0a.2", "0000:18:0a.3"]},
+            {"device": "eno4", "pci_addr": "0000:18:00.4", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0d.0", "0000:18:0d.1", "0000:18:0d.2", "0000:18:0d.3"]}
+        ]
+
+        self.sysfs_map_create(sysfs_map)
+
+        ''' Usecase: ProductID and VendorID, with mixed vendor NICs in sysfs_map  '''
+        user_config1 = [{'product_id': '1016', 'vendor_id': '15b3', 'trusted': 'true'}]
+        user_config2 = [{'product_id': '1572', 'vendor_id': '15b3', 'trusted': 'true', 'address': '0000:18:00.3'}]
+        user_config3 = [{'product_id': '1013', 'trusted': 'true', 'address': '0000:08:0c.*'}]
+
+        expected1_list = [{'product_id': '1016', 'vendor_id': '15b3', 'trusted': 'true', 'address': '0000:18:00.1'}]
+        expected3_list = [{'product_id': '1013', 'trusted': 'true', 'address': '0000:08:0c.0'},
+                          {'product_id': '1013', 'trusted': 'true', 'address': '0000:08:0c.1'},
+                          {'product_id': '1013', 'trusted': 'true', 'address': '0000:08:0c.2'}]
+
+        non_nicp, nicp = pci.generate_combined_configuration(user_config1, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, expected1_list)
+
+        non_nicp, nicp = pci.generate_combined_configuration(user_config2, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertEqual(pci_passthro, [])
+
+        non_nicp, nicp = pci.generate_combined_configuration(user_config3, system_configs_nonnicpart)
+        pci_passthro = (non_nicp + nicp)
+        self.assertCountEqual(pci_passthro, expected3_list)
+
+    def test_get_passthrough_allVFsused(self):
+        '''Usecase: Corner case where all VFs of device is used'''
+        system_configs_nonnicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 4, 'promisc': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 0}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v0', 'pci_address': '0000:18:0a.0', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 1}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v1', 'pci_address': '0000:18:0a.1', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 2}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v2', 'pci_address': '0000:18:0a.2', 'spoofcheck': 'off', 'trust': 'on'},
+            {'device': {'name': 'eno3', 'vfid': 3}, 'device_type': 'vf', 'max_tx_rate': 0,
+             'min_tx_rate': 0, 'name': 'eno3v3', 'pci_address': '0000:18:0a.3', 'spoofcheck': 'off', 'trust': 'on'}
+        ]
+
+        sysfs_map = [
+            {"device": "eno3", "pci_addr": "0000:18:00.3", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0a.0", "0000:18:0a.1", "0000:18:0a.2", "0000:18:0a.3"]},
+            {"device": "eno4", "pci_addr": "0000:18:00.4", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0d.0", "0000:18:0d.1", "0000:18:0d.2", "0000:18:0d.3"]}
+        ]
+        self.sysfs_map_create(sysfs_map)
+
+        user_config1 = [{'trusted': 'true', 'address': '0000:18:00.*'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config1, system_configs_nonnicpart)
+        self.assertEqual(nicp, [{'trusted': 'true', 'address': '0000:18:00.4'}])
+        self.assertEqual(non_nicp, [])
+
+        user_config2 = [{'trusted': 'true', 'product_id': '0x1572'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config2, system_configs_nonnicpart)
+        self.assertEqual(nicp, [{'trusted': 'true', 'product_id': '0x1572', 'address': '0000:18:00.4'}])
+        self.assertEqual(non_nicp, [])
+
+        user_config3 = [{'trusted': 'true', 'product_id': '0x154c'}]
+        non_nicp, nicp = pci.generate_combined_configuration(user_config3, system_configs_nonnicpart)
+        self.assertEqual(nicp, [{'trusted': 'true', 'product_id': '0x154c', 'address': '0000:18:00.4'}])
+        self.assertEqual(non_nicp, [])
+
+    def test_get_passthrough_err_devandaddr(self):
+        '''Usecase: Corner case where all VFs of device is used'''
+        system_configs_nonnicpart = [
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno3', 'numvfs': 4, 'promisc': 'on'},
+            {'device_type': 'pf', 'link_mode': 'legacy', 'name': 'eno4', 'numvfs': 4, 'promisc': 'on'},
+        ]
+
+        sysfs_map = [
+            {"device": "eno3", "pci_addr": "0000:18:00.3", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0a.0", "0000:18:0a.1", "0000:18:0a.2", "0000:18:0a.3"]},
+            {"device": "eno4", "pci_addr": "0000:18:00.4", "numvfs": 4, "total_vfs": "64", "pf_prod": "0x1572", "vendor": "0x8086", "vf_prod": "0x154c", "vf_addr": ["0000:18:0d.0", "0000:18:0d.1", "0000:18:0d.2", "0000:18:0d.3"]}
+        ]
+        self.sysfs_map_create(sysfs_map)
+
+        user_config1 = [{'trusted': 'true', 'address': '0000:18:00.*', 'devname': 'eno3'}]
+        try:
+            non_nicp, nicp = pci.generate_combined_configuration(user_config1, system_configs_nonnicpart)
+        except pci.InvalidConfigException:
+            pass

--- a/roles/edpm_derive_pci_device_spec/defaults/main.yml
+++ b/roles/edpm_derive_pci_device_spec/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "edpm_derive_pci_device_spec"
+
+# Defaults for PCI derive script (nic-partitioning is enabled)
+edpm_derive_pci_device_spec_conf_dir: '/var/lib/config-data/ansible-generated/derive_devicespec'
+
+edpm_derive_sriov_device_spec_list: ''
+edpm_derive_pci_device_spec_conf_file: 20-sriov-device-spec.conf
+edpm_derive_pci_device_spec_physmap_file: "{{ edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings | default('') }}"

--- a/roles/edpm_derive_pci_device_spec/meta/argument_specs.yml
+++ b/roles/edpm_derive_pci_device_spec/meta/argument_specs.yml
@@ -1,0 +1,18 @@
+---
+argument_specs:
+  # ./roles/edpm_derive_pci_device_spec/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_derive_pci_device_spec role.
+    options:
+      edpm_derive_sriov_device_spec_list:
+        type: list
+        default: []
+        description: Sriov device spec list.
+      edpm_derive_pci_device_spec_conf_file:
+        type: str
+        default: 20-sriov-device-spec.conf
+        description: Generated file with derived device_spec config
+      edpm_derive_pci_device_spec_physmap_file:
+        type: str
+        default: ''
+        description: Optional string phys_dev_mapping

--- a/roles/edpm_derive_pci_device_spec/meta/main.yml
+++ b/roles/edpm_derive_pci_device_spec/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  namespace: openstack
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_derive_pci_device_spec
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.9'
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_derive_pci_device_spec/molecule/default/collections.yml
+++ b/roles/edpm_derive_pci_device_spec/molecule/default/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+- name: community.general

--- a/roles/edpm_derive_pci_device_spec/molecule/default/converge.yml
+++ b/roles/edpm_derive_pci_device_spec/molecule/default/converge.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  become: true
+  hosts: all
+  pre_tasks:
+    - name: set basic user fact
+      set_fact:
+        ansible_user: "{{ ansible_user_id | default(lookup('env', 'USER'))}}"
+      when:
+        - ansible_user is undefined
+
+    - name: set basic home fact
+      set_fact:
+        ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+      when:
+        - ansible_user_dir is undefined
+  roles:
+    - role: "osp.edpm.edpm_derive_pci_device_spec"
+      vars:
+        edpm_derive_sriov_device_spec_list: [{"product_id": "test1"}]
+        edpm_derive_pci_device_spec_physmap_file: "sriov1:nic1"
+        edpm_derive_pci_device_spec_conf_dir: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"
+        edpm_derive_pci_device_spec_conf_file: "20-sriov-nova.conf"

--- a/roles/edpm_derive_pci_device_spec/molecule/default/molecule.yml
+++ b/roles/edpm_derive_pci_device_spec/molecule/default/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - verify
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_derive_pci_device_spec/molecule/default/prepare.yml
+++ b/roles/edpm_derive_pci_device_spec/molecule/default/prepare.yml
@@ -1,0 +1,38 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare test_deps
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+      test_deps_setup_edpm: true
+      test_deps_setup_stream: true
+    - role: osp.edpm.env_data
+
+- name: Setup user details
+  hosts: all
+  pre_tasks:
+    - name: set basic user fact
+      set_fact:
+        ansible_user: "{{ ansible_user_id | default(lookup('env', 'USER'))}}"
+      when:
+        - ansible_user is undefined
+    - name: set basic home fact
+      set_fact:
+        ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+      when:
+        - ansible_user_dir is undefined

--- a/roles/edpm_derive_pci_device_spec/molecule/default/verify.yml
+++ b/roles/edpm_derive_pci_device_spec/molecule/default/verify.yml
@@ -1,0 +1,14 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Verify derive pci device spec file exists
+      become: true
+      ansible.builtin.stat:
+        path: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data/20-sriov-nova.conf"
+      register: derive_pci_device_spec_exists
+    - name: Assert derive pci device spec file exists
+      ansible.builtin.assert:
+        that:
+          - derive_pci_device_spec_exists.stat.exists
+        fail_msg: "PCI device spec file does not exist!"

--- a/roles/edpm_derive_pci_device_spec/tasks/derive_pci_device_spec.yml
+++ b/roles/edpm_derive_pci_device_spec/tasks/derive_pci_device_spec.yml
@@ -1,0 +1,53 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+- name: Check valid input for edpm_derive_sriov_device_spec_list
+  ansible.builtin.fail:
+    msg: "List of sriov device_spec cannot be empty - edpm_derive_sriov_device_spec_list"
+  when: edpm_derive_sriov_device_spec_list | length == 0
+
+- name: Create neutron-sriov-agent directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ edpm_derive_pci_device_spec_conf_dir }}"
+    setype: "container_file_t"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0755"
+
+- name: Check if edpm node has the sriov nova conf
+  ansible.builtin.stat:
+    path: "{{ edpm_derive_pci_device_spec_conf_dir }}/{{ edpm_derive_pci_device_spec_conf_file }}"
+  register: sriov_device_spec_conf_check
+
+- name: Derive the sriov nic-partitioned pci device_spec addr
+  when:
+    - not sriov_device_spec_conf_check.stat.exists
+  become: true
+  block:
+    - name: Run derive_pci_passthrough_devicespec
+      edpm_derive_pci_passthrough_devicespec:
+        sriov_device_spec_map: "{{ edpm_derive_sriov_device_spec_list }}"
+        sriov_phydev_map: "{{ edpm_derive_pci_device_spec_physmap_file }}"
+        sriov_device_spec_out_file: "{{ edpm_derive_pci_device_spec_conf_dir }}/{{ edpm_derive_pci_device_spec_conf_file }}"
+      register: derive_pci_devicespec
+      changed_when: derive_pci_devicespec.rc == 0
+    - name: Print result of derived device_spec
+      ansible.builtin.debug:
+        msg: "{{ derive_pci_devicespec.device_spec }}"
+      when:
+        - derive_pci_devicespec.device_spec is defined

--- a/roles/edpm_derive_pci_device_spec/tasks/main.yml
+++ b/roles/edpm_derive_pci_device_spec/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Derive the SR-IOV device_spec config map for nic-partitionin
+  ansible.builtin.import_tasks: derive_pci_device_spec.yml

--- a/scripts/generate_molecule.py
+++ b/scripts/generate_molecule.py
@@ -28,7 +28,8 @@ PODMAN_EXCLUDED_ROLES = [
     'env_data',
     'edpm_ddp_package',
     'edpm_module_load',
-    'edpm_podman'
+    'edpm_podman',
+    'edpm_derive_pci_device_spec'
 ]
 
 


### PR DESCRIPTION
This role will generate the pci device_spec for sriov nic partitioning deployment.
The generated config file should be used to create device_spec configmap for custom nova dataplane service.

This has been re-factored from [PR](https://github.com/openstack-k8s-operators/edpm-ansible/pull/572)