### PR TITLE
Add edpm variable for powersave profile

### DIFF
--- a/roles/edpm_tuned/defaults/main.yml
+++ b/roles/edpm_tuned/defaults/main.yml
@@ -26,6 +26,7 @@ edpm_tuned_download_retries: 5
 edpm_tuned_profile: "throughput-performance"
 edpm_tuned_custom_profile: ""
 edpm_tuned_isolated_cores: ""
+edpm_tuned_max_power_cstate: ""
 
 # Default tuned packages to install
 edpm_tuned_system_packages_default:

--- a/roles/edpm_tuned/meta/argument_specs.yml
+++ b/roles/edpm_tuned/meta/argument_specs.yml
@@ -33,6 +33,12 @@ argument_specs:
           for example: 2,4-7 .
           Please note that the value may be rendered in a different .conf
           file, depending on your local setup.
+      edpm_tuned_max_power_cstate:
+        type: str
+        default: ""
+        description: >
+          String which specifies maximum powerstate for idling cores
+          for example, C6|140.
       edpm_tuned_system_packages_default:
         type: list
         description: >

--- a/roles/edpm_tuned/tasks/configure.yml
+++ b/roles/edpm_tuned/tasks/configure.yml
@@ -66,6 +66,19 @@
     - (edpm_tuned_isolated_cores | length) > 0
     - (edpm_tuned_conf_stat_result.stat.exists | bool)
 
+- name: "Configure c-state if profile is powersave: {{ edpm_tuned_profile }}"
+  ansible.builtin.lineinfile:
+    dest: "/etc/tuned/{{ edpm_tuned_profile }}-variables.conf"
+    mode: '0644'
+    regexp: '^max_power_state=cstate.name.*'
+    line: 'max_power_state=cstate.name:{{ edpm_tuned_max_power_cstate }}'
+  become: true
+  when:
+    - edpm_tuned_max_power_cstate is defined
+    - (edpm_tuned_max_power_cstate | length) > 0
+    - (edpm_tuned_conf_stat_result.stat.exists | bool)
+    - (edpm_tuned_profile == 'cpu-partitioning-powersave')
+
 - name: Enable tuned profile
   ansible.builtin.command: >-
     /usr/sbin/tuned-adm profile {{ edpm_tuned_profile }}


### PR DESCRIPTION
Tuned powersave profile setting needs additional
edpm variable to set the c-state value