### PR TITLE
ovs: Don't connect to local ovsdb-server via tcp

### DIFF
--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -52,7 +52,7 @@ edpm_neutron_metadata_agent_DEFAULT_debug: 'True'
 edpm_neutron_metadata_agent_DEFAULT_metadata_workers: '2'
 edpm_neutron_metadata_agent_DEFAULT_state_path: '/var/lib/neutron'
 edpm_neutron_metadata_agent_agent_root_helper: 'sudo neutron-rootwrap /etc/neutron/rootwrap.conf'
-edpm_neutron_metadata_agent_ovs_ovsdb_connection: 'tcp:127.0.0.1:6640'
+edpm_neutron_metadata_agent_ovs_ovsdb_connection: 'unix:TODO'
 edpm_neutron_metadata_agent_ovs_ovsdb_connection_timeout: '180'
 edpm_neutron_metadata_agent_ovn_ovsdb_probe_interval: '60000'
 

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -66,7 +66,7 @@ argument_specs:
         description: ''
         type: str
       edpm_neutron_metadata_agent_ovs_ovsdb_connection:
-        default: tcp:127.0.0.1:6640
+        default: unix:TODO
         description: ''
         type: str
       edpm_neutron_metadata_agent_ovs_ovsdb_connection_timeout:

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -46,7 +46,7 @@ edpm_neutron_ovn_agent_rootwrap_DEFAULT_rlimit_nofile: '1024'
 # neutron-ovn-agent.conf
 edpm_neutron_ovn_agent_DEFAULT_debug: 'True'
 edpm_neutron_ovn_agent_agent_root_helper: 'sudo neutron-rootwrap /etc/neutron/rootwrap.conf'
-edpm_neutron_ovn_agent_ovs_ovsdb_connection: 'tcp:127.0.0.1:6640'
+edpm_neutron_ovn_agent_ovs_ovsdb_connection: 'unix:TODO'
 edpm_neutron_ovn_agent_ovs_ovsdb_connection_timeout: '180'
 edpm_neutron_ovn_agent_ovn_ovsdb_connection_timeout: '180'
 edpm_neutron_ovn_agent_ovn_ovsdb_probe_interval: '60000'

--- a/roles/edpm_neutron_ovn/meta/argument_specs.yml
+++ b/roles/edpm_neutron_ovn/meta/argument_specs.yml
@@ -45,7 +45,7 @@ argument_specs:
         description: The probe interval for the OVSDB session in milliseconds
         type: str
       edpm_neutron_ovn_agent_ovs_ovsdb_connection:
-        default: tcp:127.0.0.1:6640
+        default: unix:TODO
         description: The connection string for the OVSDB backend
         type: str
       edpm_neutron_ovn_agent_ovs_ovsdb_connection_timeout:

--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -94,21 +94,3 @@
   changed_when: ovs_other_config.rc == 0
   failed_when: ovs_other_config.rc != 0
   when: edpm_ovn_ovs_other_config | length > 0
-
-- name: Add OVS Manager
-  block:
-    - name: Check if OVS Manager already exists
-      ansible.builtin.shell: |
-        set -o pipefail
-        ovs-vsctl show | grep -q "Manager"
-      register: ovs_manager_configured
-      changed_when: true
-      failed_when: false
-
-    - name: Add OVS Manager if not exists
-      ansible.builtin.shell: >
-        ovs-vsctl --timeout=5 --id=@manager -- create Manager target=\"ptcp:6640:127.0.0.1\" -- add Open_vSwitch . manager_options @manager
-      when: ovs_manager_configured.rc == 1
-      register: ovs_manager_if_not_exists
-      changed_when: ovs_manager_if_not_exists.rc == 0
-      failed_when: ovs_manager_if_not_exists.rc != 0

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -40,8 +40,7 @@ edpm_ovn_bgp_agent_bgp_vrf: bgp-vrf
 edpm_ovn_bgp_agent_bgp_vrf_table_id: 10
 edpm_ovn_bgp_agent_root_helper: "sudo ovn-bgp-agent-rootwrap /etc/ovn-bgp-agent/rootwrap.conf"
 edpm_ovn_bgp_agent_root_helper_daemon: "sudo ovn-bgp-agent-rootwrap-daemon /etc/ovn-bgp-agent/rootwrap.conf"
-edpm_ovn_bgp_agent_ovsdb_connection: "tcp:127.0.0.1:6640"
-edpm_ovn_bgp_agent_ovs_manager: "ptcp:6640:127.0.0.1"
+edpm_ovn_bgp_agent_ovsdb_connection: "unix:TODO"
 edpm_ovn_bgp_agent_image: "quay.io/podified-antelope-centos9/openstack-ovn-bgp-agent:current-podified"
 edpm_ovn_protocol: "{% if edpm_ovn_bgp_agent_internal_tls_enable | bool %}ssl{% else %}tcp{% endif %}"
 

--- a/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
+++ b/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
@@ -79,11 +79,7 @@ argument_specs:
       edpm_ovn_bgp_agent_ovsdb_connection:
         description: Connection to the OVS database, including port and protocol.
         type: str
-        default: "tcp:127.0.0.1:6640"
-      edpm_ovn_bgp_agent_ovs_manager:
-        type: str
-        default: "ptcp:6640:127.0.0.1"
-        description: OVSDB connection method.
+        default: "unix:TODO"
       edpm_ovn_bgp_agent_image:
         type: str
         default: "quay.io/podified-antelope-centos9/openstack-ovn-bgp-agent:current-podified"

--- a/roles/edpm_ovn_bgp_agent/tasks/configure.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/configure.yml
@@ -48,20 +48,3 @@
         setype: "container_file_t"
         mode: "0644"
       loop: "{{ edpm_neutron_ovn_secrets.files }}"
-
-- name: Add OVS Manager
-  block:
-    - name: Check if OVS Manager already exists
-      ansible.builtin.shell: |
-        set -o pipefail
-        ovs-vsctl show | grep -q "Manager"
-      register: ovs_manager_configured
-      failed_when: false
-      changed_when: true
-    - name: Add OVS Manager if not exists
-      ansible.builtin.shell: >
-        ovs-vsctl --timeout=5 --id=@manager -- create Manager target=\"{{ edpm_ovn_bgp_agent_ovs_manager }}\" -- add Open_vSwitch . manager_options @manager
-      when: ovs_manager_configured.rc == 1
-      register: ovs_manager_if_not_exists
-      changed_when: ovs_manager_if_not_exists.rc == 0
-      failed_when: ovs_manager_if_not_exists.rc != 0


### PR DESCRIPTION
Just do `unix:`. This allows us to avoid TLSing the connection.

WIP, not ready, should list correct socket path and mount it; will also need to clean up Manager records from pre-adoption after adoption is complete; posted for discussion.