### PR TITLE
[pre-adoption-validation]Check tuned profile

### DIFF
--- a/roles/edpm_pre_adoption_validation/defaults/main.yml
+++ b/roles/edpm_pre_adoption_validation/defaults/main.yml
@@ -21,3 +21,4 @@ edpm_pre_adoption_validation_old_neutron_config: /var/lib/config-data/puppet-gen
 
 edpm_pre_adoption_validation_hostname_enabled: true
 edpm_pre_adoption_validation_kernel_args_enabled: true
+edpm_pre_adoption_validation_tuned_enabled: true

--- a/roles/edpm_pre_adoption_validation/meta/argument_specs.yml
+++ b/roles/edpm_pre_adoption_validation/meta/argument_specs.yml
@@ -20,3 +20,7 @@ argument_specs:
         type: bool
         default: true
         description: Whether the kernel argument checks are executed.
+      edpm_pre_adoption_validation_tuned_enabled:
+        type: bool
+        default: true
+        description: Whether the tuned profile checks are executed.

--- a/roles/edpm_pre_adoption_validation/molecule/hostname-adoption-negative/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/hostname-adoption-negative/molecule.yml
@@ -17,6 +17,8 @@ provisioner:
   inventory:
     hosts:
       all:
+        vars:
+          edpm_pre_adoption_validation_tuned_enabled: false
         hosts:
           edpm-0:
             canonical_hostname: edpm-0.localdomain

--- a/roles/edpm_pre_adoption_validation/molecule/hostname-adoption-positive/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/hostname-adoption-positive/molecule.yml
@@ -17,6 +17,8 @@ provisioner:
   inventory:
     hosts:
       all:
+        vars:
+          edpm_pre_adoption_validation_tuned_enabled: false
         hosts:
           edpm-0:
             canonical_hostname: edpm-0.localdomain

--- a/roles/edpm_pre_adoption_validation/molecule/hostname-greenfield/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/hostname-greenfield/molecule.yml
@@ -17,6 +17,8 @@ provisioner:
   inventory:
     hosts:
       all:
+        vars:
+          edpm_pre_adoption_validation_tuned_enabled: false
         hosts:
           edpm-0:
             canonical_hostname: edpm-0.localdomain

--- a/roles/edpm_pre_adoption_validation/molecule/kernel-args-existing-args/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/kernel-args-existing-args/molecule.yml
@@ -19,6 +19,7 @@ provisioner:
       all:
         vars:
           edpm_pre_adoption_validation_hostname_enabled: false
+          edpm_pre_adoption_validation_tuned_enabled: false
           # this is a kernel arg that by default defined in the test env
           # we use this to simulate that what is requested during adoption
           # is already configured

--- a/roles/edpm_pre_adoption_validation/molecule/kernel-args-new-hugepages/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/kernel-args-new-hugepages/molecule.yml
@@ -19,6 +19,7 @@ provisioner:
       all:
         vars:
           edpm_pre_adoption_validation_hostname_enabled: false
+          edpm_pre_adoption_validation_tuned_enabled: false
           # This is already configured in the test env so this alone would be
           # OK
           edpm_kernel_args: "console=ttyS0"

--- a/roles/edpm_pre_adoption_validation/molecule/kernel-args-no-args/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/kernel-args-no-args/molecule.yml
@@ -19,6 +19,7 @@ provisioner:
       all:
         vars:
           edpm_pre_adoption_validation_hostname_enabled: false
+          edpm_pre_adoption_validation_tuned_enabled: false
           # as no extra kernel args is requested the check will always succeed
           # edpm_kernel_args: ""
         hosts:

--- a/roles/edpm_pre_adoption_validation/molecule/tuned-new-profile/converge.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/tuned-new-profile/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Converge
+      block:
+        - name: "Include role"
+          ansible.builtin.include_role:
+            name: osp.edpm.edpm_pre_adoption_validation
+
+        - name: "Check execution halted"
+          ansible.builtin.fail:
+            msg: "Execution should stop before this task"
+          register: should_not_run
+      rescue:
+        - name: Asset that role failed
+          ansible.builtin.assert:
+            that:
+              - should_not_run is not defined

