### PR TITLE
Fix selinux labels check for /run/libvirt

### DIFF
--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -85,7 +85,7 @@
     - libvirt
   ansible.builtin.shell: |
     set -o pipefail
-    ls -lRZ /run/libvirt | grep container_*_t
+    ls -lRZ /run/libvirt | grep -E ':container_\S+_t'
   register: run_libvirt
   failed_when: run_libvirt.rc not in [0, 1]
   changed_when: false


### PR DESCRIPTION
Match the labels with regex to properly trigger restorecon