### PR TITLE
Clean edpm_neutron_metadata role from unused variable

### DIFF
--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -71,7 +71,6 @@ edpm_neutron_dhcp_rootwrap_DEFAULT_rlimit_nofile: 1024
 # neutron-dhcp-agent.conf
 # DEFAULT
 edpm_neutron_dhcp_agent_DEFAULT_state_path: '/var/lib/neutron'
-edpm_neutron_dhcp_agent_DEFAULT_host: '{{ ansible_facts["nodename"] }}'
 edpm_neutron_dhcp_agent_DEFAULT_resync_interval: 5
 edpm_neutron_dhcp_agent_DEFAULT_resync_throttle: 1
 edpm_neutron_dhcp_agent_DEFAULT_dhcp_driver: 'neutron.agent.linux.dhcp.Dnsmasq'

--- a/roles/edpm_neutron_dhcp/meta/argument_specs.yml
+++ b/roles/edpm_neutron_dhcp/meta/argument_specs.yml
@@ -111,10 +111,6 @@ argument_specs:
         default: '/var/lib/neutron'
         description: ''
         type: str
-      edpm_neutron_dhcp_agent_DEFAULT_host:
-        default: '{{ ansible_facts["nodename"] }}'
-        description: ''
-        type: str
       edpm_neutron_dhcp_agent_DEFAULT_resync_interval:
         default: 5
         description: ''

--- a/roles/edpm_neutron_dhcp/templates/neutron-dhcp-agent.conf.j2
+++ b/roles/edpm_neutron_dhcp/templates/neutron-dhcp-agent.conf.j2
@@ -2,7 +2,6 @@
 interface_driver = openvswitch
 ovs_use_veth = False
 state_path = {{ edpm_neutron_dhcp_agent_DEFAULT_state_path }}
-host = {{ edpm_neutron_dhcp_agent_DEFAULT_host }}
 resync_interval = {{ edpm_neutron_dhcp_agent_DEFAULT_resync_interval }}
 resync_throttle = {{ edpm_neutron_dhcp_agent_DEFAULT_resync_throttle }}
 dhcp_driver = {{ edpm_neutron_dhcp_agent_DEFAULT_dhcp_driver }}

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -29,8 +29,6 @@ edpm_neutron_metadata_agent_sidecar_debug: false
 edpm_neutron_metadata_agent_sidecar_haproxy_image_name: "{{ edpm_neutron_metadata_agent_image }}"
 
 # Neutron conf
-# DEFAULT
-edpm_neutron_metadata_agent_DEFAULT_host: '{{ ansible_facts["nodename"] }}'  # also in missing vars
 # edpm_ovn_metadata_agent_DEFAULT_: ''
 # oslo_concurrency
 edpm_neutron_metadata_agent_oslo_concurrency_lock_patch: '$state_path/lock'

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -43,7 +43,6 @@ argument_specs:
         description: ''
         type: str
       edpm_neutron_metadata_agent_DEFAULT_nova_metadata_host:
-        default: '{{ edpm_neutron_metadata_agent_DEFAULT_host }}'
         description: 'Nova Metadata host to forward metadata requests to.'
         type: str
       edpm_neutron_metadata_agent_DEFAULT_nova_metadata_protocol:

--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -41,7 +41,6 @@ edpm_neutron_sriov_common_volumes:
 edpm_neutron_sriov_DEFAULT_debug: false
 edpm_neutron_sriov_DEFAULT_rpc_response_timeout: 60
 edpm_neutron_sriov_DEFAULT_transport_url: ''
-edpm_neutron_sriov_DEFAULT_host: '{{ ansible_facts["nodename"] }}'
 # oslo_concurrency
 edpm_neutron_sriov_oslo_concurrency_lock_patch: '$state_path/lock'
 # oslo_messaging_rabbit

--- a/roles/edpm_neutron_sriov/meta/argument_specs.yml
+++ b/roles/edpm_neutron_sriov/meta/argument_specs.yml
@@ -50,10 +50,6 @@ argument_specs:
         default: ''
         description: ''
         type: str
-      edpm_neutron_sriov_DEFAULT_host:
-        default: '{{ ansible_facts["nodename"] }}'
-        description: ''
-        type: str
       edpm_neutron_sriov_oslo_concurrency_lock_patch:
         default: '$state_path/lock'
         description: ''


### PR DESCRIPTION
Variable 'edpm_neutron_metadata_agent_DEFAULT_host' defined in the edpm_neutron_metadata role wasn't actually used anywhere in the role except argument_specs.yml meta file where it was used as default value for the 'edpm_neutron_metadata_agent_DEFAULT_nova_metadata_host' variable (which was also not correct).
Variable 'edpm_neutron_metadata_agent_DEFAULT_host' is actually not needed anywhere as neutron_ovn_metadata_agent reports hostname on which it is run using hostname defined in the "ovn chassis" (and this is configured by the edpm_ovn role in external_ids in ovsdb).

Because of all of that mentioned above, this small patch removes that not used variable.