### PR TITLE
[edpm_update] Added `edpm_update` role and `update` playbook

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -43,6 +43,7 @@ jobs:
         - edpm_timezone
         - edpm_tuned
         - edpm_telemetry
+        - edpm_update
         - edpm_users
         - env_data
         - edpm_pre_adoption_validation

--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -1,0 +1,13 @@
+---
+
+- name: EDPM Update
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Import edpm_update
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_update
+      tags:
+        - edpm_update

--- a/roles/edpm_update/defaults/main.yml
+++ b/roles/edpm_update/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# Toggle to enable/disable packages updates
+edpm_update_enable_packages_update: true
+
+# Toggle to enable/disable containers updates
+edpm_update_enable_containers_update: true

--- a/roles/edpm_update/defaults/main.yml
+++ b/roles/edpm_update/defaults/main.yml
@@ -26,3 +26,5 @@ edpm_update_enable_containers_update: true
 # List of packages to exclude from the update
 edpm_update_exclude_packages:
   - openvswitch
+
+edpm_update_running_services: "{{ edpm_services_override | default(edpm_services) }}"

--- a/roles/edpm_update/defaults/main.yml
+++ b/roles/edpm_update/defaults/main.yml
@@ -22,3 +22,7 @@ edpm_update_enable_packages_update: true
 
 # Toggle to enable/disable containers updates
 edpm_update_enable_containers_update: true
+
+# List of packages to exclude from the update
+edpm_update_exclude_packages:
+  - openvswitch

--- a/roles/edpm_update/meta/argument_specs.yml
+++ b/roles/edpm_update/meta/argument_specs.yml
@@ -17,3 +17,9 @@ argument_specs:
         default:
           - opensvswitch
         description: List of packages to exclude from the update
+      edpm_update_running_services:
+        type: list
+        default: edpm_services
+        description: >
+          Used to select which list of services are running
+          on the machine. The list is provided by dataplane-operator.

--- a/roles/edpm_update/meta/argument_specs.yml
+++ b/roles/edpm_update/meta/argument_specs.yml
@@ -13,3 +13,8 @@ argument_specs:
         type: bool
         default: true
         description: Toggle to enable/disable containers updates
+      edpm_update_exclude_packages:
+        type: list
+        default:
+          - opensvswitch
+        description: List of packages to exclude from the update

--- a/roles/edpm_update/meta/argument_specs.yml
+++ b/roles/edpm_update/meta/argument_specs.yml
@@ -3,7 +3,6 @@ argument_specs:
   # ./roles/edpm_update/tasks/main.yml entry point
   main:
     short_description: The main entry point for the edpm_update role.
-    description: Multiple lines description
     options:
       edpm_update_enable_packages_update:
         type: bool

--- a/roles/edpm_update/meta/argument_specs.yml
+++ b/roles/edpm_update/meta/argument_specs.yml
@@ -1,0 +1,15 @@
+---
+argument_specs:
+  # ./roles/edpm_update/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_update role.
+    description: Multiple lines description
+    options:
+      edpm_update_enable_packages_update:
+        type: bool
+        default: true
+        description: Toggle to enable/disable packages updates
+      edpm_update_enable_containers_update:
+        type: bool
+        default: true
+        description: Toggle to enable/disable containers updates

--- a/roles/edpm_update/meta/main.yml
+++ b/roles/edpm_update/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_update
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_update/molecule/default/Containerfile.j2
+++ b/roles/edpm_update/molecule/default/Containerfile.j2
@@ -1,0 +1,13 @@
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos9-wallaby/current/delorean.repo && \
+    dnf -y install sudo python3-libselinux selinux-policy {{ item.pkg_extras | default('') }} && \
+    dnf install -y python*tripleo-repos && \
+    dnf clean all -y
+
+CMD [ '/sbin/init' ]

--- a/roles/edpm_update/molecule/default/converge.yml
+++ b/roles/edpm_update/molecule/default/converge.yml
@@ -23,3 +23,4 @@
         name: osp.edpm.edpm_update
       vars:
         edpm_update_enable_containers_update: false
+        edpm_services: []

--- a/roles/edpm_update/molecule/default/converge.yml
+++ b/roles/edpm_update/molecule/default/converge.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Call edpm_update role"
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_update
+      vars:
+        edpm_update_enable_containers_update: false

--- a/roles/edpm_update/molecule/default/molecule.yml
+++ b/roles/edpm_update/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ driver:
   name: podman
 platforms:
 - command: /sbin/init
-  dockerfile: ../../../../molecule/common/Containerfile.j2
+  dockerfile: Containerfile.j2
   image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
   name: instance
   privileged: true

--- a/roles/edpm_update/molecule/default/molecule.yml
+++ b/roles/edpm_update/molecule/default/molecule.yml
@@ -1,0 +1,38 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          instance:
+            canonical_hostname: edpm-0.localdomain
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - verify
+  - cleanup
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_update/molecule/default/prepare.yml
+++ b/roles/edpm_update/molecule/default/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: osp.edpm.env_data

