### PR TITLE
Use correct standalone container name for DHCP agent

### DIFF
--- a/roles/edpm_neutron_dhcp/tasks/run.yml
+++ b/roles/edpm_neutron_dhcp/tasks/run.yml
@@ -25,7 +25,7 @@
     name: osp.edpm.edpm_container_standalone
   vars:
     edpm_debug: true
-    edpm_container_standalone_service: neutron_dhcp_agent
+    edpm_container_standalone_service: neutron_dhcp
     edpm_container_standalone_container_defs:
       neutron_dhcp_agent: "{{ lookup('template', 'neutron_dhcp_agent.yaml.j2') | from_yaml }}"
     edpm_container_standalone_kolla_config_files:


### PR DESCRIPTION
The Neutron DHCP agent doesn't follow naming convention for Neutron agent services in standalone. It does not contain the _agent suffix and is named just neutron_dhcp.

Resolves: [OSPRH-6703](https://issues.redhat.com//browse/OSPRH-6703)