### PR TITLE
disable nbd_tls until RHEL-33754 is resolved

### DIFF
--- a/roles/edpm_libvirt/molecule/default/prepare.yml
+++ b/roles/edpm_libvirt/molecule/default/prepare.yml
@@ -193,10 +193,16 @@
         csr_content: "{{ csr.csr }}"
         provider: ownca
 
+
     - name: Create password secret
       ansible.builtin.copy:
         dest: "{{ edpm_libvirt_password_path }}"
         content: "correct horse battery staple"
+      # FIXME(sean-k-mooney): this is a hack to work around
+      # the fact that the playbook uses a lookup plugin which always
+      # executes on the ansible contoller. This is needed to ensure
+      # the password is available locally when runing under vagrant.
+      delegate_to: localhost
 
     # FIXME(sean-k-mooney): this is a hack to work around the fact that we dont
     # currently manage the hostname on the DUT via boostrap or a dedicated role

--- a/roles/edpm_libvirt/molecule/default/verify.yml
+++ b/roles/edpm_libvirt/molecule/default/verify.yml
@@ -112,13 +112,19 @@
           - "run_libvirt.rc != 0"
 
     - name: Load /etc/libvirt/qemu.conf
-      ansible.builtin.shell: "grep migration_port /etc/libvirt/qemu.conf | tr '\n' ' '"
-      register: qemu_conf_migration_ports
+      become: true
+      ansible.builtin.slurp:
+        src: /etc/libvirt/qemu.conf
+      register: qemu_conf
     - name: Assert that qemu.conf has a proper migration port range
       assert:
         that:
-          - "item  == 'migration_port_min = 61152 migration_port_max = 61215 '"
-      loop: "{{ qemu_conf_migration_ports.stdout_lines }}"
+          - "'migration_port_min = 61152' in qemu_conf.content | b64decode"
+          - "'migration_port_max = 61215' in qemu_conf.content | b64decode"
+    - name: Assert that nbt_tls is disabled in qemu.conf
+      assert:
+        that:
+          - "'nbd_tls = 0' in qemu_conf.content | b64decode"
 
     - name: Load os_enabled_vtpm selinux boolean
       ansible.builtin.shell: "getsebool os_enable_vtpm"

--- a/roles/edpm_libvirt/molecule/vagrant/molecule.yml
+++ b/roles/edpm_libvirt/molecule/vagrant/molecule.yml
@@ -7,8 +7,8 @@ driver:
     name: libvirt
   provision: no
   parallel: true
-  # default_box: 'generic/rocky9'
-  default_box: 'generic/centos9s'
+  default_box: 'generic/rocky9'
+  # default_box: 'generic/centos9s'
 platforms:
 - name: compute-1
   memory: 8192

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -1,5 +1,6 @@
 ---
-
+# TODO(sean-k-mooney): This should be refactored to not use a lookup plugin
+# to read the password from a file on the controller.
 - name: Get libvirt password
   ansible.builtin.set_fact:
     sasl_password: "{{ lookup('file', edpm_libvirt_password_path, lstrip=false, rstrip=false) }}"

--- a/roles/edpm_libvirt/templates/qemu.conf.j2
+++ b/roles/edpm_libvirt/templates/qemu.conf.j2
@@ -1,10 +1,15 @@
 max_files = 32768
 max_processes = 131072
+# NOTE(sean-k-mooney): nbd_tls = 0 is required until
+# a new release of libvirt is available see
+# https://issues.redhat.com/browse/RHEL-33754
 {% if edpm_libvirt_tls_certs_enabled|bool %}
 vnc_tls = 1
 vnc_tls_x509_verify = 1
+nbd_tls = 0
 {% else -%}
 vnc_tls = 0
+nbd_tls = 0
 {% endif %}
 # NOTE(gibi): In tripleo the default range was intentionally changed to avoid
 # port usage conflicts. See https://review.openstack.org/#/c/561784


### PR DESCRIPTION
This change disabled nbd_tls to prevent guest
crahses on local storage guest live migrations.

Closes: [OSPRH-6931](https://issues.redhat.com//browse/OSPRH-6931)
