### PR TITLE
[adoption]Add a new role for pre adoption validation 

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -45,6 +45,7 @@ jobs:
         - edpm_telemetry
         - edpm_users
         - env_data
+        - edpm_pre_adoption_validation
 
     runs-on: ubuntu-22.04
     steps:

--- a/docs/source/playbooks/pre_adoption_validation.rst
+++ b/docs/source/playbooks/pre_adoption_validation.rst
@@ -1,0 +1,6 @@
+==================================
+Playbook - pre_adoption_validation
+==================================
+
+.. literalinclude:: ../../../playbooks/pre_adoption_validation.yml
+   :language: YAML

--- a/docs/source/roles/role-edpm_pre_adoption_validation.rst
+++ b/docs/source/roles/role-edpm_pre_adoption_validation.rst
@@ -1,0 +1,6 @@
+===================================
+Role - edpm_pre_adoption_validation
+===================================
+
+.. include::
+  ../collections/osp/edpm/edpm_pre_adoption_validation_role.rst

--- a/playbooks/pre_adoption_validation.yml
+++ b/playbooks/pre_adoption_validation.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Validate adoption configuration
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  become: true
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Validate adoption configuration
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_pre_adoption_validation
+      tags:
+        - osp.edpm.edpm_pre_adoption_validation

--- a/roles/edpm_pre_adoption_validation/defaults/main.yml
+++ b/roles/edpm_pre_adoption_validation/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+edpm_pre_adoption_validation_old_nova_config: /var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf
+edpm_pre_adoption_validation_old_neutron_config: /var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf

--- a/roles/edpm_pre_adoption_validation/handlers/main.yml
+++ b/roles/edpm_pre_adoption_validation/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/roles/edpm_pre_adoption_validation/meta/argument_specs.yml
+++ b/roles/edpm_pre_adoption_validation/meta/argument_specs.yml
@@ -1,0 +1,14 @@
+---
+argument_specs:
+  # ./roles/edpm_pre_adoption_validation/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_pre_adoption_validation role.
+    options:
+      edpm_pre_adoption_validation_old_nova_config:
+        type: str
+        default: /var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf
+        description: The path of the pre-adoption version of the nova.conf file on the node
+      edpm_pre_adoption_validation_old_neutron_config:
+        type: str
+        default: /var/lib/config-data/puppet-generated/neutron/etc/neutron/nova.conf
+        description: The path of the pre-adoption version of the neutron.conf file on the node

--- a/roles/edpm_pre_adoption_validation/meta/main.yml
+++ b/roles/edpm_pre_adoption_validation/meta/main.yml
@@ -1,0 +1,42 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_pre_adoption_validation
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-negative/converge.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-negative/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Converge
+      block:
+        - name: "Include role"
+          ansible.builtin.include_role:
+            name: osp.edpm.edpm_pre_adoption_validation
+
+        - name: "Check execution halted"
+          ansible.builtin.fail:
+            msg: "Execution should stop before this task"
+          register: should_not_run
+      rescue:
+        - name: Asset that role failed
+          ansible.builtin.assert:
+            that:
+              - should_not_run is not defined

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-negative/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-negative/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+- name: edpm-0
+  command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          edpm-0:
+            canonical_hostname: edpm-0.localdomain
+
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+     - destroy
+     - create
+     - prepare
+     - converge

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-negative/prepare.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-negative/prepare.yml
@@ -1,0 +1,46 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps  # noqa: role-name[path]
+    - role: osp.edpm.env_data
+- name: Setup DUT
+  hosts: all
+  pre_tasks:
+    - name: Ensure old config directory exists
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: "directory"
+        mode: "0777"
+      loop:
+        - {"path": "/var/lib/config-data/puppet-generated/nova/etc/nova/"}
+        - {"path": "/var/lib/config-data/puppet-generated/neutron/etc/neutron/"}
+
+    - name: Copy old configs to simulate a tripleo deployment
+      become: true
+      vars:
+        test_data: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/test-data"
+      ansible.builtin.copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        mode: preserve
+      loop:
+        - {"src": "{{ test_data }}/old_nova.conf", "dest": "/var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf"}
+        - {"src": "{{ test_data }}/old_neutron.conf", "dest": "/var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf"}
+  tasks: []

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-negative/test-data/old_neutron.conf
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-negative/test-data/old_neutron.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+host=oldname.localdomain

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-negative/test-data/old_nova.conf
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-negative/test-data/old_nova.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+host = oldname.localdomain

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-positive/converge.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-positive/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Converge
+      block:
+        - name: "Include role"
+          ansible.builtin.include_role:
+            name: osp.edpm.edpm_pre_adoption_validation
+      rescue:
+        - name: Assert that the validaton passed
+          ansible.builtin.fail:
+            msg: "validation should pass as the old and new configs are matching"

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-positive/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-positive/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+- name: edpm-0
+  command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          edpm-0:
+            canonical_hostname: edpm-0.localdomain
+
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+     - destroy
+     - create
+     - prepare
+     - converge

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-positive/prepare.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-positive/prepare.yml
@@ -1,0 +1,46 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps  # noqa: role-name[path]
+    - role: osp.edpm.env_data
+- name: Setup DUT
+  hosts: all
+  pre_tasks:
+    - name: Ensure old config directory exists
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: "directory"
+        mode: "0777"
+      loop:
+        - {"path": "/var/lib/config-data/puppet-generated/nova/etc/nova/"}
+        - {"path": "/var/lib/config-data/puppet-generated/neutron/etc/neutron/"}
+
+    - name: Copy old configs to simulate a tripleo deployment
+      become: true
+      vars:
+        test_data: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/test-data"
+      ansible.builtin.copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        mode: preserve
+      loop:
+        - {"src": "{{ test_data }}/old_nova.conf", "dest": "/var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf"}
+        - {"src": "{{ test_data }}/old_neutron.conf", "dest": "/var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf"}
+  tasks: []

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-positive/test-data/old_neutron.conf
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-positive/test-data/old_neutron.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+host=edpm-0.localdomain

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-positive/test-data/old_nova.conf
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-positive/test-data/old_nova.conf
@@ -1,0 +1,13 @@
+[DEFAULT]
+host = edpm-0.localdomain
+
+# other examples of lines starting with host
+[filter_scheduler]
+host_subset_size = 1
+
+[remote_debug]
+host = foo
+
+# Duplicate keys can happen
+[filter_scheduler]
+host_subset_size = 1