--- a/roles/edpm_update/tasks/containers.yml
+++ b/roles/edpm_update/tasks/containers.yml
@@ -4,6 +4,8 @@
   ansible.builtin.include_role:
     name: osp.edpm.edpm_podman
     tasks_from: login.yml
+    apply:
+      become: true
   tags:
     - edpm_podman
     - edpm_update
@@ -12,94 +14,116 @@
   ansible.builtin.include_role:
     name: osp.edpm.edpm_iscsid
     tasks_from: run.yml
+    apply:
+      become: true
   tags:
     - edpm_iscsid
     - edpm_update
-  when: '"nova-storage" in edpm_services'
+  when: '"nova-storage" in edpm_update_running_services'
 
 - name: Updates containers for edpm_ovn role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_ovn
     tasks_from: run.yml
+    apply:
+      become: true
   tags:
     - edpm_ovn
     - edpm_update
-  when: '"ovn" in edpm_services'
+  when: '"ovn" in edpm_update_running_services'
 
 - name: Updates containers for edpm_frr role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_frr
     tasks_from: run.yml
+    apply:
+      become: true
   tags:
     - edpm_frr
     - edpm_update
-  when: '"frr" in edpm_services'
+  when: '"frr" in edpm_update_running_services'
 
 - name: Updates containers for edpm_ovn_bgp_agent role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_ovn_bgp_agent
     tasks_from: run.yml
+    apply:
+      become: true
   tags:
     - edpm_ovn_bgp_agent
     - edpm_update
-  when: '"ovn-bgp-agent" in edpm_services'
+  when: '"ovn-bgp-agent" in edpm_update_running_services'
 
 - name: Updates containers for edpm_neutron_metadata role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_neutron_metadata
     tasks_from: run.yml
+    apply:
+      become: true
   tags:
     - edpm_neutron_metadata
     - edpm_update
-  when: '"neutron-metadata" in edpm_services'
+  when: '"neutron-metadata" in edpm_update_running_services'
 
 - name: Updates containers for edpm_neutron_ovn role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_neutron_ovn
     tasks_from: run.yml
+    apply:
+      become: true
   tags:
     - edpm_neutron_ovn
     - edpm_update
-  when: '"neutron-ovn" in edpm_services'
+  when: '"neutron-ovn" in edpm_update_running_services'
 
 - name: Updates containers for edpm_multipathd role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_multipathd
     tasks_from: run.yml
+    apply:
+      become: true
   tags:
     - edpm_multipathd
     - edpm_update
-  when: '"nova-storage" in edpm_services'
+  when: '"nova-storage" in edpm_update_running_services'
 
 - name: Updates containers for edpm_nova role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_nova
     tasks_from: install.yml
+    apply:
+      become: true
   tags:
     - edpm_nova
     - edpm_update
-  when: '"nova" in edpm_services'
+  when: '"nova" in edpm_update_running_services'
 
 - name: Updates containers for edpm_neutron_sriov role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_neutron_sriov
     tasks_from: run.yml
+    apply:
+      become: true
   tags:
     - edpm_neutron_sriov
     - edpm_update
-  when: '"neutron-sriov" in edpm_services'
+  when: '"neutron-sriov" in edpm_update_running_services'
 
 - name: Updates containers for edpm_neutron_dhcp role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_neutron_dhcp
     tasks_from: run.yml
-  when: '"neutron-dhcp" in edpm_services'
+    apply:
+      become: true
+  when: '"neutron-dhcp" in edpm_update_running_services'
 
 - name: Updates containers for edpm_logrotate_crond role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_logrotate_crond
     tasks_from: run.yml
+    apply:
+      become: true
   tags:
     - edpm_logrotate_crond
     - edpm_update
-  when: '"run-os" in edpm_services'
+  when: '"run-os" in edpm_update_running_services'

--- a/roles/edpm_update/tasks/containers.yml
+++ b/roles/edpm_update/tasks/containers.yml
@@ -15,6 +15,7 @@
   tags:
     - edpm_iscsid
     - edpm_update
+  when: '"nova-storage" in edpm_services'
 
 - name: Updates containers for edpm_ovn role
   ansible.builtin.include_role:
@@ -23,6 +24,7 @@
   tags:
     - edpm_ovn
     - edpm_update
+  when: '"ovn" in edpm_services'
 
 - name: Updates containers for edpm_frr role
   ansible.builtin.include_role:
@@ -31,6 +33,7 @@
   tags:
     - edpm_frr
     - edpm_update
+  when: '"frr" in edpm_services'
 
 - name: Updates containers for edpm_ovn_bgp_agent role
   ansible.builtin.include_role:
@@ -39,6 +42,7 @@
   tags:
     - edpm_ovn_bgp_agent
     - edpm_update
+  when: '"ovn-bgp-agent" in edpm_services'
 
 - name: Updates containers for edpm_neutron_metadata role
   ansible.builtin.include_role:
@@ -47,6 +51,7 @@
   tags:
     - edpm_neutron_metadata
     - edpm_update
+  when: '"neutron-metadata" in edpm_services'
 
 - name: Updates containers for edpm_neutron_ovn role
   ansible.builtin.include_role:
