### PR TITLE
Wait for nodes to be reachable

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -1,4 +1,12 @@
 ---
+- name: Check remote connections
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  gather_facts: false
+  tasks:
+    - name: Wait for connection
+      ansible.builtin.wait_for_connection:
+        delay: "{{ edpm_wait_for_connection_delay | default(10) }}"
+        timeout: "{{ edpm_wait_for_connection_timeout | default(600) }}"
 
 - name: Bootstrap node
   hosts: "{{ edpm_override_hosts | default('all', true) }}"


### PR DESCRIPTION
Sometimes baremetal nodes are not reachable for few mins after they have been provisioned. As bootstrap is always the first play run, this would allow us wait for sometime for the connections to be ready.