### PR TITLE
Re-enable libvirt TLS but not NBD TLS

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -66,7 +66,6 @@ edpm_libvirt_ceph_path: /var/lib/openstack/config/ceph
 
 # certs
 # FIXME: (owalsh) Disable until certs are correct https://libvirt.org/kbase/tlscerts.html
-# edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_libvirt_tls_certs_enabled: false
+edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 edpm_libvirt_tls_cert_src_dir: /var/lib/openstack/certs/libvirt
 edpm_libvirt_tls_ca_src_dir: /var/lib/openstack/certs/libvirt

--- a/roles/edpm_libvirt/templates/qemu.conf.j2
+++ b/roles/edpm_libvirt/templates/qemu.conf.j2
@@ -2,7 +2,7 @@ max_files = 32768
 max_processes = 131072
 vnc_tls = 0
 vnc_tls_x509_verify = 0
-default_tls_x509_verify = 1
+default_tls_x509_verify = 0
 nbd_tls = 0
 # NOTE(gibi): In tripleo the default range was intentionally changed to avoid
 # port usage conflicts. See https://review.openstack.org/#/c/561784
@@ -12,6 +12,7 @@ migration_port_max = 61215
 group = "{{ edpm_nova_libvirt_qemu_group }}"
 {% endif %}
 {% if edpm_libvirt_tls_certs_enabled | bool %}
-default_tls_x509_cert_dir = "/etc/pki/libvirt"
-default_tls_x509_verify = 1
+# FIXME(owalsh): disable until QEMU hostname validation issue is resolved
+# default_tls_x509_cert_dir = "/etc/pki/libvirt"
+# default_tls_x509_verify = 1
 {% endif %}

--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -30,10 +30,9 @@ edpm_nova_config_dest: /var/lib/openstack/config/nova
 edpm_nova_compute_image: "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"
 
 # Libvirt TLS
-# FIXME: (owalsh) Disable until certs are correct https://libvirt.org/kbase/tlscerts.html
-# edpm_nova_live_migration_tls: "{{ edpm_tls_certs_enabled | default(False) }}"
+edpm_nova_live_migration_tls: "{{ edpm_tls_certs_enabled | default(False) }}"
+# FIXME: (owalsh) disable until QEMU hostname validation is resolved
 # edpm_nova_live_migration_native_tls: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_nova_live_migration_tls: false
 edpm_nova_live_migration_native_tls: false
 
 # NOTE(sean-k-mooney): nova will use unix sockets for libvirt and communicate with ovs via tcp

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -63,7 +63,7 @@
     - name: Assert libvirt is configured to use tls for live migration
       ansible.builtin.assert:
         that:
-          - "'live_migration_with_native_tls = true' in host_specific_config.content | b64decode"
+          - "'live_migration_with_native_tls = True' in host_specific_config.content | b64decode"
           - "'live_migration_scheme = tls' in host_specific_config.content | b64decode"
 
     - name: Assert that host is rendered into the host specific config

--- a/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
+++ b/roles/edpm_nova/templates/02-nova-host-specific.conf.j2
@@ -3,7 +3,7 @@ my_ip = {{ ctlplane_ip }}
 host = {{ canonical_hostname }}
 
 [libvirt]
-live_migration_with_native_tls = {% if edpm_nova_live_migration_native_tls|bool %}true{% else %}false{% endif %}
+live_migration_with_native_tls = {{ edpm_nova_live_migration_native_tls|bool }}
 {% if edpm_nova_live_migration_tls|bool %}
 live_migration_scheme = tls
 {% endif %}


### PR DESCRIPTION
Related: [OSPRH-2387](https://issues.redhat.com//browse/OSPRH-2387)