### PR TITLE
Use rhoso-release as release rpm name

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -48,7 +48,7 @@ edpm_bootstrap_packages_bootstrap:
   - grubby
 
 edpm_bootstrap_release_version_package:
-  - rhosp-release
+  - rhoso-release
 
 # List of packages that are required for legacy networking to function.
 # NOTE: We are using 'network' service provided by 'network-scripts' (initscripts)

--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -37,7 +37,7 @@ argument_specs:
       edpm_bootstrap_release_version_package:
         type: list
         default:
-          - rhosp-release
+          - rhoso-release
 
       edpm_bootstrap_legacy_network_packages:
         type: list


### PR DESCRIPTION
This has changed from rhosp-release to rhoso-release for OSP18.

Signed-off-by: James Slagle <jslagle@redhat.com>
