### PR TITLE
Replacing shell wrapped python script with a module

### DIFF
--- a/plugins/modules/edpm_get_ini_file.py
+++ b/plugins/modules/edpm_get_ini_file.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import configparser
+
+import yaml
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = """
+---
+module: edpm_get_ini_file
+author:
+    - Jiri Podivin <jpodivin@redhat.com>
+version_added: '0.0.1'
+short_description: Retrieve contents of section, key or entire given ini file
+notes: []
+description: |
+    Retrieve contents of given ini file. Either a single value,
+    section or an entire file as a dictionary.
+options:
+    path:
+        description: |
+            Path to ini file.
+        type: str
+        required: true
+    section:
+        description: |
+            Name of the section containing the key.
+        type: str
+    key:
+        description: |
+            Name of the field you want to retrieve.
+        type: str
+
+"""
+
+EXAMPLES = """
+- name: Create network configs with defaults
+  edpm_get_ini_file:
+    path: /path/to/ini
+    section: main
+    key: some_key
+"""
+
+RETURN = """
+value:
+    description: |
+        Contents of given ini file.
+    returned: success
+    type: str
+    sample: localhost.local
+"""
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=yaml.safe_load(DOCUMENTATION)['options'],
+        supports_check_mode=True,
+    )
+    results = dict(
+        changed=False
+    )
+    # Parse args
+    args = module.params
+
+    # Argument sanity check
+    if args["key"] and not args["section"]:
+        module.fail_json(f"Key {args['key']} was specified without corresponding section.")
+    cfg = configparser.ConfigParser(strict=False)
+
+    # Open file
+    file = cfg.read(args["path"])
+
+    # Get file contents
+    try:
+        # Late check on ret val from ConfigParser
+        if not file:
+            module.fail_json(f"File at {args['path']} couldn't be parsed.")
+        if args["section"]:
+            value = dict(cfg[args["section"]])
+            if args["key"]:
+                value = value[args["key"]]
+        else:
+            value = {key: dict(val) for key, val in cfg.items()}
+        results['value'] = value
+    except KeyError:
+        module.fail_json(
+            f"File {args['path']} doesn't contain key {args['key']} in section {args['section']}")
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/edpm_pre_adoption_validation/tasks/hostname.yml
+++ b/roles/edpm_pre_adoption_validation/tasks/hostname.yml
@@ -25,49 +25,52 @@
         path: "{{ edpm_pre_adoption_validation_old_nova_config }}"
       register: nova_old_config_file
 
-    # NOTE(gibi): we intentionally using python configparser to extract
-    # the config value. Grep is not enough as multiple sections have 'host'
-    # key. Also we cannot rely on crudini as it is not available on the
-    # node being adopted.
-    - name: Compare old nova service host to {{ canonical_hostname }}
+    - name: Retrieve original hostname
       when: nova_old_config_file.stat.exists
-      ansible.builtin.command:
-        cmd: >
-          python3 -c
-          "import configparser as c;
-          p = c.ConfigParser(strict=False);
-          p.read('{{ edpm_pre_adoption_validation_old_nova_config }}');
-          print(p['DEFAULT']['host'])"
-      register: nova_old_config_output
-      changed_when: false
-      failed_when: nova_old_config_output.stdout != canonical_hostname
+      osp.edpm.edpm_get_ini_file:
+        section: 'DEFAULT'
+        key: 'host'
+        path: "{{ edpm_pre_adoption_validation_old_nova_config }}"
+      register: nova_old_hostname
+      failed_when: false
+
+    - name: Compare old nova service host to {{ canonical_hostname }}
+      when:
+        - nova_old_config_file.stat.exists
+        - nova_old_hostname.value != canonical_hostname
+      ansible.builtin.fail:
+        msg: "{{ canonical_hostname }} doesn't match original nova hostname {{ nova_old_hostname.value }}"
 
     - name: Check if old neutron.conf exists
       ansible.builtin.stat:
         path: "{{ edpm_pre_adoption_validation_old_neutron_config }}"
       register: neutron_old_config_file
 
-    - name: Compare old neutron service host to {{ canonical_hostname }}
+    - name: Retrieve original hostname
       when: neutron_old_config_file.stat.exists
-      ansible.builtin.command:
-        cmd: >
-          python3 -c
-          "import configparser as c;
-          p = c.ConfigParser(strict=False);
-          p.read('{{ edpm_pre_adoption_validation_old_neutron_config }}');
-          print(p['DEFAULT']['host'])"
-      register: neutron_old_config_output
-      changed_when: false
-      failed_when: neutron_old_config_output.stdout != canonical_hostname
+      osp.edpm.edpm_get_ini_file:
+        section: 'DEFAULT'
+        key: 'host'
+        path: "{{ edpm_pre_adoption_validation_old_neutron_config }}"
+      register: neutron_old_hostname
+      failed_when: false
+
+    - name: Compare old neutron service host to {{ canonical_hostname }}
+      when:
+        - neutron_old_config_file.stat.exists
+        - neutron_old_hostname.value != canonical_hostname
+      ansible.builtin.fail:
+        msg: "{{ canonical_hostname }} doesn't match original neutron hostname {{ neutron_old_hostname.value }}"
+
 
     - name: Print validated information
       ansible.builtin.debug:
         msg:
           - "canonical_hostname: {{ canonical_hostname }}"
-          - "old nova service host config: {{ nova_old_config_output.stdout | default('not found') }}"
-          - "old neutron service host config: {{ neutron_old_config_output.stdout | default('not found') }}"
+          - "old nova service host config: {{ nova_old_hostname.value | default('not found') }}"
+          - "old neutron service host config: {{ neutron_old_hostname.value | default('not found') }}"
 
-- name: Check if hostname -f is consistent with the hostname in nova.conf {{ nova_old_config_output.stdout }}
+- name: Check if hostname -f is consistent with the hostname in nova.conf {{ nova_old_hostname.value }}
   become: true
   tags:
     - adoption
@@ -77,4 +80,4 @@
     cmd: /usr/bin/hostname -f
   register: hypervisor_hostname
   changed_when: false
-  failed_when: hypervisor_hostname.stdout != nova_old_config_output.stdout
+  failed_when: hypervisor_hostname.stdout != nova_old_hostname.value


### PR DESCRIPTION
Existing implementation of the role is working fine. But it doesn't align with our current best practice.
This PR replace script with proper module, including error handling, parameter sanity check, documentation etc.
This module will also provide generic way to get contents of any ini file on target machine.

Approach utilizing [ansible.builitin.ini](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ini_lookup.html) lookup proved workable. However, since the look up requires file to be present in one of pre-set search paths, its use would necessitate further changes to the role.Possibly including provision for more arguments.

When compared with that, a simple custom module seemed preferable. 