### PR TITLE
Fix pre adoption nova.conf path default

### DIFF
--- a/roles/edpm_pre_adoption_validation/defaults/main.yml
+++ b/roles/edpm_pre_adoption_validation/defaults/main.yml
@@ -16,5 +16,5 @@
 
 
 # All variables intended for modification should be placed in this file.
-edpm_pre_adoption_validation_old_nova_config: /var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf
+edpm_pre_adoption_validation_old_nova_config: /var/lib/config-data/puppet-generated/nova_libvirt/etc/nova/nova.conf
 edpm_pre_adoption_validation_old_neutron_config: /var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf

--- a/roles/edpm_pre_adoption_validation/meta/argument_specs.yml
+++ b/roles/edpm_pre_adoption_validation/meta/argument_specs.yml
@@ -6,7 +6,7 @@ argument_specs:
     options:
       edpm_pre_adoption_validation_old_nova_config:
         type: str
-        default: /var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf
+        default: /var/lib/config-data/puppet-generated/nova_libvirt/etc/nova/nova.conf
         description: The path of the pre-adoption version of the nova.conf file on the node
       edpm_pre_adoption_validation_old_neutron_config:
         type: str

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-negative/prepare.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-negative/prepare.yml
@@ -29,7 +29,7 @@
         state: "directory"
         mode: "0777"
       loop:
-        - {"path": "/var/lib/config-data/puppet-generated/nova/etc/nova/"}
+        - {"path": "/var/lib/config-data/puppet-generated/nova_libvirt/etc/nova/"}
         - {"path": "/var/lib/config-data/puppet-generated/neutron/etc/neutron/"}
 
     - name: Copy old configs to simulate a tripleo deployment
@@ -41,6 +41,6 @@
         dest: "{{ item.dest }}"
         mode: preserve
       loop:
-        - {"src": "{{ test_data }}/old_nova.conf", "dest": "/var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf"}
+        - {"src": "{{ test_data }}/old_nova.conf", "dest": "/var/lib/config-data/puppet-generated/nova_libvirt/etc/nova/nova.conf"}
         - {"src": "{{ test_data }}/old_neutron.conf", "dest": "/var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf"}
   tasks: []

--- a/roles/edpm_pre_adoption_validation/molecule/adoption-positive/prepare.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/adoption-positive/prepare.yml
@@ -29,7 +29,7 @@
         state: "directory"
         mode: "0777"
       loop:
-        - {"path": "/var/lib/config-data/puppet-generated/nova/etc/nova/"}
+        - {"path": "/var/lib/config-data/puppet-generated/nova_libvirt/etc/nova/"}
         - {"path": "/var/lib/config-data/puppet-generated/neutron/etc/neutron/"}
 
     - name: Copy old configs to simulate a tripleo deployment
@@ -41,6 +41,6 @@
         dest: "{{ item.dest }}"
         mode: preserve
       loop:
-        - {"src": "{{ test_data }}/old_nova.conf", "dest": "/var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf"}
+        - {"src": "{{ test_data }}/old_nova.conf", "dest": "/var/lib/config-data/puppet-generated/nova_libvirt/etc/nova/nova.conf"}
         - {"src": "{{ test_data }}/old_neutron.conf", "dest": "/var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf"}
   tasks: []


### PR DESCRIPTION
The 91d657948bcfa5159e02f4ae4dae579c58a7bfbc wrongly used
/var/lib/config-data/nova instead of nova_libvirt to look at the config
of from of the pre-adopted node. We missed this as it was only tested
with standalone deployments where both nova and nova_libvirt exists on
the machine. In a multinode deployment only nova_libvirt exists on the
compute node.

Implements: [OSPRH-6333](https://issues.redhat.com//browse/OSPRH-6333)
