### PR TITLE
Fix file ownership for neutron dhcp and metadata agent

### DIFF
--- a/roles/edpm_neutron_dhcp/tasks/install.yml
+++ b/roles/edpm_neutron_dhcp/tasks/install.yml
@@ -19,8 +19,8 @@
     path: "{{ item.path }}"
     setype: "container_file_t"
     state: directory
-    owner: "{{ item.owner | default(lookup('pipe', 'whoami')) }}"
-    group: "{{ item.group | default(lookup('pipe', 'whoami')) }}"
+    owner: "{{ item.owner | default(ansible_user) | default(ansible_user_id) }}"
+    group: "{{ item.group | default(ansible_user) | default(ansible_user_id) }}"
     mode: "{{ item.mode | default(omit) }}"
   loop:
     - {'path': "/var/lib/openstack/config/containers", "mode": "0750"}

--- a/roles/edpm_neutron_metadata/tasks/install.yml
+++ b/roles/edpm_neutron_metadata/tasks/install.yml
@@ -19,8 +19,8 @@
     path: "{{ item.path }}"
     state: directory
     setype: "container_file_t"
-    owner: "{{ item.owner | default(lookup('pipe', 'whoami')) }}"
-    group: "{{ item.group | default(lookup('pipe', 'whoami')) }}"
+    owner: "{{ item.owner | default(ansible_user) | default(ansible_user_id) }}"
+    group: "{{ item.group | default(ansible_user) | default(ansible_user_id) }}"
     mode: "{{ item.mode | default(omit) }}"
   loop:
     - {'path': "{{ edpm_neutron_metadata_agent_config_dir }}"}


### PR DESCRIPTION
Installation tasks in the edpm_neutron_dhcp and edpm_neutron_metadata were using `default(lookup('pipe', 'whoami'))` which [by design runs on the ansible controller](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pipe_lookup.html#notes) and not the target host as this tasks intends. 
Replacing with `default(ansible_user_id)` which is the user that Ansible logs in.

JIRA: [OSPRH-7321](https://issues.redhat.com/browse/OSPRH-7321)