### PR TITLE
Disable libvirt TLS for now

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -65,6 +65,8 @@ edpm_libvirt_packages:
 edpm_libvirt_ceph_path: /var/lib/openstack/config/ceph
 
 # certs
-edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
+# FIXME: (owalsh) Disable until certs are correct https://libvirt.org/kbase/tlscerts.html
+# edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
+edpm_libvirt_tls_certs_enabled: false
 edpm_libvirt_tls_cert_src_dir: /var/lib/openstack/certs/libvirt
 edpm_libvirt_tls_ca_src_dir: /var/lib/openstack/certs/libvirt

--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -29,8 +29,13 @@ edpm_nova_config_src: /var/lib/openstack/configs
 edpm_nova_config_dest: /var/lib/openstack/config/nova
 edpm_nova_compute_image: "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"
 
-# certs
-edpm_nova_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
+# Libvirt TLS
+# FIXME: (owalsh) Disable until certs are correct https://libvirt.org/kbase/tlscerts.html
+# edpm_nova_live_migration_tls: "{{ edpm_tls_certs_enabled | default(False) }}"
+# edpm_nova_live_migration_native_tls: "{{ edpm_tls_certs_enabled | default(False) }}"
+edpm_nova_live_migration_tls: false
+edpm_nova_live_migration_native_tls: false
+
 # NOTE(sean-k-mooney): nova will use unix sockets for libvirt and communicate with ovs via tcp
 # so we will not need the libvirt or ovs client certs or ca. nova will communicate other services
 # via there api endpoints and will connect to rabbitmq. To support this we will need to trust

--- a/roles/edpm_nova/meta/argument_specs.yml
+++ b/roles/edpm_nova/meta/argument_specs.yml
@@ -25,10 +25,14 @@ argument_specs:
         description: |
           The path to the directory where the nova config files
           will be rendered on the compute node.
-      edpm_nova_tls_certs_enabled:
+      edpm_nova_live_migration_tls:
         type: bool
         default: false
-        description: Boolean to specify whether TLS certs are enabled.
+        description: Boolean to specify whether live migration TLS is enabled.
+      edpm_nova_live_migration_native_tls:
+        type: bool
+        default: false
+        description: Boolean to specify whether live migration NBD TLS is enabled.
       edpm_nova_compute_image:
         type: str
         default: "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"

--- a/roles/edpm_nova/molecule/default/converge.yml
+++ b/roles/edpm_nova/molecule/default/converge.yml
@@ -16,4 +16,5 @@
       vars:
         edpm_nova_config_src: "{{lookup('env', 'MOLECULE_PROJECT_DIRECTORY')}}/molecule/default/test-data"
         edpm_nova_tls_ca_src_dir: /tmp/pki
-        edpm_nova_tls_certs_enabled: true
+        edpm_nova_live_migration_tls: true
+        edpm_nova_live_migration_native_tls: true

--- a/roles/edpm_nova/tasks/install.yml
+++ b/roles/edpm_nova/tasks/install.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Check if ca bundle exists
+  ansible.builtin.stat:
+    path: "{{ edpm_nova_tls_ca_src_dir }}/tls-ca-bundle.pem"
+  register: ca_bundle_stat_res
+
 - name: Render nova container
   tags:
     - install
@@ -9,6 +14,8 @@
     dest: "/var/lib/openstack/config/containers/nova_compute.json"
     setype: "container_file_t"
     mode: "0644"
+  vars:
+    ca_bundle_exists: "{{ ca_bundle_stat_res.stat.exists }}"
   notify:
     - Restart nova
 - name: Deploy nova container

--- a/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
+++ b/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
@@ -2,8 +2,8 @@
 my_ip = {{ ctlplane_ip }}
 host = {{ canonical_hostname }}
 
-{% if edpm_nova_tls_certs_enabled | bool %}
 [libvirt]
-live_migration_with_native_tls = true
+live_migration_with_native_tls = {% if edpm_nova_live_migration_native_tls|bool %}true{% else %}false{% endif %}
+{% if edpm_nova_live_migration_tls|bool %}
 live_migration_scheme = tls
 {% endif %}

--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -10,8 +10,8 @@
     },
     "volumes": [
         "/var/lib/openstack/config/nova:/var/lib/kolla/config_files:ro",
-{% if edpm_nova_tls_certs_enabled %}
-	"{{ edpm_nova_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro",
+{% if ca_bundle_exists|bool %}
+        "{{ edpm_nova_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z",
 {% endif %}
         "/etc/localtime:/etc/localtime:ro",
         "/lib/modules:/lib/modules:ro",


### PR DESCRIPTION
The current certs are not valid for libvirt.
Specific requirements in https://libvirt.org/kbase/tlscerts.html

QEMU cert paths are also incorrect. Current dataplan-operator is broken https://github.com/openstack-k8s-operators/openstack-operator/pull/732#issuecomment-2041915225