### PR TITLE
[edpm_neutron_dhcp] Add caCerts to container if tls enabled

### DIFF
--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -40,6 +40,11 @@ edpm_neutron_dhcp_common_volumes:
   - "{{ edpm_neutron_dhcp_agent_lib_dir }}/dhcp_agent_dnsmasq_wrapper:/usr/local/bin/dnsmasq:ro"
   - "{{ edpm_neutron_dhcp_agent_lib_dir }}/kill_scripts:/etc/neutron/kill_scripts:ro"
 
+edpm_neutron_dhcp_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
+edpm_neutron_dhcp_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-dhcp') }}"
+edpm_neutron_dhcp_tls_volumes:
+  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-dhcp') }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
+
 # Sidecar containers settings
 edpm_neutron_dhcp_sidecar_debug: false
 edpm_neutron_dhcp_sidecar_haproxy_image_name: "{{ edpm_neutron_dhcp_image }}"

--- a/roles/edpm_neutron_dhcp/meta/argument_specs.yml
+++ b/roles/edpm_neutron_dhcp/meta/argument_specs.yml
@@ -47,6 +47,11 @@ argument_specs:
           - "{{ edpm_neutron_dhcp_agent_lib_dir }}/kill_scripts:/etc/neutron/kill_scripts:ro"
         description: List of volumes in a mount point form.
         type: list
+      edpm_neutron_dhcp_tls_enabled:
+        default: false
+        description: >
+          Should TLS cacerts be configured for neutron dhcp
+        type: bool
       edpm_neutron_dhcp_sidecar_debug:
         default: false
         description: "Enable or disable DEBUG mode in the sidecar wrappers scripts"

--- a/roles/edpm_neutron_dhcp/templates/neutron_dhcp_agent.yaml.j2
+++ b/roles/edpm_neutron_dhcp/templates/neutron_dhcp_agent.yaml.j2
@@ -11,6 +11,11 @@ volumes:
   {%- set edpm_neutron_dhcp_volumes =
           edpm_neutron_dhcp_volumes +
           edpm_neutron_dhcp_common_volumes %}
+{%- if edpm_neutron_dhcp_tls_enabled | bool %}
+  {%- set edpm_neutron_dhcp_volumes =
+          edpm_neutron_dhcp_volumes +
+          edpm_neutron_dhcp_tls_volumes %}
+{%- endif -%}
   {{ edpm_neutron_dhcp_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS


### PR DESCRIPTION
Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/848

Closes: [OSPRH-6498](https://issues.redhat.com//browse/OSPRH-6498)