### PR TITLE
Add OVN TLS certs for metadata agent

### DIFF
--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -52,3 +52,13 @@ edpm_neutron_metadata_agent_agent_root_helper: 'sudo neutron-rootwrap /etc/neutr
 edpm_neutron_metadata_agent_ovs_ovsdb_connection: 'tcp:127.0.0.1:6640'
 edpm_neutron_metadata_agent_ovs_ovsdb_connection_timeout: '180'
 edpm_neutron_metadata_agent_ovn_ovsdb_probe_interval: '60000'
+
+# tls
+edpm_neutron_metadata_agent_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
+
+edpm_neutron_metadata_tls_volumes:
+  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron_metadata') }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron_metadata') }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron_metadata') }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron_metadata') }}/tls-ca-bundle.pem:\
+    /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -129,3 +129,13 @@ argument_specs:
         default: "{{ edpm_neutron_metadata_agent_image }}"
         description: Image used to spawn haproxy sidecar containers.
         type: str
+      edpm_neutron_metadata_agent_tls_enabled:
+        default: false
+        description: >
+          Enable TLS for ovnsb connection
+      edpm_neutron_metadata_tls_volumes:
+        default:
+          - /var/lib/openstack/certs/neutron_metadata_agent/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z
+          - /var/lib/openstack/certs/neutron_metadata_agent/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
+          - /var/lib/openstack/certs/neutron_metadata_agent/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
+          - /var/lib/openstack/cacerts/neutron_metadata_agent/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z

--- a/roles/edpm_neutron_metadata/templates/ovn_metadata_agent.yaml.j2
+++ b/roles/edpm_neutron_metadata/templates/ovn_metadata_agent.yaml.j2
@@ -1,3 +1,12 @@
+{%- set edpm_neutron_metadata_volumes = [] %}
+{%- set edpm_neutron_metadata_volumes =
+        edpm_neutron_metadata_volumes +
+        edpm_neutron_metadata_common_volumes %}
+{%- if edpm_neutron_metadata_agent_tls_enabled | bool %}
+{%- set edpm_neutron_metadata_volumes =
+        edpm_neutron_metadata_volumes +
+        edpm_neutron_metadata_tls_volumes %}
+{%- endif -%}
 start_order: 2
 image: "{{ edpm_neutron_metadata_agent_image }}"
 net: host
@@ -8,11 +17,6 @@ user: root
 restart: always
 depends_on:
   - openvswitch.service