--- a/roles/edpm_pre_adoption_validation/molecule/greenfield/converge.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/greenfield/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Converge
+      block:
+        - name: "Include role"
+          ansible.builtin.include_role:
+            name: "osp.edpm.edpm_pre_adoption_validation"
+      rescue:
+        - name: Assert that validation is skipped
+          ansible.builtin.fail:
+            msg: "validation should be skipped on greenfield as no old config files exist"

--- a/roles/edpm_pre_adoption_validation/molecule/greenfield/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/greenfield/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+- name: edpm-0
+  command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          edpm-0:
+            canonical_hostname: edpm-0.localdomain
+
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+     - destroy
+     - create
+     - prepare
+     - converge

--- a/roles/edpm_pre_adoption_validation/molecule/greenfield/prepare.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/greenfield/prepare.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps  # noqa: role-name[path]
+    - role: osp.edpm.env_data
+- name: Setup DUT
+  hosts: all
+  pre_tasks: []
+  tasks: []

--- a/roles/edpm_pre_adoption_validation/tasks/main.yml
+++ b/roles/edpm_pre_adoption_validation/tasks/main.yml
@@ -1,0 +1,68 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Validate that hostname for the EDPM openstack services do not change
+  become: true
+  tags:
+    - adoption
+    - validation
+  block:
+    - name: Check if old nova.conf exists
+      ansible.builtin.stat:
+        path: "{{ edpm_pre_adoption_validation_old_nova_config }}"
+      register: nova_old_config_file
+
+    # NOTE(gibi): we intentionally using python configparser to extract
+    # the config value. Grep is not enough as multiple sections have 'host'
+    # key. Also we cannot rely on crudini as it is not available on the
+    # node being adopted.
+    - name: Compare old nova service host to {{ canonical_hostname }}
+      when: nova_old_config_file.stat.exists
+      ansible.builtin.command:
+        cmd: >
+          python3 -c
+          "import configparser as c;
+          p = c.ConfigParser(strict=False);
+          p.read('{{ edpm_pre_adoption_validation_old_nova_config }}');
+          print(p['DEFAULT']['host'])"
+      register: nova_old_config_output
+      changed_when: false
+      failed_when: nova_old_config_output.stdout != canonical_hostname
+
+    - name: Check if old neutron.conf exists
+      ansible.builtin.stat:
+        path: "{{ edpm_pre_adoption_validation_old_neutron_config }}"
+      register: neutron_old_config_file
+
+    - name: Compare old neutron service host to {{ canonical_hostname }}
+      when: neutron_old_config_file.stat.exists
+      ansible.builtin.command:
+        cmd: >
+          python3 -c
+          "import configparser as c;
+          p = c.ConfigParser(strict=False);
+          p.read('{{ edpm_pre_adoption_validation_old_neutron_config }}');
+          print(p['DEFAULT']['host'])"
+      register: neutron_old_config_output
+      changed_when: false
+      failed_when: neutron_old_config_output.stdout != canonical_hostname
+
+    - name: Print validated information
+      ansible.builtin.debug:
+        msg:
+          - "canonical_hostname: {{ canonical_hostname }}"
+          - "old nova service host config: {{ nova_old_config_output.stdout | default('not found')}}"
+          - "old neutron service host config: {{ neutron_old_config_output.stdout | default('not found')}}"


### PR DESCRIPTION
The new edpm_pre_adoption_validation role is intended to be used as
dataplane service in a separate deployment during adoption that runs
before the main deployment of the adoption process. This role does not
change anything on the EDPM nodes just reads their current (pre-adoption)
configuration and check if the intended new (post-adoption)
configuration will not cause any trouble.

The first check introduced by this commit ensures that the openstack
service hostname will not change during adoption on the EDPM nodes. Such
change would cause adoption failure in a later stage, after the point of
no return, as nova-compute will refuse to start up if it detects the
host rename. Additionally neutron services might fail too / or create
database corruption due to the host rename.

Implements: [OSPRH-5713](https://issues.redhat.com//browse/OSPRH-5713)