### PR TITLE
Revert "Use rhoso-release as release rpm name"

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -48,7 +48,7 @@ edpm_bootstrap_packages_bootstrap:
   - grubby
 
 edpm_bootstrap_release_version_package:
-  - rhoso-release
+  - rhosp-release
 
 # List of packages that are required for legacy networking to function.
 # NOTE: We are using 'network' service provided by 'network-scripts' (initscripts)

--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -37,7 +37,7 @@ argument_specs:
       edpm_bootstrap_release_version_package:
         type: list
         default:
-          - rhoso-release
+          - rhosp-release
 
       edpm_bootstrap_legacy_network_packages:
         type: list


### PR DESCRIPTION
This reverts commit 95e18cb90d46fe1c2b887132a310972590b91a75.

The change broke adoption jobs that fail to find the package during bootstrap.