-volumes:
-  {% set edpm_neutron_metadata_volumes = [] %}
-  {%- set edpm_neutron_metadata_volumes =
-          edpm_neutron_metadata_volumes +
-          edpm_neutron_metadata_common_volumes %}
-  {{ edpm_neutron_metadata_volumes }}
+volumes: {{ edpm_neutron_metadata_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_ovn/templates/ovn_controller.yaml.j2
+++ b/roles/edpm_ovn/templates/ovn_controller.yaml.j2
@@ -1,3 +1,12 @@
+{%- set edpm_ovn_controller_volumes = [] %}
+{%- set edpm_ovn_controller_volumes =
+        edpm_ovn_controller_volumes +
+        edpm_ovn_controller_common_volumes %}
+{%- if edpm_ovn_tls_enabled | bool %}
+{%- set edpm_ovn_controller_volumes =
+        edpm_ovn_controller_volumes +
+        edpm_ovn_controller_tls_volumes %}
+{%- endif -%}
 start_order: 1
 image: "{{ edpm_ovn_controller_agent_image }}"
 net: host
@@ -8,18 +17,7 @@ depends_on:
   - openvswitch.service
 {% if edpm_ovn_cpu_set | default(false) %}
 cpuset_cpus: "{{ edpm_ovn_cpu_set }}"
-{% endif -%}
-volumes:
-  {% set edpm_ovn_controller_volumes = [] %}
-  {%- set edpm_ovn_controller_volumes =
-          edpm_ovn_controller_volumes +
-          edpm_ovn_controller_common_volumes %}
-  {%- if edpm_ovn_tls_enabled | bool -%}
-  {%- set edpm_ovn_controller_volumes =
-         edpm_ovn_controller_volumes +
-         edpm_ovn_controller_common_volumes +
-         edpm_ovn_controller_tls_volumes -%}
-  {% endif %}
-  {{ edpm_ovn_controller_volumes }}
+{% endif %}
+volumes: {{ edpm_ovn_controller_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_ovn_bgp_agent/templates/bgp_ovn_controller.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/bgp_ovn_controller.yaml.j2
@@ -1,3 +1,13 @@
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes = [] %}
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
+        edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
+        edpm_ovn_bgp_agent_local_ovn_controller_volumes %}
+{%- if edpm_enable_internal_tls|bool %}
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
+        edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes %}
+{%- endif -%}
 start_order: 1
 image: "{{ edpm_ovn_bgp_agent_local_ovn_controller_image }}"
 net: host
@@ -8,20 +18,7 @@ depends_on:
   - openvswitch.service
 {% if edpm_ovn_cpu_set|default(false) %}
 cpuset_cpus: "{{ edpm_ovn_cpu_set }}"
-{% endif -%}
-volumes:
-  {% set edpm_ovn_bgp_agent_local_ovn_cluster_volumes = [] %}
-  {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
-          edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
-          edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-          edpm_ovn_bgp_agent_local_ovn_controller_volumes %}
-  {%- if edpm_enable_internal_tls|bool -%}
-  {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
-         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
-         edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-         edpm_ovn_bgp_agent_local_ovn_controller_volumes +
-         edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes -%}
-  {% endif %}
-  {{ edpm_ovn_bgp_agent_local_ovn_cluster_volumes }}
+{% endif %}
+volumes: {{ edpm_ovn_bgp_agent_local_ovn_cluster_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_ovn_bgp_agent/templates/nb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/nb_db_server.yaml.j2
@@ -1,3 +1,13 @@
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes = [] %}
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
+        edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
+        edpm_ovn_bgp_agent_local_ovn_nb_volumes %}
+{%- if edpm_enable_internal_tls|bool %}
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
+        edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes %}
+{%- endif -%}
 start_order: 1
 image: "{{ edpm_ovn_bgp_agent_local_ovn_nb_db_image }}"
 net: host
@@ -8,20 +18,7 @@ depends_on:
   - openvswitch.service
 {% if edpm_ovn_cpu_set|default(false) %}
 cpuset_cpus: "{{ edpm_ovn_cpu_set }}"
-{% endif -%}
-volumes:
-  {% set edpm_ovn_bgp_agent_local_ovn_cluster_volumes = [] %}
-  {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
-          edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
-          edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-          edpm_ovn_bgp_agent_local_ovn_nb_volumes %}
-  {%- if edpm_enable_internal_tls|bool -%}
-  {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
-         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
-         edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-         edpm_ovn_bgp_agent_local_ovn_nb_volumes +
-         edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes -%}
-  {% endif %}
-  {{ edpm_ovn_bgp_agent_local_ovn_cluster_volumes }}
+{% endif %}
+volumes: {{ edpm_ovn_bgp_agent_local_ovn_cluster_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_ovn_bgp_agent/templates/northd.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/northd.yaml.j2
@@ -1,3 +1,13 @@
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes = [] %}
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
+        edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
+        edpm_ovn_bgp_agent_local_ovn_northd_volumes %}
+{%- if edpm_enable_internal_tls|bool %}
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
+        edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes %}
+{%- endif -%}
 start_order: 1
 image: "{{ edpm_ovn_bgp_agent_local_ovn_northd_image }}"
 net: host
@@ -8,20 +18,7 @@ depends_on:
   - openvswitch.service
 {% if edpm_ovn_cpu_set|default(false) %}
 cpuset_cpus: "{{ edpm_ovn_cpu_set }}"
