### PR TITLE
 Add data-plane-adoption job to the edpm-ansible zuul github-check layout 

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -16,3 +16,37 @@
         - edpm-ansible-molecule-edpm_ovn_bgp_agent
         - edpm-ansible-molecule-edpm_ovs
         - edpm-ansible-molecule-edpm_tripleo_cleanup
+        - openstack-k8s-operators-content-provider
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
+            dependencies:
+              - openstack-k8s-operators-content-provider
+            # files based on https://github.com/marios/data-plane-adoption/blob/ec0f395a8321dc4c3ced71b777102ad7dc9de1b2/tests/roles/dataplane_adoption/tasks/main.yaml#L256
+            files:
+              - ^playbooks/bootstrap.yml
+              - ^playbooks/download_cache.yml
+              - ^playbooks/configure_network.yml
+              - ^playbooks/validate_network.yml
+              - ^playbooks/install_os.yml
+              - ^playbooks/configure_os.yml
+              - ^playbooks/ssh_known_hosts.yml
+              - ^playbooks/run_os.yml
+              - ^playbooks/install_certs.yml
+              - ^playbooks/libvirt.yml
+              - ^playbooks/ovn.yml
+              - ^playbooks/neutron_metadata.yml
+              - ^roles/edpm_bootstrap/*
+              - ^roles/edpm_download_cache/*
+              - ^roles/edpm_network_config/*
+              - ^roles/edpm_nodes_validation/*
+              - ^roles/edpm_podman/*
+              - ^roles/edpm_sshd/*
+              - ^roles/edpm_timezone/*
+              - ^roles/edpm_container_manage/*
+              - ^roles/edpm_nftables/*
+              - ^roles/edpm_logrotate_crond/*
+              - ^roles/edpm_ssh_known_hosts/*
+              - ^roles/edpm_install_certs/*
+              - ^roles/edpm_libvirt/*
+              - ^roles/edpm_ovn/*
+              - ^roles/edpm_neutron_metadata/*
+              - ^roles/edpm_pre_adoption_validation/*


### PR DESCRIPTION
This adds cifmw-data-plane-adoption-osp-17-to-extracted-crc to github-check.

https://issues.redhat.com/browse/OSPRH-7332