### PR TITLE
Fix qemu cert path and permissions

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -67,4 +67,3 @@ edpm_libvirt_ceph_path: /var/lib/openstack/config/ceph
 # certs
 edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 edpm_libvirt_tls_cert_src_dir: /var/lib/openstack/certs/libvirt
-edpm_libvirt_tls_ca_src_dir: /var/lib/openstack/certs/libvirt

--- a/roles/edpm_libvirt/molecule/default/converge.yml
+++ b/roles/edpm_libvirt/molecule/default/converge.yml
@@ -17,5 +17,4 @@
     - role: osp.edpm.edpm_libvirt
       vars:
         edpm_libvirt_tls_cert_src_dir: /tmp/pki
-        edpm_libvirt_tls_ca_src_dir: /tmp/pki
         edpm_libvirt_tls_certs_enabled: true

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -17,7 +17,8 @@
     - {"path": "/var/lib/edpm-config/firewall", "owner": "root", "group": "root"}
     - {"path": "/etc/pki/libvirt", "owner": "root", "group": "root"}
     - {"path": "/etc/pki/libvirt/private", "owner": "root", "group": "root"}
-    - {"path": "/etc/pki/CA/libvirt", "owner": "root", "group": "root"}
+    - {"path": "/etc/pki/CA", "owner": "root", "group": "root"}
+    - {"path": "/etc/pki/qemu", "owner": "root", "group": "qemu"}
 
 - name: Render libvirt config files
   tags:
@@ -109,7 +110,7 @@
     persistent: true
     state: true
 
-- name: Move TLS files to the right location on the compute node
+- name: Move libvirt TLS files to the right location on the compute node
   tags:
     - configure
     - libvirt
@@ -119,7 +120,7 @@
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/libvirt/private/serverkey.pem"}
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt", "dest": "/etc/pki/libvirt/clientcert.pem"}
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/libvirt/private/clientkey.pem"}
-    - {"src": "{{ edpm_libvirt_tls_ca_src_dir }}/ca.crt", "dest": "/etc/pki/CA/cacert.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/ca.crt", "dest": "/etc/pki/CA/cacert.pem"}
   ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -127,4 +128,24 @@
     mode: "0600"
     owner: "root"
     group: "root"
+  when: edpm_libvirt_tls_certs_enabled
+
+- name: Move qemu TLS files to the right location on the compute node
+  tags:
+    - configure
+    - libvirt
+  become: true
+  loop:
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt", "dest": "/etc/pki/qemu/server-cert.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/qemu/server-key.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt", "dest": "/etc/pki/qemu/client-cert.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/qemu/client-key.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/ca.crt", "dest": "/etc/pki/qemu/ca-cert.pem"}
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    remote_src: true
+    mode: "0640"
+    owner: "root"
+    group: "qemu"
   when: edpm_libvirt_tls_certs_enabled

--- a/roles/edpm_libvirt/templates/qemu.conf.j2
+++ b/roles/edpm_libvirt/templates/qemu.conf.j2
@@ -2,7 +2,6 @@ max_files = 32768
 max_processes = 131072
 vnc_tls = 0
 vnc_tls_x509_verify = 0
-default_tls_x509_verify = 1
 nbd_tls = 0
 # NOTE(gibi): In tripleo the default range was intentionally changed to avoid
 # port usage conflicts. See https://review.openstack.org/#/c/561784
@@ -12,6 +11,7 @@ migration_port_max = 61215
 group = "{{ edpm_nova_libvirt_qemu_group }}"
 {% endif %}
 {% if edpm_libvirt_tls_certs_enabled | bool %}
-default_tls_x509_cert_dir = "/etc/pki/libvirt"
-default_tls_x509_verify = 1
+default_tls_x509_cert_dir = "/etc/pki/qemu"
 {% endif %}
+# FIXME(owalsh): remove this when client cert is valid
+default_tls_x509_verify = 0


### PR DESCRIPTION
Qemu is expecting the ca cert to be in a single dir and root:qemu 0640

https://docs.openstack.org/nova/latest/admin/secure-live-migration-with-qemu-native-tls.html#other-tls-environment-related-checks-on-compute-nodes

Client cert is not valid right now so disable mTLS until this is fixed.

Also remove unnecessary edpm_libvirt_tls_ca_src_dir var.