### PR TITLE
Remove healthcheck for frr container

### DIFF
--- a/roles/edpm_frr/templates/frr.yaml.j2
+++ b/roles/edpm_frr/templates/frr.yaml.j2
@@ -4,8 +4,6 @@ net: host
 privileged: false
 user: frr
 restart: always
-healthcheck:
-  test: '/openstack/healthcheck'
 cap_add:
   - NET_BIND_SERVICE
   - NET_RAW


### PR DESCRIPTION
We dropped /openstack/healthcheck in the image so let's remove the healthcheck from the container definition.