### PR TITLE
Drop usage of edpm_service_name

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -19,6 +19,8 @@
 
 # All variables within this role should have a prefix of "edpm_libvirt"
 
+# service name this role manages
+edpm_libvirt_service_name: libvirt
 # seconds between retries for download tasks
 edpm_libvirt_download_delay: 5
 # number of retries for download tasks
@@ -65,8 +67,8 @@ edpm_libvirt_packages:
   # for SASL auth
   - cyrus-sasl-scram
 edpm_libvirt_ceph_path: /var/lib/openstack/config/ceph
-edpm_libvirt_password_path: /var/lib/openstack/configs/{{ edpm_service_name | default('libvirt') }}/LibvirtPassword
+edpm_libvirt_password_path: /var/lib/openstack/configs/{{ edpm_libvirt_service_name }}/LibvirtPassword
 
 # certs
 edpm_libvirt_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_libvirt_tls_cert_src_dir: /var/lib/openstack/certs/{{ edpm_service_name | default('libvirt') }}
+edpm_libvirt_tls_cert_src_dir: /var/lib/openstack/certs/{{ edpm_libvirt_service_name }}

--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -18,13 +18,16 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "edpm_neutron_dhcp"
 
+# service name this role manages
+edpm_neutron_dhcp_service_name: neutron-dhcp
+
 # seconds between retries for download tasks
 edpm_neutron_dhcp_images_download_delay: 5
 
 # number of retries for download tasks
 edpm_neutron_dhcp_images_download_retries: 5
 
-edpm_neutron_dhcp_agent_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('neutron-dhcp') }}"
+edpm_neutron_dhcp_agent_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_dhcp_service_name }}"
 edpm_neutron_dhcp_agent_config_dir: "/var/lib/config-data/ansible-generated/neutron-dhcp-agent"
 edpm_neutron_dhcp_agent_lib_dir: "/var/lib/neutron"
 edpm_neutron_dhcp_image: "quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent:current-podified"
@@ -41,7 +44,7 @@ edpm_neutron_dhcp_common_volumes:
   - "{{ edpm_neutron_dhcp_agent_lib_dir }}/kill_scripts:/etc/neutron/kill_scripts:ro"
 
 edpm_neutron_dhcp_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_neutron_dhcp_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-dhcp') }}"
+edpm_neutron_dhcp_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_neutron_dhcp_service_name }}"
 edpm_neutron_dhcp_tls_volumes:
   - "{{ edpm_neutron_dhcp_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -1,13 +1,16 @@
 ---
 # defaults file for edpm_ovn
 
+# service name this role manages
+edpm_neutron_metadata_service_name: neutron-metadata
+
 # seconds between retries for download tasks
 edpm_neutron_metadata_images_download_delay: 5
 
 # number of retries for download tasks
 edpm_neutron_metadata_images_download_retries: 5
 
-edpm_neutron_metadata_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('neutron-metadata') }}"
+edpm_neutron_metadata_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_metadata_service_name }}"
 edpm_neutron_metadata_agent_config_dir: /var/lib/config-data/ansible-generated/neutron-ovn-metadata-agent
 edpm_neutron_metadata_agent_log_dir: "/var/log/neutron"
 edpm_neutron_metadata_agent_lib_dir: "/var/lib/neutron"
@@ -57,8 +60,8 @@ edpm_neutron_metadata_agent_ovn_ovsdb_probe_interval: '60000'
 edpm_neutron_metadata_agent_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 
 edpm_neutron_metadata_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron-metadata') }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron-metadata') }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron-metadata') }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
-  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-metadata') }}/tls-ca-bundle.pem:\
+  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/cacerts/{{ edpm_neutron_metadata_service_name }}/tls-ca-bundle.pem:\
     /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
-# defaults file for edpm_ovn
+# defaults file for edpm_neutron_ovn
+
+# service name this role manages
+edpm_neutron_ovn_service_name: neutron-ovn
 
 # seconds between retries for download tasks
 edpm_neutron_ovn_images_download_delay: 5
@@ -7,7 +10,7 @@ edpm_neutron_ovn_images_download_delay: 5
 # number of retries for download tasks
 edpm_neutron_ovn_images_download_retries: 5
 
-edpm_neutron_ovn_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('neutron-ovn') }}"
+edpm_neutron_ovn_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_ovn_service_name }}"
 edpm_neutron_ovn_agent_config_dir: /var/lib/config-data/ansible-generated/neutron-ovn-agent
 edpm_neutron_ovn_agent_log_dir: "/var/log/neutron"
 
@@ -20,11 +23,11 @@ edpm_neutron_ovn_common_volumes:
   - /var/lib/kolla/config_files/ovn_agent.json:/var/lib/kolla/config_files/config.json:ro
 
 edpm_neutron_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_neutron_ovn_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-ovn') }}"