@@ -55,6 +60,7 @@
   tags:
     - edpm_neutron_ovn
     - edpm_update
+  when: '"neutron-ovn" in edpm_services'
 
 - name: Updates containers for edpm_multipathd role
   ansible.builtin.include_role:
@@ -63,6 +69,7 @@
   tags:
     - edpm_multipathd
     - edpm_update
+  when: '"nova-storage" in edpm_services'
 
 - name: Updates containers for edpm_nova role
   ansible.builtin.include_role:
@@ -71,6 +78,7 @@
   tags:
     - edpm_nova
     - edpm_update
+  when: '"nova" in edpm_services'
 
 - name: Updates containers for edpm_neutron_sriov role
   ansible.builtin.include_role:
@@ -79,11 +87,13 @@
   tags:
     - edpm_neutron_sriov
     - edpm_update
+  when: '"neutron-sriov" in edpm_services'
 
 - name: Updates containers for edpm_neutron_dhcp role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_neutron_dhcp
     tasks_from: run.yml
+  when: '"neutron-dhcp" in edpm_services'
 
 - name: Updates containers for edpm_logrotate_crond role
   ansible.builtin.include_role:
@@ -92,3 +102,4 @@
   tags:
     - edpm_logrotate_crond
     - edpm_update
+  when: '"run-os" in edpm_services'

--- a/roles/edpm_update/tasks/containers.yml
+++ b/roles/edpm_update/tasks/containers.yml
@@ -1,0 +1,94 @@
+---
+
+- name: Login to container registries if needed
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_podman
+    tasks_from: login.yml
+  tags:
+    - edpm_podman
+    - edpm_update
+
+- name: Updates containers for edpm_iscsid role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_iscsid
+    tasks_from: run.yml
+  tags:
+    - edpm_iscsid
+    - edpm_update
+
+- name: Updates containers for edpm_ovn role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_ovn
+    tasks_from: run.yml
+  tags:
+    - edpm_ovn
+    - edpm_update
+
+- name: Updates containers for edpm_frr role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_frr
+    tasks_from: run.yml
+  tags:
+    - edpm_frr
+    - edpm_update
+
+- name: Updates containers for edpm_ovn_bgp_agent role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_ovn_bgp_agent
+    tasks_from: run.yml
+  tags:
+    - edpm_ovn_bgp_agent
+    - edpm_update
+
+- name: Updates containers for edpm_neutron_metadata role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_metadata
+    tasks_from: run.yml
+  tags:
+    - edpm_neutron_metadata
+    - edpm_update
+
+- name: Updates containers for edpm_neutron_ovn role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_ovn
+    tasks_from: run.yml
+  tags:
+    - edpm_neutron_ovn
+    - edpm_update
+
+- name: Updates containers for edpm_multipathd role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_multipathd
+    tasks_from: run.yml
+  tags:
+    - edpm_multipathd
+    - edpm_update
+
+- name: Updates containers for edpm_nova role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_nova
+    tasks_from: install.yml
+  tags:
+    - edpm_nova
+    - edpm_update
+
+- name: Updates containers for edpm_neutron_sriov role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_sriov
+    tasks_from: run.yml
+  tags:
+    - edpm_neutron_sriov
+    - edpm_update
+
+- name: Updates containers for edpm_neutron_dhcp role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_dhcp
+    tasks_from: run.yml
+
+- name: Updates containers for edpm_logrotate_crond role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_logrotate_crond
+    tasks_from: run.yml
+  tags:
+    - edpm_logrotate_crond
+    - edpm_update

--- a/roles/edpm_update/tasks/main.yml
+++ b/roles/edpm_update/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# "edpm_update" will search for and load any operating system variable file
+
+- name: Update packages
+  ansible.builtin.include_tasks: packages.yml
+  when: edpm_update_enable_packages_update
+
+- name: Update containers
+  ansible.builtin.include_tasks: containers.yml
+  when: edpm_update_enable_containers_update

--- a/roles/edpm_update/tasks/packages.yml
+++ b/roles/edpm_update/tasks/packages.yml
@@ -5,5 +5,6 @@
     name: "*"
     state: latest
     update_cache: true
+    exclude: "{{ edpm_update_exclude_packages }}"
   tags:
     - edpm_update

--- a/roles/edpm_update/tasks/packages.yml
+++ b/roles/edpm_update/tasks/packages.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Apply packages updates
+  ansible.builtin.dnf:  # noqa: package-latest
+    name: "*"
+    state: latest
+    update_cache: true
+  tags:
+    - edpm_update

--- a/roles/edpm_update/tasks/packages.yml
+++ b/roles/edpm_update/tasks/packages.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Apply packages updates
+  become: true
   ansible.builtin.dnf:  # noqa: package-latest
     name: "*"
     state: latest


### PR DESCRIPTION
The `edpm_update` role is added to allow the update of packages and containers on EDPM nodes.

The related `update.yml` playbook has been added.

Jira: https://issues.redhat.com/browse/OSPRH-6219