### PR TITLE
Add molecule check for string port-range

### DIFF
--- a/roles/edpm_nftables/molecule/action/prepare.yml
+++ b/roles/edpm_nftables/molecule/action/prepare.yml
@@ -57,3 +57,8 @@
               proto: tcp
               dport: 1211
               action: drop
+          - rule_name: '020 string port-range check'
+            rule:
+              proto: tcp
+              dport: 5555-5558
+              action: accept

--- a/roles/edpm_nftables/molecule/destination/prepare.yml
+++ b/roles/edpm_nftables/molecule/destination/prepare.yml
@@ -57,3 +57,9 @@
               proto: tcp
               destination: "fd00:fd00:fd00:2000::/64"
               dport: 1211
+          - rule_name: '020 string port-range check'
+            rule:
+              proto: tcp
+              destination: 1.1.1.1/32
+              dport: 5555-5558
+              action: accept

--- a/roles/edpm_nftables/molecule/source/prepare.yml
+++ b/roles/edpm_nftables/molecule/source/prepare.yml
@@ -55,3 +55,9 @@
               proto: tcp
               source: "fd00:fd00:fd00:2000::/64"
               dport: 1211
+          - rule_name: '020 string port-range check'
+            rule:
+              proto: tcp
+              source: 1.1.1.1/32
+              dport: 5555-5558
+              action: accept


### PR DESCRIPTION
This change adds a string port range component to the molecule tests to ensure we're able to parse a string without trying to iterate over it.

Resolves: https://issues.redhat.com/browse/OSPRH-7637