+edpm_neutron_ovn_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_neutron_ovn_service_name }}"
 edpm_neutron_ovn_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron-ovn') }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron-ovn') }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('neutron-ovn') }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
   - "{{ edpm_neutron_ovn_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
 # Neutron conf

--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -17,6 +17,9 @@
 
 # All variables intended for modification should be placed in this file.
 
+# service name this role manages
+edpm_neutron_sriov_service_name: neutron-sriov
+
 # seconds between retries for download tasks
 edpm_neutron_sriov_images_download_delay: 5
 
@@ -24,7 +27,7 @@ edpm_neutron_sriov_images_download_delay: 5
 edpm_neutron_sriov_images_download_retries: 5
 
 # All variables within this role should have a prefix of "edpm_neutron_sriov_agent"
-edpm_neutron_sriov_agent_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('neutron-sriov') }}"
+edpm_neutron_sriov_agent_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_sriov_service_name }}"
 edpm_neutron_sriov_agent_config_dir: "/var/lib/config-data/ansible-generated/neutron-sriov-agent"
 edpm_neutron_sriov_image: "quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent:current-podified"
 
@@ -37,7 +40,7 @@ edpm_neutron_sriov_common_volumes:
   - /var/log/containers/neutron:/var/log/neutron:z
 
 edpm_neutron_sriov_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_neutron_sriov_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('neutron-sriov') }}"
+edpm_neutron_sriov_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_neutron_sriov_service_name }}"
 edpm_neutron_sriov_tls_volumes:
   - "{{ edpm_neutron_sriov_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 

--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -17,6 +17,9 @@
 
 # All variables intended for modification should be placed in this file.
 
+# service name this role manages
+edpm_nova_service_name: nova
+
 # seconds between retries for download tasks
 edpm_nova_image_download_delay: 5
 
@@ -40,7 +43,7 @@ edpm_nova_live_migration_native_tls: false
 # so we will not need the libvirt or ovs client certs or ca. nova will communicate other services
 # via there api endpoints and will connect to rabbitmq. To support this we will need to trust
 # the general ca root cert.
-edpm_nova_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('nova') }}"
+edpm_nova_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_nova_service_name }}"
 
 # list of tripleo nova services to stop during EDPM adoption
 edpm_nova_old_tripleo_compute_sevices:

--- a/roles/edpm_nova/tasks/install.yml
+++ b/roles/edpm_nova/tasks/install.yml
@@ -5,6 +5,15 @@
     path: "{{ edpm_nova_tls_ca_src_dir }}/tls-ca-bundle.pem"
   register: ca_bundle_stat_res
 
+# TODO(slagle) This is a temporary backwards compatible task so this can merge
+# independently of the dataplane-operator change. This can be removed when
+# https://github.com/openstack-k8s-operators/dataplane-operator/pull/885
+# merges. Remove the check in templates/nova_compute.json.j2 as well.
+- name: Check if nova-custom ca bundle exists
+  ansible.builtin.stat:
+    path: "/var/lib/openstack/cacerts/nova-custom/tls-ca-bundle.pem"
+  register: nova_custom_ca_bundle_stat_res
+
 - name: Render nova container
   tags:
     - install
@@ -16,6 +25,7 @@
     mode: "0644"
   vars:
     ca_bundle_exists: "{{ ca_bundle_stat_res.stat.exists }}"
+    nova_custom_ca_bundle_exists: "{{ nova_custom_ca_bundle_stat_res.stat.exists }}"
   notify:
     - Restart nova
 - name: Deploy nova container

--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -12,6 +12,8 @@
         "/var/lib/openstack/config/nova:/var/lib/kolla/config_files:ro",
 {% if ca_bundle_exists|bool %}
         "{{ edpm_nova_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z",
+{% elif nova_custom_ca_bundle_exists|bool %}
+        "/var/lib/openstack/cacerts/nova-custom/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z",
 {% endif %}
         "/etc/localtime:/etc/localtime:ro",
         "/lib/modules:/lib/modules:ro",

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -1,13 +1,16 @@
 ---
 # defaults file for edpm_ovn
 
+# service name this role manages
+edpm_ovn_service_name: "ovn"
+
 # seconds between retries for download tasks
 edpm_ovn_images_download_delay: 5
 
 # number of retries for download tasks
 edpm_ovn_images_download_retries: 5
 
-edpm_ovn_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('ovn') }}"
+edpm_ovn_config_src: "/var/lib/openstack/configs/{{ edpm_ovn_service_name }}"
 edpm_ovn_bridge: br-int
 edpm_ovn_bridge_mappings: ["datacentre:br-ex"]
 
@@ -61,10 +64,10 @@ edpm_ovn_controller_common_volumes:
   - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
 
 edpm_ovn_controller_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('ovn') }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('ovn') }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('ovn') }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
