### PR TITLE
Stop edpm_telemetry selinux relabelling the system dbus socket

### DIFF
--- a/roles/edpm_telemetry/tasks/install.yml
+++ b/roles/edpm_telemetry/tasks/install.yml
@@ -64,7 +64,7 @@
       - "--no-collector.pressure"
       - "--no-collector.rapl"
     volumes:
-      - "/var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw,z"
+      - "/var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw"
       - "{{ edpm_telemetry_config_dest }}/node_exporter.yaml:/etc/node_exporter/node_exporter.yaml:z"
       - "{{ edpm_telemetry_certs }}:/etc/node_exporter/tls:z"
   when:


### PR DESCRIPTION
This will break the host.

E.g systemd-hostnamed fails with `type=AVC msg=audit([1713190908](tel:1713190908).762:30498): avc:  denied  { write } for  pid=116232 comm="systemd-hostnam" name="system_bus_socket" dev="tmpfs" ino=459 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:container_file_t:s0 tclass=sock_file permissive=0`