### PR TITLE
Fix TLS for ceilometer

### DIFF
--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -30,3 +30,5 @@ edpm_telemetry_ceilometer_ipmi_image: quay.io/podified-antelope-centos9/openstac
 edpm_telemetry_certs: /var/lib/openstack/certs/telemetry
 # CA certs location for tls encryption
 edpm_telemetry_cacerts: /var/lib/openstack/cacerts/telemetry
+# If TLS should be enabled for telemetry
+edpm_telemetry_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"

--- a/roles/edpm_telemetry/templates/ceilometer_agent_compute.json.j2
+++ b/roles/edpm_telemetry/templates/ceilometer_agent_compute.json.j2
@@ -16,10 +16,10 @@
         "/etc/hosts:/etc/hosts:ro",
         "/etc/pki/tls/certs/ca-bundle.trust.crt:/etc/pki/tls/certs/ca-bundle.trust.crt:ro",
         "/etc/localtime:/etc/localtime:ro",
-        "/etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:ro",
         "/etc/pki/ca-trust/source/anchors:/etc/pki/ca-trust/source/anchors:ro",
-        "/dev/log:/dev/log",
-        "/etc/pki/tls/cert.pem:/etc/pki/tls/cert.pem:ro",
-        "/etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:ro"
+{% if edpm_telemetry_tls_certs_enabled %}
+	"{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z",
+{% endif %}
+        "/dev/log:/dev/log"
     ]
 }

--- a/roles/edpm_telemetry/templates/ceilometer_agent_ipmi.json.j2
+++ b/roles/edpm_telemetry/templates/ceilometer_agent_ipmi.json.j2
@@ -15,10 +15,10 @@
         "/etc/hosts:/etc/hosts:ro",
         "/etc/pki/tls/certs/ca-bundle.trust.crt:/etc/pki/tls/certs/ca-bundle.trust.crt:ro",
         "/etc/localtime:/etc/localtime:ro",
-        "/etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:ro",
         "/etc/pki/ca-trust/source/anchors:/etc/pki/ca-trust/source/anchors:ro",
-        "/dev/log:/dev/log",
-        "/etc/pki/tls/cert.pem:/etc/pki/tls/cert.pem:ro",
-        "/etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:ro"
+{% if edpm_telemetry_tls_certs_enabled %}
+        "{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z",
+{% endif %}
+        "/dev/log:/dev/log"
     ]
 }


### PR DESCRIPTION
Ceilometer was failing to access the CA certificate, which wasn't correctly mounted. This mounts the CA certificate to the expected location if TLS is enabled.

Jira: https://issues.redhat.com/browse/OSPRH-6177