### PR TITLE
Fix roles default vars to correctly use edpm_service_name

### DIFF
--- a/roles/edpm_frr/defaults/main.yml
+++ b/roles/edpm_frr/defaults/main.yml
@@ -81,7 +81,7 @@ edpm_frr_volumes:
   - /etc/pki/tls/certs/ca-bundle.trust.crt:/etc/pki/tls/certs/ca-bundle.trust.crt:ro
   - /etc/pki/tls/cert.pem:/etc/pki/tls/cert.pem:ro
   - /var/lib/kolla/config_files/frr.json:/var/lib/kolla/config_files/config.json:ro
-  - /var/lib/config-data/ansible-generated/frr:/var/lib/kolla/config_files/src:ro
+  - "{{ edpm_frr_config_basedir }}:/var/lib/kolla/config_files/src:ro"
   - /var/log/containers/frr:/var/log/frr:z
   - /run/frr:/run/frr:shared,z
 

--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -24,7 +24,7 @@ edpm_neutron_dhcp_images_download_delay: 5
 # number of retries for download tasks
 edpm_neutron_dhcp_images_download_retries: 5
 
-edpm_neutron_dhcp_agent_config_src: "/var/lib/openstack/configs/neutron-dhcp"
+edpm_neutron_dhcp_agent_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('neutron-dhcp') }}"
 edpm_neutron_dhcp_agent_config_dir: "/var/lib/config-data/ansible-generated/neutron-dhcp-agent"
 edpm_neutron_dhcp_agent_lib_dir: "/var/lib/neutron"
 edpm_neutron_dhcp_image: "quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent:current-podified"
@@ -43,7 +43,7 @@ edpm_neutron_dhcp_common_volumes:
 edpm_neutron_dhcp_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 edpm_neutron_dhcp_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-dhcp') }}"
 edpm_neutron_dhcp_tls_volumes:
-  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-dhcp') }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
+  - "{{ edpm_neutron_dhcp_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
 # Sidecar containers settings
 edpm_neutron_dhcp_sidecar_debug: false

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -7,7 +7,7 @@ edpm_neutron_metadata_images_download_delay: 5
 # number of retries for download tasks
 edpm_neutron_metadata_images_download_retries: 5
 
-edpm_neutron_metadata_config_src: /var/lib/openstack/configs/neutron-metadata
+edpm_neutron_metadata_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('neutron-metadata') }}"
 edpm_neutron_metadata_agent_config_dir: /var/lib/config-data/ansible-generated/neutron-ovn-metadata-agent
 edpm_neutron_metadata_agent_log_dir: "/var/log/neutron"
 edpm_neutron_metadata_agent_lib_dir: "/var/lib/neutron"
@@ -57,8 +57,8 @@ edpm_neutron_metadata_agent_ovn_ovsdb_probe_interval: '60000'
 edpm_neutron_metadata_agent_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 
 edpm_neutron_metadata_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron_metadata') }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron_metadata') }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron_metadata') }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
-  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron_metadata') }}/tls-ca-bundle.pem:\
+  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron-metadata') }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron-metadata') }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron-metadata') }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-metadata') }}/tls-ca-bundle.pem:\
     /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -7,7 +7,7 @@ edpm_neutron_ovn_images_download_delay: 5
 # number of retries for download tasks
 edpm_neutron_ovn_images_download_retries: 5
 
-edpm_neutron_ovn_config_src: /var/lib/openstack/configs/neutron-ovn
+edpm_neutron_ovn_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('neutron-ovn') }}"
 edpm_neutron_ovn_agent_config_dir: /var/lib/config-data/ansible-generated/neutron-ovn-agent
 edpm_neutron_ovn_agent_log_dir: "/var/log/neutron"
 

--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -24,7 +24,7 @@ edpm_neutron_sriov_images_download_delay: 5
 edpm_neutron_sriov_images_download_retries: 5
 
 # All variables within this role should have a prefix of "edpm_neutron_sriov_agent"
