### PR TITLE
When kernelargs are changed, ensure reboot file exists

### DIFF
--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -155,16 +155,13 @@
 - name: Reboot block
   when:
     - reboot_required is defined and reboot_required
+    - grub_file_entry_check is changed
     - not edpm_kernel_defer_reboot|bool
     - not _workload_protection|default(false)|bool
   block:
     - name: Reboot tasks
       ansible.builtin.include_tasks: reboot.yaml
-      when:
-        - grub_file_entry_check is not changed
 
-    - name: Skipping reboot for deployed node
+    - name: Skipping automated reboot for deployed node
       ansible.builtin.debug:  # noqa: no-handler
-        msg: "Reboot is skipped for kernel arg change, user has to plan the reboot with migration and downtime"
-      when:
-        - grub_file_entry_check is changed
+        msg: "Automatic reboot is skipped for kernel arg change, user has to plan the reboot with migration and downtime"


### PR DESCRIPTION
 When kernelargs are changed, ensure reboot file exists

This change ensures that the `edpm_kernel` file is created under the
`reboot_required` directory when `grub.cfg` has been updated. This
ensures the user is able to determine when a node needs rebooting[1], and
they can do so by including our `edpm_reboot` role via the `reboot.yml`
playbook in a `servicesOverride` on the deployment.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/blob/main/docs/source/roles/role-edpm_reboot.rst?plain=1#L10-L18