### PR TITLE
[edpm_neutron_sriov] Add caCerts to container if tls enabled

### DIFF
--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -36,6 +36,11 @@ edpm_neutron_sriov_common_volumes:
   - /var/lib/kolla/config_files/neutron_sriov_agent.json:/var/lib/kolla/config_files/config.json:ro
   - /var/log/containers/neutron:/var/log/neutron:z
 
+edpm_neutron_sriov_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
+edpm_neutron_sriov_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-sriov') }}"
+edpm_neutron_sriov_tls_volumes:
+  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-sriov') }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
+
 # neutron.conf
 # DEFAULT
 edpm_neutron_sriov_DEFAULT_debug: false

--- a/roles/edpm_neutron_sriov/meta/argument_specs.yml
+++ b/roles/edpm_neutron_sriov/meta/argument_specs.yml
@@ -38,6 +38,11 @@ argument_specs:
           - /var/log/containers/neutron:/var/log/neutron:z
         description: List of volumes in a mount point form.
         type: list
+      edpm_neutron_sriov_tls_enabled:
+        default: false
+        description: >
+          Should TLS cacerts be configured for neutron sriov
+        type: bool
       edpm_neutron_sriov_DEFAULT_debug:
         default: false
         description: "Enable or disable DEBUG mode in the Neutron agent"

--- a/roles/edpm_neutron_sriov/templates/neutron_sriov_agent.yaml.j2
+++ b/roles/edpm_neutron_sriov/templates/neutron_sriov_agent.yaml.j2
@@ -9,6 +9,11 @@ volumes:
   {%- set edpm_neutron_sriov_volumes =
           edpm_neutron_sriov_volumes +
           edpm_neutron_sriov_common_volumes %}
+{%- if edpm_neutron_sriov_tls_enabled | bool %}
+  {%- set edpm_neutron_sriov_volumes =
+          edpm_neutron_sriov_volumes +
+          edpm_neutron_sriov_tls_volumes %}
+{%- endif -%}
   {{ edpm_neutron_sriov_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS


### PR DESCRIPTION
Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/842