-edpm_neutron_sriov_agent_config_src: "/var/lib/openstack/configs/neutron-sriov"
+edpm_neutron_sriov_agent_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('neutron-sriov') }}"
 edpm_neutron_sriov_agent_config_dir: "/var/lib/config-data/ansible-generated/neutron-sriov-agent"
 edpm_neutron_sriov_image: "quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent:current-podified"
 
@@ -39,7 +39,7 @@ edpm_neutron_sriov_common_volumes:
 edpm_neutron_sriov_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 edpm_neutron_sriov_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-sriov') }}"
 edpm_neutron_sriov_tls_volumes:
-  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-sriov') }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
+  - "{{ edpm_neutron_sriov_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
 # neutron.conf
 # DEFAULT

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -31,7 +31,7 @@ edpm_ovn_bgp_agent_certificate: /etc/pki/tls/certs/ovndb.crt
 edpm_ovn_bgp_agent_ca_cert: /etc/pki/tls/certs/ovndbca.crt
 edpm_ovn_bgp_agent_internal_tls_enable: "{{ edpm_tls_certs_enabled | default(False) }}"
 edpm_ovn_bgp_agent_config_basedir: "/var/lib/config-data/ansible-generated/ovn-bgp-agent"
-edpm_ovn_bgp_agent_config_src: /var/lib/openstack/configs/ovn-bgp-agent
+edpm_ovn_bgp_agent_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('ovn-bgp-agent') }}"
 edpm_ovn_bgp_agent_bgp_as: 64999
 edpm_ovn_bgp_agent_clear_vrf_routes_on_startup: false
 edpm_ovn_bgp_agent_bgp_nic: bgp-nic
@@ -59,7 +59,7 @@ edpm_ovn_bgp_agent_common_volumes:
   - /dev/log:/dev/log
   - /etc/iproute2:/etc/iproute2
   - /var/lib/kolla/config_files/ovn_bgp_agent.json:/var/lib/kolla/config_files/config.json:ro
-  - /var/lib/config-data/ansible-generated/ovn-bgp-agent:/var/lib/kolla/config_files/src:ro
+  - "{{ edpm_ovn_bgp_agent_config_basedir }}:/var/lib/kolla/config_files/src:ro"
   - /run/frr:/run/frr:shared,z
   - /run/openvswitch:/run/openvswitch:shared,z
 

--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -17,7 +17,7 @@
 
 # All variables intended for modification should be placed in this file.
 # Directory in the ansibleEE container
-edpm_telemetry_config_src: /var/lib/openstack/configs/telemetry
+edpm_telemetry_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('telemetry') }}"
 # Directory in the compute node
 edpm_telemetry_config_dest: /var/lib/openstack/config/telemetry
 # Image to use for node_exporter
@@ -27,8 +27,8 @@ edpm_telemetry_ceilometer_compute_image: quay.io/podified-antelope-centos9/opens
 # Image to use for Ceilometer Ipmi
 edpm_telemetry_ceilometer_ipmi_image: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
 # Certificates location for tls encryption
-edpm_telemetry_certs: /var/lib/openstack/certs/telemetry
+edpm_telemetry_certs: "/var/lib/openstack/certs/{{ edpm_service_name | default('telemetry') }}"
 # CA certs location for tls encryption
-edpm_telemetry_cacerts: /var/lib/openstack/cacerts/telemetry
+edpm_telemetry_cacerts: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('telemetry') }}"
 # If TLS should be enabled for telemetry
 edpm_telemetry_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"

--- a/roles/edpm_telemetry_logging/defaults/main.yml
+++ b/roles/edpm_telemetry_logging/defaults/main.yml
@@ -17,6 +17,6 @@
 
 # All variables intended for modification should be placed in this file.
 # Directory in the ansibleEE container
-edpm_telemetry_logging_config_src: /var/lib/openstack/configs/logging
+edpm_telemetry_logging_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('logging') }}"
 # Directory of rsyslog config in the compute node
 edpm_telemetry_rsyslog_config_dest: /etc/rsyslog.d


### PR DESCRIPTION
Some vars were not using "edpm_service_name" for
the generated content, this patch fixes it.

Additionally fixed some unused vars.