### PR TITLE
Cleanup role for tripleo services

### DIFF
--- a/docs/source/playbooks/tripleo_cleanup.rst
+++ b/docs/source/playbooks/tripleo_cleanup.rst
@@ -1,0 +1,10 @@
+==========================
+Playbook - tripleo_cleanup
+==========================
+
+Stops and disables all tripleo services running on target hosts.
+Heuristic based on systemd unit name pattern matching is used to determine
+which services should be stopped and disabled.
+
+.. literalinclude:: ../../../playbooks/tripleo_cleanup.yml
+   :language: YAML

--- a/docs/source/roles/role-edpm_tripleo_cleanup.rst
+++ b/docs/source/roles/role-edpm_tripleo_cleanup.rst
@@ -1,0 +1,13 @@
+================================
+Role - edpm_tripleo_cleanup
+================================
+
+Role stops and disables all systemd units enumerated to it.
+If the role doesn't recieve list of services, it will instead stop and disable
+all units containing string "tripleo" in their name.
+
+This way we can effectivelly prevent any leftovers of original tripleo based
+deployment from interfering with post-adoption setup.
+
+.. include::
+  ../collections/osp/edpm/edpm_tripleo_cleanup_role.rst

--- a/playbooks/tripleo_cleanup.yml
+++ b/playbooks/tripleo_cleanup.yml
@@ -1,0 +1,27 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Cleanup Tripleo services
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  gather_facts: true
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Stop and disable Tripleo services
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_tripleo_cleanup

--- a/roles/edpm_tripleo_cleanup/defaults/main.yml
+++ b/roles/edpm_tripleo_cleanup/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+edpm_old_tripleo_services: []
+
+# Remove unit files
+edpm_remove_tripleo_unit_files: true

--- a/roles/edpm_tripleo_cleanup/meta/argument_specs.yml
+++ b/roles/edpm_tripleo_cleanup/meta/argument_specs.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+argument_specs:
+  # roles/edpm_tripleo_cleanup/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_tripleo_cleanup role.
+    options:
+      edpm_old_tripleo_services:
+        type: "list"
+        description: |
+          List of tripleo services to be disabled and stopped.
+          If the list is empty, all services containing string 'tripleo'
+          in their names will be disabled, stopped and masked.
+        default: []
+      edpm_remove_tripleo_unit_files:
+        type: "bool"
+        description: |
+          Remove unit files after disabling services.
+          This operation is irreversible. Furthermore, issues may occur,
+          if the unit files are managed by package manager.
+        default: true

--- a/roles/edpm_tripleo_cleanup/meta/main.yml
+++ b/roles/edpm_tripleo_cleanup/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  namespace: openstack
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_tripleo_cleanup
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.9'
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_tripleo_cleanup/molecule/default/collections.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.general

--- a/roles/edpm_tripleo_cleanup/molecule/default/converge.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: "osp.edpm.edpm_tripleo_cleanup"
+      vars:
+        edpm_old_tripleo_services:
+          - fake-tripleo-service

--- a/roles/edpm_tripleo_cleanup/molecule/default/molecule.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+platforms:
+  - name: compute-1
+    groups:
+      - compute
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          compute-1:
+            ctlplane_ip: 10.0.0.3
+            canonical_hostname: edpm-0.localdomain
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/roles/edpm_tripleo_cleanup/molecule/default/prepare.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/prepare.yml
@@ -1,0 +1,40 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+- name: Prepare test_deps
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+      test_deps_extra_packages:
+        - podman
+  tasks:
+    - name: Create mock service
+      become: true
+      ansible.builtin.copy:
+        src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/test-data/fake-tripleo-service.service"
+        dest: /usr/lib/systemd/system/fake-tripleo-service.service
+        mode: '0644'
+
+    - name: Enable mock service
+      become: true
+      ansible.builtin.systemd_service:
+        name: fake-tripleo-service
+        enabled: true
+
+    - name: Start mock service
+      become: true
+      ansible.builtin.systemd_service:
+        name: fake-tripleo-service
+        state: started

--- a/roles/edpm_tripleo_cleanup/molecule/default/test-data/fake-tripleo-service.service
+++ b/roles/edpm_tripleo_cleanup/molecule/default/test-data/fake-tripleo-service.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Fake tripleo service
+
+[Service]
+ExecStart=/usr/bin/true
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/edpm_tripleo_cleanup/molecule/default/verify.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check if unit file exists and fail if it does
+      ansible.builtin.file:
+        path: /usr/lib/systemd/system/fake-tripleo-service.service
+        state: absent
+      check_mode: true

--- a/roles/edpm_tripleo_cleanup/tasks/main.yml
+++ b/roles/edpm_tripleo_cleanup/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Reload units to check for new changes
+  tags:
+    - adoption
+  become: true
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
+- name: Set list of tripleo services
+  tags:
+    - adoption
+  ansible.builtin.set_fact:
+    tripleo_services: "{{ edpm_old_tripleo_services }}"
+
+- name: Discover tripleo services
+  tags:
+    - adoption
+  when: tripleo_services | length == 0
+  block:
+    - name: Get all services
+      ansible.builtin.service_facts:
+    - name: Filter for tripleo services
+      ansible.builtin.set_fact:
+        tripleo_services: "{{ ansible_facts.services.keys() | select('contains', 'tripleo') }}"
+
+- name: Stop and disable tripleo services
+  tags:
+    - adoption
+  become: true
+  ansible.builtin.systemd_service:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+    masked: true
+  loop: "{{ tripleo_services }}"
+
+- name: Remove unit files
+  tags:
+    - adoption
+  become: true
+  ansible.builtin.file:
+    path: /usr/lib/systemd/system/{{ item }}.service
+    state: absent
+  loop: "{{ tripleo_services }}"
+  when: edpm_remove_tripleo_unit_files

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -61,3 +61,8 @@
     parent: edpm-ansible-molecule-base
     vars:
       TEST_RUN: edpm_ovs
+- job:
+    name: edpm-ansible-molecule-edpm_tripleo_cleanup
+    parent: edpm-ansible-molecule-base
+    vars:
+      TEST_RUN: edpm_tripleo_cleanup

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -15,3 +15,4 @@
         - edpm-ansible-molecule-edpm_iscsid
         - edpm-ansible-molecule-edpm_ovn_bgp_agent
         - edpm-ansible-molecule-edpm_ovs
+        - edpm-ansible-molecule-edpm_tripleo_cleanup


### PR DESCRIPTION
Just a role with documentation and tests. Actual invocations of the role, along with removals of other cleanup routines, will be included in follow up PRs.