-{% endif -%}
-volumes:
-  {% set edpm_ovn_bgp_agent_local_ovn_cluster_volumes = [] %}
-  {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
-          edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
-          edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-          edpm_ovn_bgp_agent_local_ovn_northd_volumes %}
-  {%- if edpm_enable_internal_tls|bool -%}
-  {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
-         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
-         edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-         edpm_ovn_bgp_agent_local_ovn_northd_volumes +
-         edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes -%}
-  {% endif %}
-  {{ edpm_ovn_bgp_agent_local_ovn_cluster_volumes }}
+{% endif %}
+volumes: {{ edpm_ovn_bgp_agent_local_ovn_cluster_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_ovn_bgp_agent/templates/ovn_bgp_agent.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/ovn_bgp_agent.yaml.j2
@@ -1,3 +1,22 @@
+{%- set edpm_ovn_bgp_agent_volumes = [] %}
+{%- set edpm_ovn_bgp_agent_volumes =
+        edpm_ovn_bgp_agent_volumes +
+        edpm_ovn_bgp_agent_common_volumes %}
+{%- if edpm_ovn_bgp_agent_local_ovn_routing|bool %}
+{%- set edpm_ovn_bgp_agent_volumes =
+        edpm_ovn_bgp_agent_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes %}
+{%- endif %}
+{%- if edpm_ovn_bgp_agent_internal_tls_enable|bool %}
+{%- set edpm_ovn_bgp_agent_volumes =
+        edpm_ovn_bgp_agent_volumes +
+        edpm_ovn_bgp_agent_tls_volumes %}
+{%- if edpm_ovn_bgp_agent_local_ovn_routing|bool %}
+{%- set edpm_ovn_bgp_agent_volumes =
+        edpm_ovn_bgp_agent_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes %}
+{%- endif %}
+{%- endif -%}
 start_order: 0
 image: "{{ edpm_ovn_bgp_agent_image }}"
 net: host
@@ -6,30 +25,6 @@ user: root
 restart: always
 depends_on:
   - openvswitch.service
-volumes:
-  {% set edpm_ovn_bgp_agent_volumes = [] %}
-  {%- set edpm_ovn_bgp_agent_volumes =
-          edpm_ovn_bgp_agent_volumes +
-          edpm_ovn_bgp_agent_common_volumes %}
-  {% if edpm_ovn_bgp_agent_local_ovn_routing|bool %}
-  {%- set edpm_ovn_bgp_agent_volumes =
-          edpm_ovn_bgp_agent_volumes +
-          edpm_ovn_bgp_agent_common_volumes +
-          edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes -%}
-  {% endif %}
-  {% if edpm_ovn_bgp_agent_internal_tls_enable|bool %}
-  {%- set edpm_ovn_bgp_agent_volumes =
-         edpm_ovn_bgp_agent_volumes +
-         edpm_ovn_bgp_agent_common_volumes +
-         edpm_ovn_bgp_agent_tls_volumes -%}
-  {% if edpm_ovn_bgp_agent_local_ovn_routing|bool %}
-  {%- set edpm_ovn_bgp_agent_volumes =
-          edpm_ovn_bgp_agent_volumes +
-          edpm_ovn_bgp_agent_common_volumes +
-          edpm_ovn_bgp_agent_tls_volumes +
-          edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes -%}
-  {% endif %}
-  {% endif %}
-  {{ edpm_ovn_bgp_agent_volumes }}
+volumes: {{ edpm_ovn_bgp_agent_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_ovn_bgp_agent/templates/sb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/sb_db_server.yaml.j2
@@ -1,3 +1,13 @@
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes = [] %}
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
+        edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
+        edpm_ovn_bgp_agent_local_ovn_sb_volumes %}
+{%- if edpm_enable_internal_tls|bool %}
+{%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
+        edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes %}
+{%- endif -%}
 start_order: 1
 image: "{{ edpm_ovn_bgp_agent_local_ovn_sb_db_image }}"
 net: host
@@ -8,20 +18,7 @@ depends_on:
   - openvswitch.service
 {% if edpm_ovn_cpu_set|default(false) %}
 cpuset_cpus: "{{ edpm_ovn_cpu_set }}"
-{% endif -%}
-volumes:
-  {% set edpm_ovn_bgp_agent_local_ovn_cluster_volumes = [] %}
-  {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
-          edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
-          edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-          edpm_ovn_bgp_agent_local_ovn_sb_volumes %}
-  {%- if edpm_enable_internal_tls|bool -%}
-  {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
-         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
-         edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-         edpm_ovn_bgp_agent_local_ovn_sb_volumes +
-         edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes -%}
-  {% endif %}
-  {{ edpm_ovn_bgp_agent_local_ovn_cluster_volumes }}
+{% endif %}
+volumes: {{ edpm_ovn_bgp_agent_local_ovn_cluster_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS


### PR DESCRIPTION
Metadata agent requires TLS certs to access the southdb. Also cleanup dup volume mounts in ovn services.