### PR TITLE
[edpm_nova]Do not add immutable flag to compute_id 

### DIFF
--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -178,5 +178,8 @@
     owner: nova
     group: nova
     mode: "0400"
-    attributes: "+i"
+    # NOTE(gibi): podman 4.6.0 (OSP 17.1) has a race condition that leads to
+    # container startup failure if a mounted file has the attribute set
+    # while podman 4.9.4 (OSP 18) does not show this issue
+    # attributes: "+i"
   when: compute_id.stat.exists


### PR DESCRIPTION
The podman version 4.6.0 has a bug that causes that sometimes a
container fails to start if it mounts an file with +i flag set.
This podman version is used in the adoption form state making the
adoption unstable (1 in 8 CI run fails). The greenfield 18 deployment
uses podman 4.9.4 that does not show this error. So to make the adoption
stable the edpm_nova role will not add the +i flag to existing
compute_id files. Still if the role pre-generates the file that means it
is a greenfield run so the flag can be, and will be, set safely.