### PR TITLE
Skip removal of services related to swift storage

### DIFF
--- a/roles/edpm_tripleo_cleanup/defaults/main.yml
+++ b/roles/edpm_tripleo_cleanup/defaults/main.yml
@@ -21,3 +21,19 @@ edpm_old_tripleo_services: []
 
 # Remove unit files
 edpm_remove_tripleo_unit_files: true
+
+# Keep services listed
+edpm_service_removal_skip_list:
+  - tripleo_swift_account_auditor
+  - tripleo_swift_account_reaper
+  - tripleo_swift_account_replicator
+  - tripleo_swift_account_server
+  - tripleo_swift_container_auditor
+  - tripleo_swift_container_replicator
+  - tripleo_swift_container_server
+  - tripleo_swift_container_updater
+  - tripleo_swift_object_auditor
+  - tripleo_swift_object_expirer
+  - tripleo_swift_object_replicator
+  - tripleo_swift_object_server
+  - tripleo_swift_object_updater

--- a/roles/edpm_tripleo_cleanup/meta/argument_specs.yml
+++ b/roles/edpm_tripleo_cleanup/meta/argument_specs.yml
@@ -33,3 +33,22 @@ argument_specs:
           This operation is irreversible. Furthermore, issues may occur,
           if the unit files are managed by package manager.
         default: true
+      edpm_service_removal_skip_list:
+        type: "list"
+        description: |
+          List of services to be kept during cleanup.
+          By default these are services related to Swift storag.
+        default:
+          - tripleo_swift_account_auditor
+          - tripleo_swift_account_reaper
+          - tripleo_swift_account_replicator
+          - tripleo_swift_account_server
+          - tripleo_swift_container_auditor
+          - tripleo_swift_container_replicator
+          - tripleo_swift_container_server
+          - tripleo_swift_container_updater
+          - tripleo_swift_object_auditor
+          - tripleo_swift_object_expirer
+          - tripleo_swift_object_replicator
+          - tripleo_swift_object_server
+          - tripleo_swift_object_updater

--- a/roles/edpm_tripleo_cleanup/tasks/main.yml
+++ b/roles/edpm_tripleo_cleanup/tasks/main.yml
@@ -37,6 +37,9 @@
     - name: Filter for tripleo services
       ansible.builtin.set_fact:
         tripleo_services: "{{ ansible_facts.services.keys() | select('contains', 'tripleo') }}"
+    - name: Filter services in skip list
+      ansible.builtin.set_fact:
+        tripleo_services: "{{ tripleo_services | reject('in', edpm_service_removal_skip_list ) }}"
 
 - name: Stop and disable tripleo services
   tags:


### PR DESCRIPTION
Swift storage services are removed by a separate procedure later during adoption process.
Therefore it is undesirable to remove them together with other services originally deployed by tripleO.

https://issues.redhat.com/browse/OSPRH-7432 