### PR TITLE
[libvirt] enable vencrypt when libvirt tls enabled

### DIFF
--- a/roles/edpm_libvirt/templates/qemu.conf.j2
+++ b/roles/edpm_libvirt/templates/qemu.conf.j2
@@ -1,7 +1,11 @@
 max_files = 32768
 max_processes = 131072
+{% if edpm_libvirt_tls_certs_enabled|bool %}
+vnc_tls = 1
+vnc_tls_x509_verify = 1
+{% else -%}
 vnc_tls = 0
-vnc_tls_x509_verify = 0
+{% endif %}
 # NOTE(gibi): In tripleo the default range was intentionally changed to avoid
 # port usage conflicts. See https://review.openstack.org/#/c/561784
 migration_port_min = 61152


### PR DESCRIPTION
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/780

Jira: [OSPRH-6174](https://issues.redhat.com//browse/OSPRH-6174)