### PR TITLE
FIPS task should not change reboot policy

### DIFF
--- a/roles/edpm_bootstrap/tasks/fips.yml
+++ b/roles/edpm_bootstrap/tasks/fips.yml
@@ -60,8 +60,6 @@
             state: touch
             mode: "0600"
         - name: Call edpm_reboot role
-          vars:
-            edpm_reboot_strategy: force
           ansible.builtin.include_role:
             name: edpm_reboot
 


### PR DESCRIPTION
As reported in https://issues.redhat.com/browse/OSPRH-7301 , the fips task incorrectly changes the reboot policy when the required fips status changes.  We should follow whatever is defined by the deployer instead.

If nothing is defined, the policy is auto - which will result in a reboot.

In the case of a redeployed or adopted environment, we will end up simply logging that a reboot is supposed to happen.  But we will then likely fail the subsquent fips status check - which is the desired behavior.

Resolves: https://issues.redhat.com/browse/OSPRH-7301