--- a/roles/edpm_pre_adoption_validation/molecule/tuned-new-profile/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/tuned-new-profile/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
       all:
         vars:
           edpm_pre_adoption_validation_hostname_enabled: false
-          edpm_pre_adoption_validation_tuned_enabled: false
-          # this is a kernel arg isn't defined in the test env therefore
-          # we can use it for a negative scenario where the check fails
-          edpm_kernel_args: "test=1"
+          # This means the adoption config requests a different profile
+          # that is configured so we expect the check to fail.
+          edpm_tuned_profile: cpu-partitioning
         hosts:
           edpm-0:
             canonical_hostname: edpm-0.localdomain

--- a/roles/edpm_pre_adoption_validation/molecule/tuned-new-profile/prepare.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/tuned-new-profile/prepare.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps  # noqa: role-name[path]
+    - role: osp.edpm.env_data
+- name: Setup DUT
+  hosts: all
+  pre_tasks:
+  - name: Create /etc/tuned/ directory
+    become: true
+    ansible.builtin.file:
+      path: "/etc/tuned"
+      state: "directory"
+      owner: root
+      group: root
+  # NOTE(gibi): We pre-set a profile that will not match with what the adoption
+  # config requires so we expect the check to fail.
+  - name: Set active tuned profile
+    become: true
+    ansible.builtin.copy:
+      dest: "/etc/tuned/active_profile"
+      owner: root
+      group: root
+      content: |
+        throughput-performance
+  tasks: []

--- a/roles/edpm_pre_adoption_validation/molecule/tuned-no-change/converge.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/tuned-no-change/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Converge
+      block:
+        - name: "Include role"
+          ansible.builtin.include_role:
+            name: osp.edpm.edpm_pre_adoption_validation
+      rescue:
+        - name: Assert that the validaton passed
+          ansible.builtin.fail:
+            msg: "validation should pass as the old and new configs are matching"

--- a/roles/edpm_pre_adoption_validation/molecule/tuned-no-change/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/tuned-no-change/molecule.yml
@@ -19,10 +19,8 @@ provisioner:
       all:
         vars:
           edpm_pre_adoption_validation_hostname_enabled: false
-          edpm_pre_adoption_validation_tuned_enabled: false
-          # this is a kernel arg isn't defined in the test env therefore
-          # we can use it for a negative scenario where the check fails
-          edpm_kernel_args: "test=1"
+          # NOTE(gibi): edpm_tuned_profile defaulted by the edpm_tuned_role
+          # edpm_tuned_profile: throughput-performance
         hosts:
           edpm-0:
             canonical_hostname: edpm-0.localdomain

--- a/roles/edpm_pre_adoption_validation/molecule/tuned-no-change/prepare.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/tuned-no-change/prepare.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps  # noqa: role-name[path]
+    - role: osp.edpm.env_data
+- name: Setup DUT
+  hosts: all
+  pre_tasks:
+  - name: Create /etc/tuned/ directory
+    become: true
+    ansible.builtin.file:
+      path: "/etc/tuned"
+      state: "directory"
+      owner: root
+      group: root
+  # NOTE(gibi): We pre-set the profile to match with what adoption would set
+  # so the validation will pass as no changes needed
+  - name: Set active tuned profile
+    become: true
+    ansible.builtin.copy:
+      dest: "/etc/tuned/active_profile"
+      owner: root
+      group: root
+      content: |
+        throughput-performance
+  tasks: []

--- a/roles/edpm_pre_adoption_validation/molecule/tuned-no-profile/converge.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/tuned-no-profile/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Converge
+      block:
+        - name: "Include role"
+          ansible.builtin.include_role:
+            name: osp.edpm.edpm_pre_adoption_validation
+
+        - name: "Check execution halted"
+          ansible.builtin.fail:
+            msg: "Execution should stop before this task"
+          register: should_not_run
+      rescue:
+        - name: Asset that role failed
+          ansible.builtin.assert:
+            that:
+              - should_not_run is not defined

--- a/roles/edpm_pre_adoption_validation/molecule/tuned-no-profile/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/tuned-no-profile/molecule.yml
@@ -19,10 +19,6 @@ provisioner:
       all:
         vars:
           edpm_pre_adoption_validation_hostname_enabled: false
