### PR TITLE
Add output of os-net-config file before applying in edpm_network_config

### DIFF
--- a/roles/edpm_network_config/tasks/os_net_config.yml
+++ b/roles/edpm_network_config/tasks/os_net_config.yml
@@ -30,6 +30,16 @@
         dest: "{{ nic_config_file }}"
         mode: '0644'
         backup: true
+    - name: Retrieve and output nic_config_file contents for debug before applying
+      when: edpm_network_config_debug|bool
+      block:
+        - name: Retrieve content of nic_config_file before applying
+          ansible.builtin.slurp:
+            path: "{{ nic_config_file }}"
+          register: os_net_config_config
+        - name: Debug print nic_config_file contents
+          ansible.builtin.debug:
+            msg: "{{ os_net_config_config['content'] | b64decode | trim }}"
     - name: Run edpm_os_net_config_module with network_config
       edpm_os_net_config:
         config_file: "{{ nic_config_file }}"


### PR DESCRIPTION
Adds a debug task to display the contents of the os-net-config config file before this is applied. This can be especially useful if node connectivity is disrupted after the config is applied.

https://issues.redhat.com/browse/OSPRH-5754