### PR TITLE
Check an FQDN is set

### DIFF
--- a/roles/edpm_nodes_validation/defaults/main.yml
+++ b/roles/edpm_nodes_validation/defaults/main.yml
@@ -22,5 +22,7 @@ edpm_nodes_validation_hide_sensitive_logs: true
 edpm_nodes_validation_ping_test_ips: []
 edpm_nodes_validation_validate_controllers_icmp: true
 edpm_nodes_validation_validate_fqdn: false
+edpm_nodes_validation_validate_fqdn_hosts_file: /etc/hosts
+edpm_nodes_validation_check_for_fqdn: true
 edpm_nodes_validation_validate_gateway_icmp: true
 edpm_nodes_validation_ping_test_gateway_ips: []

--- a/roles/edpm_nodes_validation/meta/argument_specs.yml
+++ b/roles/edpm_nodes_validation/meta/argument_specs.yml
@@ -16,10 +16,18 @@ argument_specs:
         description: Attempt to reach controllers with ping.
         type: bool
         default: true
+      edpm_nodes_validation_check_for_fqdn:
+        description: Verify if an FQDN is set. Typically required for TLS-e.
+        type: bool
+        default: true
       edpm_nodes_validation_validate_fqdn:
         description: Verify if hostname matches FQDN from /etc/hosts
         type: bool
         default: false
+      edpm_nodes_validation_validate_fqdn_hosts_file:
+        description: Hosts file to check for verifying that hostname matches FQDN
+        type: str
+        default: /etc/hosts
       edpm_nodes_validation_validate_gateway_icmp:
         description: Attempt to reach gateway with ping.
         type: bool

--- a/roles/edpm_nodes_validation/molecule/default/prepare.yml
+++ b/roles/edpm_nodes_validation/molecule/default/prepare.yml
@@ -26,5 +26,12 @@
       ansible.builtin.dnf:
         name: hostname
         state: present
+    - name: Set a FQDN
+      command: hostname instance.localdomain
+    - name: Add FQDN to /tmp/hosts
+      lineinfile:
+        path: /tmp/hosts
+        line: 127.0.0.1 instance.localdomain instance
+        create: true
   roles:
     - role: osp.edpm.env_data

--- a/roles/edpm_nodes_validation/molecule/default/test_vars.yml
+++ b/roles/edpm_nodes_validation/molecule/default/test_vars.yml
@@ -1,1 +1,2 @@
 edpm_nodes_validation_validate_fqdn: true
+edpm_nodes_validation_validate_fqdn_hosts_file: /tmp/hosts

--- a/roles/edpm_nodes_validation/tasks/main.yml
+++ b/roles/edpm_nodes_validation/tasks/main.yml
@@ -64,11 +64,26 @@
     - edpm_nodes_validation_validate_controllers_icmp|bool
     - edpm_nodes_validation_ping_test_ips | length > 0
 
-- name: Verify the configured FQDN vs /etc/hosts
+- name: Verify a FQDN is set block
+  when:
+    - edpm_nodes_validation_check_for_fqdn|bool
+  block:
+    - name: Run hostname -f
+      ansible.builtin.command: hostname -f
+      register: hostname
+      changed_when: false
+
+    - name: Verify a FQDN is set
+      ansible.builtin.assert:
+        that: hostname.stdout.find(".") != -1
+        fail_msg: "{{ hostname.stdout }} does not contain . and does not appear to be an FQDN."
+        success_msg: "{{ hostname.stdout }} contains . and appears to be an FQDN."
+
+- name: Verify the configured FQDN vs {{ edpm_nodes_validation_validate_fqdn_hosts_file }}
   ansible.builtin.shell: |
     HOSTNAME=$(hostname)
     SHORT_NAME=$(hostname -s)
-    FQDN_FROM_HOSTS=$(awk '$1 !~ /#/ && $3 == "'${SHORT_NAME}'"{print $2}' /etc/hosts)
+    FQDN_FROM_HOSTS=$(awk '$1 !~ /#/ && $3 == "'${SHORT_NAME}'"{print $2}' {{ edpm_nodes_validation_validate_fqdn_hosts_file }})
     if [[ $HOSTNAME != $FQDN_FROM_HOSTS ]]; then
       echo "FAILURE"
       echo -e "System hostname: ${HOSTNAME}\nEntry from /etc/hosts: ${FQDN_FROM_HOSTS}\n"


### PR DESCRIPTION
An FQDN should be set, and a validation is added to check. The
validation can be disabled with the edpm_nodes_validation_check_for_fqdn
variable.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/797
Jira: https://issues.redhat.com/browse/OSPRH-6187
Jira: [OSPRH-16536](https://issues.redhat.com//browse/OSPRH-16536)
Signed-off-by: James Slagle <jslagle@redhat.com>
