### PR TITLE
Add edpm_reboot_strategy to reboot role

### DIFF
--- a/docs/source/roles/role-edpm_reboot.rst
+++ b/docs/source/roles/role-edpm_reboot.rst
@@ -14,20 +14,22 @@ This Ansible role allows to do the following tasks:
 
 * Reboot EDPM computes.
   During deployment reboot is triggered automatically if required. During
-  post-deployment reconfiguration reboot is not started. User has to plan
-  reboot maintenance window and set `edpm_reboot_force_reboot` flag to true.
+  post-deployment reconfiguration or adoption process reboot is not started.
+  User has to plan reboot maintenance window and set `edpm_reboot_strategy`
+  flag to force.
 
-Here is an example of a playbook to start reboot:
+
+Here is an example of a playbook to  force start reboot:
 
 .. code-block:: YAML
 
-    - name: Check and start reboot of nodes if required
+    - name: Force start reboot of nodes
       block:
-        - name: "Check and start reboot of nodes if required"
+        - name: "Force start reboot of nodes"
           include_role:
             name: edpm_reboot
            vars:
-             edpm_reboot_force_reboot: true
+             edpm_reboot_strategy: force
 
 
 .. include::

--- a/roles/edpm_bootstrap/tasks/fips.yml
+++ b/roles/edpm_bootstrap/tasks/fips.yml
@@ -61,7 +61,7 @@
             mode: "0600"
         - name: Call edpm_reboot role
           vars:
-            edpm_reboot_force_reboot: true
+            edpm_reboot_strategy: force
           ansible.builtin.include_role:
             name: edpm_reboot
 

--- a/roles/edpm_reboot/defaults/main.yaml
+++ b/roles/edpm_reboot/defaults/main.yaml
@@ -17,7 +17,8 @@
 
 # All variables intended for modification should be placed in this file.
 
-edpm_reboot_force_reboot: false
-edpm_reboot_nova_compute_config_dir: /var/lib/openstack/config/nova
+edpm_reboot_strategy: auto
+edpm_reboot_old_tripleo_node_config_dir: /var/lib/config-data
+edpm_reboot_edpm_node_config_dir: /var/lib/openstack/config
 edpm_reboot_timeout_reboot: 3600
 edpm_reboot_post_reboot_delay: 60

--- a/roles/edpm_reboot/meta/argument_specs.yml
+++ b/roles/edpm_reboot/meta/argument_specs.yml
@@ -4,17 +4,21 @@ argument_specs:
   main:
     short_description: The main entry point for the edpm_reboot role.
     options:
-      edpm_reboot_force_reboot:
+      edpm_reboot_strategy:
         description: |
-          Force reboot of the node. Automated reboot for nodes is by defulat defered as it can impact running vms.
-          Only on initial run when nova related files are not yet created reboot is not defered.
-          When edpm_reboot_force_reboot is set to true, reboot is allowed and will be perfomed if required.
-        type: bool
-        default: false
-      edpm_reboot_nova_compute_config_dir:
+          Default strategy is auto. In auto mode reboot for deployed nodes is by default defered as it can
+          impact running vms or openstack services. Only on initial run when nova related files are not yet created reboot is not defered.
+          When edpm_reboot_force_reboot is set to force, reboot is allowed and will be perfomed always.
+        type: str
+        default: auto
+      edpm_reboot_old_tripleo_node_config_dir:
         type: path
-        default: /var/lib/openstack/config/nova
-        description: This should be synced with edpm_nova_compute role
+        default: /var/lib/config-data
+        description: Path to check for tripleo pre-adopted nodes
+      edpm_reboot_edpm_node_config_dir:
+        type: path
+        default: /var/lib/openstack/config
+        description: Path for storing configuration of edpm nodes. This should be synced with edpm-ansible roles.
       edpm_reboot_timeout_reboot:
         type: int
         default: 3600

--- a/roles/edpm_reboot/tasks/main.yaml
+++ b/roles/edpm_reboot/tasks/main.yaml
@@ -53,10 +53,15 @@
     paths: /var/lib/openstack/reboot_required/
   register: reboot_files
 
-- name: Check if node has a nova.conf config
+- name: Check if old_tripleo_node config dir exists
   ansible.builtin.stat:
-    path: "{{ edpm_reboot_nova_compute_config_dir }}/01-nova.conf"
-  register: nova_conf_check
+    path: "{{ edpm_reboot_old_tripleo_node_config_dir }}"
+  register: old_tripleo_node_conf
+
+- name: Check if edpm_node config dir exists
+  ansible.builtin.stat:
+    path: "{{ edpm_reboot_edpm_node_config_dir }}"
+  register: edpm_node_conf
 
 - name: Set reboot_required fact
   ansible.builtin.set_fact:
@@ -65,16 +70,17 @@
 
 - name: Print message if reboot is required, but is not going to be started
   ansible.builtin.debug:
-    msg: "Reboot is required but was not started. User has to plan the reboot and set edpm_reboot_force_reboot to true"
+    msg: "Reboot is required but was not started. Edpm_reboot_strategy is set to never or this is
+          already deployed machine. Reboot has to be planned. To start reboot set edpm_reboot_strategy
+          to force"
   when:
     - reboot_required|default(false)
-    - nova_conf_check.stat.exists
-    - not edpm_reboot_force_reboot|bool
+    - (edpm_reboot_strategy|lower == "never" or old_tripleo_node_conf.stat.exists or edpm_node_conf.stat.exists)
 
 - name: Run reboot nodes actions
-  when:
-    - reboot_required is defined and reboot_required|bool
-    - edpm_reboot_force_reboot|bool or not nova_conf_check.stat.exists
+  when: (edpm_reboot_strategy|lower == "force") or
+        (reboot_required|default(false) and edpm_reboot_strategy|lower == "auto" and not old_tripleo_node_conf.stat.exists
+         and not edpm_node_conf.stat.exists)
   block:
     - name: Reboot tasks
       ansible.builtin.include_tasks: reboot.yaml


### PR DESCRIPTION
Add edpm_reboot_strategy to reboot role that defines if reboot should be started or not. There are three modes: auto, never and force. The default is auto.

Add also more generic check for existence of openstack configs for already
deployed nodes, both old tripleo and new edpm node.