-  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('ovn') }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/cacerts/{{ edpm_ovn_service_name }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
 edpm_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -19,6 +19,7 @@
 
 # All variables within this role should have a prefix of "edpm_ovn_bgp_agent"
 
+edpm_ovn_bgp_agent_service_name: ovn-bgp-agent
 edpm_ovn_bgp_agent_enable: true
 edpm_ovn_bgp_agent_debug: true
 edpm_ovn_bgp_agent_reconcile_interval: 300
@@ -31,7 +32,7 @@ edpm_ovn_bgp_agent_certificate: /etc/pki/tls/certs/ovndb.crt
 edpm_ovn_bgp_agent_ca_cert: /etc/pki/tls/certs/ovndbca.crt
 edpm_ovn_bgp_agent_internal_tls_enable: "{{ edpm_tls_certs_enabled | default(False) }}"
 edpm_ovn_bgp_agent_config_basedir: "/var/lib/config-data/ansible-generated/ovn-bgp-agent"
-edpm_ovn_bgp_agent_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('ovn-bgp-agent') }}"
+edpm_ovn_bgp_agent_config_src: "/var/lib/openstack/configs/{{ edpm_ovn_bgp_agent_service_name }}"
 edpm_ovn_bgp_agent_bgp_as: 64999
 edpm_ovn_bgp_agent_clear_vrf_routes_on_startup: false
 edpm_ovn_bgp_agent_bgp_nic: bgp-nic
@@ -64,10 +65,10 @@ edpm_ovn_bgp_agent_common_volumes:
   - /run/openvswitch:/run/openvswitch:shared,z
 
 edpm_ovn_bgp_agent_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('ovn-bgp-agent') }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('ovn-bgp-agent') }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_service_name | default('ovn-bgp-agent') }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
-  - "/var/lib/openstack/cacerts/{{ edpm_service_name | default('ovn-bgp-agent') }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/cacerts/{{ edpm_ovn_bgp_agent_service_name }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
   # we need to add the InternalTLSCAFile and do a if/then/else in case tls-e
 

--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -16,8 +16,10 @@
 
 
 # All variables intended for modification should be placed in this file.
+# Service name this role manages
+edpm_telemetry_service_name: telemetry
 # Directory in the ansibleEE container
-edpm_telemetry_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('telemetry') }}"
+edpm_telemetry_config_src: "/var/lib/openstack/configs/{{ edpm_telemetry_service_name }}"
 # Directory in the compute node
 edpm_telemetry_config_dest: /var/lib/openstack/config/telemetry
 # Image to use for node_exporter
@@ -27,8 +29,8 @@ edpm_telemetry_ceilometer_compute_image: quay.io/podified-antelope-centos9/opens
 # Image to use for Ceilometer Ipmi
 edpm_telemetry_ceilometer_ipmi_image: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
 # Certificates location for tls encryption
-edpm_telemetry_certs: "/var/lib/openstack/certs/{{ edpm_service_name | default('telemetry') }}"
+edpm_telemetry_certs: "/var/lib/openstack/certs/{{ edpm_telemetry_service_name }}"
 # CA certs location for tls encryption
-edpm_telemetry_cacerts: "/var/lib/openstack/cacerts/{{ edpm_service_name | default('telemetry') }}"
+edpm_telemetry_cacerts: "/var/lib/openstack/cacerts/{{ edpm_telemetry_service_name }}"
 # If TLS should be enabled for telemetry
 edpm_telemetry_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"

--- a/roles/edpm_telemetry_logging/defaults/main.yml
+++ b/roles/edpm_telemetry_logging/defaults/main.yml
@@ -16,7 +16,9 @@
 
 
 # All variables intended for modification should be placed in this file.
+# Service name this role manages
+edpm_telemetry_logging_service_name: logging
 # Directory in the ansibleEE container
-edpm_telemetry_logging_config_src: "/var/lib/openstack/configs/{{ edpm_service_name | default('logging') }}"
+edpm_telemetry_logging_config_src: "/var/lib/openstack/configs/{{ edpm_telemetry_logging_service_name }}"
 # Directory of rsyslog config in the compute node
 edpm_telemetry_rsyslog_config_dest: /etc/rsyslog.d


### PR DESCRIPTION
edpm_service_name corresponds to the DataPlaneService name, creating
tight coupling between the name of the service and the expected podman
volume paths.

This breaks many assumptions around custom DataPlaneServices, and the
fact that different services may use the same ansible roles, or a single
service may use multiple ansible roles that need different volume paths.

These paths should instead be isolated from the DataPlaneService name.
This commit drops usage of edpm_service_name which is set by
dataplane-operator, and adds a new var per role for creating the path.
The new vars will not be set by dataplane-operator.

A corresponding dataplane-operator commit will take care of creating the
paths so that they are in the ansible role expected locations.

Jira: https://issues.redhat.com/browse/OSPRH-7112
Signed-off-by: James Slagle <jslagle@redhat.com>
