### PR TITLE
Allow ovn-encap-tos to be configured

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -36,6 +36,7 @@ edpm_ovn_chassis_mac_mapping_prefixes:
 
 edpm_ovn_chassis_mac_mapping_seed: "{{ ansible_machine_id }}"
 edpm_ovn_encap_type: geneve
+edpm_ovn_encap_tos: "0"
 edpm_ovn_dbs: []
 edpm_enable_chassis_gw: false
 edpm_enable_chassis_extport: false
@@ -81,6 +82,7 @@ edpm_ovn_ovs_external_ids:
     {{ chassis_mac_mappings | join(',') }}"
   ovn-encap-ip: "{{ edpm_ovn_encap_ip }}"
   ovn-encap-type: "{{ edpm_ovn_encap_type }}"
+  ovn-encap-tos: "{{ edpm_ovn_encap_tos }}"
   ovn-match-northd-version: "{{ ovn_match_northd_version }}"
   ovn-monitor-all: "{{ ovn_monitor_all }}"
   ovn-remote: >-

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -82,6 +82,11 @@ argument_specs:
         description: >
           Passed to the `edpm_ovn_ovs_external_ids` as value for the `ovn-encap-type`.
         type: str
+      edpm_ovn_encap_tos:
+        default: '0'
+        description: >
+          Passed to the `edpm_ovn_ovs_external_ids` as value for the `ovn-encap-tos`.
+        type: str
       edpm_ovn_multi_rhel:
         default: false
         description: ''

--- a/roles/edpm_ovn/molecule/default/verify-tasks.yml
+++ b/roles/edpm_ovn/molecule/default/verify-tasks.yml
@@ -13,6 +13,12 @@
   register: output
   failed_when: output.stdout != 'geneve'
 
+- name: Verify ovn-encap-tos
+  ansible.builtin.shell: >
+    /usr/bin/ovs-vsctl get open_vswitch . external_ids:ovn-encap-tos
+  register: output
+  failed_when: output.stdout != '"0"'
+
 - name: Verify ovn firewall rules are applied
   block:
     - name: Rule source file exists

--- a/roles/edpm_ovn/molecule/noconfig/verify.yml
+++ b/roles/edpm_ovn/molecule/noconfig/verify.yml
@@ -16,3 +16,9 @@
         /usr/bin/ovs-vsctl get open_vswitch . external_ids:ovn-encap-type
       register: output
       failed_when: output.stdout != 'vxlan'
+
+    - name: Verify ovn-encap-tos
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open_vswitch . external_ids:ovn-encap-tos
+      register: output
+      failed_when: output.stdout != '"0"'


### PR DESCRIPTION
This patch allows for the ovn-encap-tos to be configured in ovn-controller.

By default this option has the value of 0, as per OVS options:tos description [0], but it could also contain the word "inherit" therefore the field type for this patch is "str".

[0]
options : tos: optional string
      Optional. The value of the ToS bits to be set on the encapsulat‐
      ing packet. ToS is interpreted as DSCP and ECN  bits,  ECN  part
      must be zero. It may also be the word inherit, in which case the
      ToS will be copied from the inner packet if it is IPv4  or  IPv6
      (otherwise  it  will be 0). The ECN fields are always inherited.
      Default is 0.

http://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.txt

Resolves: [OSPRH-6712](https://issues.redhat.com//browse/OSPRH-6712)