### PR TITLE
Multiple certs

### DIFF
--- a/roles/edpm_install_certs/tasks/copy_certs_and_keys.yaml
+++ b/roles/edpm_install_certs/tasks/copy_certs_and_keys.yaml
@@ -21,10 +21,10 @@
   block:
     - name: Set paths
       ansible.builtin.set_fact:
-        cert_src_path: "/var/lib/openstack/certs/{{ service }}"
-        cacert_dest_path: "/var/lib/openstack/certs/{{ service }}"
-        cert_dest_path: "/var/lib/openstack/certs/{{ service }}"
-        key_dest_path: "/var/lib/openstack/certs/{{ service }}"
+        cert_src_path: "{{ service_cert_path }}"
+        cacert_dest_path: "{{ service_cert_path }}"
+        cert_dest_path: "{{ service_cert_path }}"
+        key_dest_path: "{{ service_cert_path }}"
 
     - name: Ensure that the destination directories exist
       ansible.builtin.file:

--- a/roles/edpm_install_certs/tasks/main.yml
+++ b/roles/edpm_install_certs/tasks/main.yml
@@ -17,17 +17,18 @@
 - name: Find certs and keys
   ansible.builtin.find:
     paths: /var/lib/openstack/certs
-    recurse: false
+    depth: 3
+    recurse: true
     file_type: directory
-  register: found_certs_services
+  register: found_cert_paths
   delegate_to: localhost
 
 - name: Copy certs and keys to the correct location
   ansible.builtin.include_tasks: copy_certs_and_keys.yaml
   loop:
-    "{{ found_certs_services['files'] | map(attribute='path') | map('basename') | list }}"
+    "{{ found_cert_paths['files'] | selectattr('path', 'match', '/var/lib/openstack/certs/.+/.+') | map(attribute='path') |list }}"
   loop_control:
-    loop_var: service
+    loop_var: service_cert_path
 
 - name: Find cacerts
   ansible.builtin.find:

--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -71,4 +71,4 @@ edpm_libvirt_password_path: /var/lib/openstack/configs/{{ edpm_libvirt_service_n
 
 # certs
 edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_libvirt_tls_cert_src_dir: /var/lib/openstack/certs/{{ edpm_libvirt_service_name }}
+edpm_libvirt_tls_cert_src_dir: /var/lib/openstack/certs/{{ edpm_libvirt_service_name }}/default

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -60,8 +60,8 @@ edpm_neutron_metadata_agent_ovn_ovsdb_probe_interval: '60000'
 edpm_neutron_metadata_agent_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 
 edpm_neutron_metadata_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
   - "/var/lib/openstack/cacerts/{{ edpm_neutron_metadata_service_name }}/tls-ca-bundle.pem:\
     /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -139,7 +139,7 @@ argument_specs:
         type: list
         elements: str
         default:
-          - /var/lib/openstack/certs/neutron_metadata_agent/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z
-          - /var/lib/openstack/certs/neutron_metadata_agent/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
-          - /var/lib/openstack/certs/neutron_metadata_agent/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
+          - /var/lib/openstack/certs/neutron_metadata_agent/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z
+          - /var/lib/openstack/certs/neutron_metadata_agent/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
+          - /var/lib/openstack/certs/neutron_metadata_agent/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
           - /var/lib/openstack/cacerts/neutron_metadata_agent/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -25,9 +25,9 @@ edpm_neutron_ovn_common_volumes:
 edpm_neutron_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 edpm_neutron_ovn_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_neutron_ovn_service_name }}"
 edpm_neutron_ovn_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
   - "{{ edpm_neutron_ovn_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
 # Neutron conf

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -65,9 +65,9 @@ edpm_ovn_controller_common_volumes:
   - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
 
 edpm_ovn_controller_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
   - "/var/lib/openstack/cacerts/{{ edpm_ovn_service_name }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
 edpm_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -61,9 +61,9 @@ argument_specs:
         type: list
       edpm_ovn_controller_tls_volumes:
         default:
-          - /var/lib/openstack/certs/ovn/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z
-          - /var/lib/openstack/certs/ovn/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
-          - /var/lib/openstack/certs/ovn/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
+          - /var/lib/openstack/certs/ovn/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z
+          - /var/lib/openstack/certs/ovn/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
+          - /var/lib/openstack/certs/ovn/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
           - /var/lib/openstack/cacerts/ovn/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z
         description: List of TLS volumes in a mount point form.
         type: list

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -65,9 +65,9 @@ edpm_ovn_bgp_agent_common_volumes:
   - /run/openvswitch:/run/openvswitch:shared,z
 
 edpm_ovn_bgp_agent_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
   - "/var/lib/openstack/cacerts/{{ edpm_ovn_bgp_agent_service_name }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
   # we need to add the InternalTLSCAFile and do a if/then/else in case tls-e

--- a/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
+++ b/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
@@ -142,7 +142,7 @@ argument_specs:
         type: list
         description: list of mounted TLS certificate volumes
         default:
-          - "/var/lib/openstack/certs/ovn-bgp-agent/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-          - "/var/lib/openstack/certs/ovn-bgp-agent/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-          - "/var/lib/openstack/certs/ovn-bgp-agent/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+          - "/var/lib/openstack/certs/ovn-bgp-agent/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+          - "/var/lib/openstack/certs/ovn-bgp-agent/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+          - "/var/lib/openstack/certs/ovn-bgp-agent/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
           - "/var/lib/openstack/cacerts/ovn-bgp-agent/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"

--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -29,7 +29,7 @@ edpm_telemetry_ceilometer_compute_image: quay.io/podified-antelope-centos9/opens
 # Image to use for Ceilometer Ipmi
 edpm_telemetry_ceilometer_ipmi_image: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
 # Certificates location for tls encryption
-edpm_telemetry_certs: "/var/lib/openstack/certs/{{ edpm_telemetry_service_name }}"
+edpm_telemetry_certs: "/var/lib/openstack/certs/{{ edpm_telemetry_service_name }}/default"
 # CA certs location for tls encryption
 edpm_telemetry_cacerts: "/var/lib/openstack/cacerts/{{ edpm_telemetry_service_name }}"
 # If TLS should be enabled for telemetry


### PR DESCRIPTION
This accompanies a change to provide for multiple certs to be issued per dataplane service.

We may have to force merge to unlock the dependencies with the dataplane patch.