-          edpm_pre_adoption_validation_tuned_enabled: false
-          # this is a kernel arg isn't defined in the test env therefore
-          # we can use it for a negative scenario where the check fails
-          edpm_kernel_args: "test=1"
         hosts:
           edpm-0:
             canonical_hostname: edpm-0.localdomain

--- a/roles/edpm_pre_adoption_validation/molecule/tuned-no-profile/prepare.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/tuned-no-profile/prepare.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Red Hat, Inc.
+# Copyright 2023 Red Hat, Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,14 +15,17 @@
 # under the License.
 
 
-- name: Validate hostname
-  when: edpm_pre_adoption_validation_hostname_enabled
-  ansible.builtin.include_tasks: hostname.yml
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps  # noqa: role-name[path]
+    - role: osp.edpm.env_data
+- name: Setup DUT
+  hosts: all
+  # NOTE(gibi): we intentionally not configure any tuned profile for this test
+  # to simulate the that there is no tuned configure in the node before
+  # adoption. We expect that the pre-adoption check fails as during adoption
+  # tuned would be configured.
 
-- name: Validate kernel_args
-  when: edpm_pre_adoption_validation_kernel_args_enabled
-  ansible.builtin.include_tasks: kernel_args.yml
-
-- name: Validate tuned profile
-  when: edpm_pre_adoption_validation_tuned_enabled
-  ansible.builtin.include_tasks: tuned.yml
+  pre_tasks: []
+  tasks: []

--- a/roles/edpm_pre_adoption_validation/tasks/hostname.yml
+++ b/roles/edpm_pre_adoption_validation/tasks/hostname.yml
@@ -64,5 +64,5 @@
       ansible.builtin.debug:
         msg:
           - "canonical_hostname: {{ canonical_hostname }}"
-          - "old nova service host config: {{ nova_old_config_output.stdout | default('not found')}}"
-          - "old neutron service host config: {{ neutron_old_config_output.stdout | default('not found')}}"
+          - "old nova service host config: {{ nova_old_config_output.stdout | default('not found') }}"
+          - "old neutron service host config: {{ neutron_old_config_output.stdout | default('not found') }}"

--- a/roles/edpm_pre_adoption_validation/tasks/tuned.yml
+++ b/roles/edpm_pre_adoption_validation/tasks/tuned.yml
@@ -1,0 +1,49 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# NOTE(gibi): We need this trick as these tasks depend on the
+# edpm_tuned_profile variable. If that var is not provided in the inventory
+# then it is defaulted by the edpm_tuned role to a non trivial default value.
+- name: Include defaults from edpm_tuned
+  when: edpm_tuned_profile is undefined
+  ansible.builtin.include_vars: "{{ role_path }}/../edpm_tuned/defaults/main.yml"
+
+- name: Check if an active profile file exists
+  ansible.builtin.stat:
+    path: "/etc/tuned/active_profile"
+  register: edpm_tuned_active_profile_file
+
+- name: Load tuned active profile
+  ansible.builtin.slurp:
+    src: "/etc/tuned/active_profile"
+  register: edpm_tuned_active_profile
+  when: edpm_tuned_active_profile_file.stat.exists
+
+- name: Validate that there is active tuned profile
+  when: not edpm_tuned_active_profile_file.stat.exists
+  ansible.builtin.fail:
+    msg: >-
+      There is no active tuned profile. During adoption this would cause a
+      new profile configured but that would require a reboot.
+
+- name: Validate that current active tuned profile won't change
+  when: edpm_tuned_active_profile_file.stat.exists
+  ansible.builtin.debug:
+    msg: >-
+     Validating that the current profile
+     '{{ (edpm_tuned_active_profile['content'] | b64decode).strip() }}' is the
+     same as the new profile '{{ edpm_tuned_profile }}'
+  failed_when: edpm_tuned_profile != (edpm_tuned_active_profile['content'] | b64decode).strip()


### PR DESCRIPTION
New check is added to edpm_pre_adoption_validation role that ensure that
the tuned profile does not change during adoption as such change would
require a reboot that is not possible during adoption.

Implements: [OSPRH-5715](https://issues.redhat.com//browse/OSPRH-5715)
