### PR TITLE
Create required file to enforce a reboot while calling `edpm_reboot` role

### DIFF
--- a/roles/edpm_bootstrap/tasks/fips.yml
+++ b/roles/edpm_bootstrap/tasks/fips.yml
@@ -45,11 +45,25 @@
       when: edpm_bootstrap_fips_mode == 'disabled'
 
     - name: Enforce a reboot to ensure the change of FIPS status
-      vars:
-        edpm_reboot_force_reboot: true
-      ansible.builtin.include_role:
-        name: edpm_reboot
       when: _fms_enable.rc == 0 or _fms_disable.rc == 0
+      block:
+        - name: Create directory required by edpm-reboot role
+          become: true
+          ansible.builtin.file:
+            path: /var/lib/openstack/reboot_required/
+            state: directory
+            mode: "0755"
+        - name: Create required file to enforce a reboot
+          become: true
+          ansible.builtin.file:
+            path: /var/lib/openstack/reboot_required/fips_reboot
+            state: touch
+            mode: "0600"
+        - name: Call edpm_reboot role
+          vars:
+            edpm_reboot_force_reboot: true
+          ansible.builtin.include_role:
+            name: edpm_reboot
 
     - name: Ensure that the proper FIPS status is enabled
       ansible.builtin.include_tasks: fips_status.yml


### PR DESCRIPTION
Declaring `edpm_reboot_force_reboot` wasn't enough to enforce a reboot using `edpm_reboot` role, so a proper file is now created in `/var/lib/openstack/reboot_required/` folder, as defined in the role itself [[1](https://github.com/openstack-k8s-operators/edpm-ansible/blob/9a1bfaf1029edff0eb7f54c162f9d26925851405/roles/edpm_reboot/tasks/main.yaml#L51-L80)]