### PR TITLE
Use private variable for sshd_options

### DIFF
--- a/roles/edpm_sshd/molecule/banners/converge.yml
+++ b/roles/edpm_sshd/molecule/banners/converge.yml
@@ -21,3 +21,4 @@
     - name: osp.edpm.edpm_sshd
       edpm_sshd_motd_enabled: true
       edpm_sshd_banner_enabled: true
+      edpm_sshd_banner_text: "Test banner"

--- a/roles/edpm_sshd/molecule/banners/verify.yml
+++ b/roles/edpm_sshd/molecule/banners/verify.yml
@@ -1,0 +1,12 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Ensure banner is set correctly
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "Banner /etc/issue"
+        state: present
+      register: banner
+      failed_when:
+        - banner is changed

--- a/roles/edpm_sshd/tasks/configure.yml
+++ b/roles/edpm_sshd/tasks/configure.yml
@@ -68,7 +68,7 @@
 
     - name: Update sshd configuration options from vars
       ansible.builtin.set_fact:
-        edpm_sshd_server_options: |-
+        _edpm_sshd_server_options: |-
          {% set _ = edpm_sshd_server_options.__setitem__('PasswordAuthentication', edpm_sshd_password_authentication) %}
          {% if edpm_sshd_banner_enabled %}
          {% set _ = edpm_sshd_server_options.__setitem__('Banner', '/etc/issue') %}

--- a/roles/edpm_sshd/templates/sshd_config_block.j2
+++ b/roles/edpm_sshd/templates/sshd_config_block.j2
@@ -1,6 +1,6 @@
 ## {{ ansible_managed }}
 
-{% for k, v in edpm_sshd_server_options.items() %}
+{% for k, v in _edpm_sshd_server_options.items() %}
 {%   if (v is iterable) and (v is not string) %}
 {%     set vars = (v | unique) %}
 {%     for var in vars %}


### PR DESCRIPTION
Use private variable when rendering sshd server options. This avoids issues with clobbering user provided settings when we try to re-use the same variable name.