### PR TITLE
Stop overwriting EFI grub.cfg

### DIFF
--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -89,16 +89,6 @@
         line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${GRUB_EDPM_KERNEL_ARGS}"'
         insertafter: '^GRUB_EDPM_KERNEL_ARGS.*'
 
-    - name: Check grub config paths
-      ansible.builtin.stat:
-        path: "{{ item }}"
-      register: grub_stat
-      loop:
-        - /boot/efi/EFI/BOOT
-        - /boot/efi/EFI/redhat
-        - /boot/efi/EFI/centos
-        - /boot/efi/EFI/fedora
-
     - name: Check if grub2-mkconfig has --update-bls-cmdline option
       ansible.builtin.shell:
         cmd: grub2-mkconfig --help | grep '\-\-update-bls-cmdline'
@@ -115,27 +105,6 @@
       register: _grub2_mkconfig
       changed_when: _grub2_mkconfig.rc == 0
       failed_when: _grub2_mkconfig.rc != 0
-
-    - name: Generate EFI grub config
-      ansible.builtin.command: >-
-        grub2-mkconfig -o {{ item.stat.path }}/grub.cfg
-        {{ '--update-bls-cmdline'
-        if check_update_bls_cmdline.rc == 0
-        else '' }}
-      when: item.stat.exists | bool
-      loop: "{{ grub_stat.results }}"
-      register: _grub2_mkconfig_efi
-      changed_when: _grub2_mkconfig_efi.rc == 0
-      failed_when: _grub2_mkconfig_efi.rc != 0
-
-    - name: Copy grubenv to EFI directory
-      ansible.builtin.copy:
-        remote_src: true
-        src: /boot/grub2/grubenv
-        dest: "{{ item.stat.path }}/grubenv"
-        mode: "0644"
-      when: item.stat.exists|bool
-      loop: "{{ grub_stat.results }}"
 
     - name: Check for active tuned profile
       ansible.builtin.stat:


### PR DESCRIPTION
The EFI grub.cfg is being replaced with a RHEL style redirect[1] so that it no longer has to be updated along with the /boot/grub2/grub.cfg. This change removes the tasks which overwrite the EFI grub.cfg, which undoes the fix in [1].

An equivalent change is occuring for 17.1 images[2] and for upgrade paths into 17.1[3] so we will be able to ensure any host upgrading to 18.0 will have the correct redirect grub.cfg in place.

[1] https://github.com/openstack-k8s-operators/edpm-image-builder/pull/30
[2] https://code.engineering.redhat.com/gerrit/c/openstack-tripleo-image-elements/+/452100
[3] https://code.engineering.redhat.com/gerrit/c/tripleo-ansible/+/452086
    https://code.engineering.redhat.com/gerrit/c/openstack-tripleo-heat-templates/+/452099