### PR TITLE
add supprot for limited extra bind mount suppport in edpm_nova

### DIFF
--- a/molecule/test-helpers/verify_mounts.yaml
+++ b/molecule/test-helpers/verify_mounts.yaml
@@ -1,0 +1,14 @@
+- name: verify dir exists
+  become: true
+  block:
+      - name: "Collect container mounts for: {{ item }}"
+        ansible.builtin.shell: |
+          podman inspect {{ item.name }} | jq '.[0].HostConfig.Binds[]'
+        changed_when: false
+        register:
+          container_mounts
+      - name: Assert mount exists {{ item }}
+        ansible.builtin.assert:
+          that:
+            - "'{{ item.src }}:{{ item.dest }}:{{item.options | default('ro')}}' in container_mounts.stdout"
+          fail_msg: "Bind mount not found in {{ item.name }}"

--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -56,3 +56,6 @@ edpm_nova_old_tripleo_compute_sevices:
   - tripleo_nova_metadata.service
   - tripleo_nova_scheduler.service
   - tripleo_nova_vnc_proxy.service
+
+# a list of addtional host mounts
+edpm_nova_extra_bind_mounts: []

--- a/roles/edpm_nova/meta/argument_specs.yml
+++ b/roles/edpm_nova/meta/argument_specs.yml
@@ -54,3 +54,26 @@ argument_specs:
           - tripleo_nova_vnc_proxy.service
         description: |
           List of tripleo nova services to stop during EDPM adoption
+      edpm_nova_extra_bind_mounts:
+        type: list
+        default: []
+        description: |
+          A list of additional host mounts to be added to the nova compute container
+          This enabled vendor integration to pass addtional data files to the nova compute
+          container. The list should be in the form of a list of dictionaries with the
+          following keys:
+          - src: The path to the file or directory on the host
+          - dest: The path to the file or directory in the container
+          - options: The options to set for the bind mount in podman format (optional)
+          src should not be a subdirectory of the following paths:
+          - /var/lib/openstack
+          - /var/lib/nova
+          dest must not be a subdirectory of the following paths:
+          - /var/lib/openstack
+          - /var/lib/nova
+          - /etc/nova
+          and must be a subdirectory of:
+          - /var/lib
+          - /etc
+          - /opt
+          options defaults to "ro" if not specified

--- a/roles/edpm_nova/molecule/default/converge.yml
+++ b/roles/edpm_nova/molecule/default/converge.yml
@@ -18,3 +18,9 @@
         edpm_nova_tls_ca_src_dir: /tmp/pki
         edpm_nova_live_migration_tls: true
         edpm_nova_live_migration_native_tls: true
+        edpm_nova_extra_bind_mounts:
+          - src: /var/lib/vendor_integration
+            dest: /var/lib/vendor_integration
+          - src: /opt/vendor_integration_2
+            dest: /opt/vendor_integration_2
+            options: "shared"

--- a/roles/edpm_nova/molecule/default/prepare.yml
+++ b/roles/edpm_nova/molecule/default/prepare.yml
@@ -173,3 +173,13 @@
         path: '/var/lib/openstack/config/nova/test.conf'
         state: touch
         mode: 0644
+
+    - name: Create vendor integration directories
+      become: true
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: "directory"
+        mode: "0755"
+      loop:
+        - {"path": "/var/lib/vendor_integration"}
+        - {"path": "/opt/vendor_integration_2"}

--- a/roles/edpm_nova/molecule/default/verify.yml
+++ b/roles/edpm_nova/molecule/default/verify.yml
@@ -29,6 +29,15 @@
         # NOTE(sean-k-mooney): this directory is normaly created by the edpm_install_cert role
         # in molecule we create it in prepare so lets just assert it exists
         - "{{ edpm_nova_tls_ca_src_dir }}"
+
+    - name: ensure extra mounts are present
+      ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_mounts.yaml"
+      loop:
+        - { "name": "nova_compute", "src": "/var/lib/vendor_integration",
+            "dest": "/var/lib/vendor_integration" }
+        - { "name": "nova_compute", "src": "/opt/vendor_integration_2",
+            "dest": "/opt/vendor_integration_2", "options": "shared" }
+
     - name: ensure systemd services are defined and functional
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_systemd_unit.yaml"
       loop:

--- a/roles/edpm_nova/molecule/vagrant/molecule.yml
+++ b/roles/edpm_nova/molecule/vagrant/molecule.yml
@@ -30,6 +30,7 @@ provisioner:
         hosts:
           compute-1:
             ctlplane_ip: 10.0.0.3
+            canonical_hostname: edpm-0.localdomain
 verifier:
   name: ansible
 scenario:

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -1,4 +1,57 @@
 ---
+- name: Validate extra bind mounts if specified
+  when: edpm_nova_extra_bind_mounts | length > 0
+  tags:
+    - configure
+    - nova
+  block:
+    - name: Get source directory details
+      become: true
+      ansible.builtin.stat:
+        path: "{{ item.src }}"
+      register: source_dir_results
+      loop: "{{ edpm_nova_extra_bind_mounts }}"
+      tags:
+        - configure
+        - nova
+
+    - name: Assert edpm_nova_extra_bind_mounts source directories exist
+      become: true
+      ansible.builtin.assert:
+        that:
+          - "source_dir_results.results | map(attribute='stat.exists') | list"
+      tags:
+        - configure
+        - nova
+
+    - name: Assert edpm_nova_extra_bind_mounts src paths are valid
+      ansible.builtin.assert:
+        that:
+          - "'{{ item }}' not in  {{ edpm_nova_extra_bind_mounts }} | map(attribute='src') | list"
+      loop:
+        - /var/lib/nova
+        - /var/lib/openstack
+      tags:
+        - configure
+        - nova
+
+    - name: Assert edpm_nova_extra_bind_mounts dest paths do not collide with standard mounts
+      ansible.builtin.assert:
+        that:
+          - "'{{ item }}' not in {{ edpm_nova_extra_bind_mounts }} | map(attribute='dest') | list "
+      loop:
+        - /var/lib/nova
+        - /var/lib/openstack
+        - /etc/nova
+      tags:
+        - configure
+        - nova
+
+    - name: Assert edpm_nova_extra_bind_mounts dest paths are subdirectory of valid paths
+      ansible.builtin.assert:
+        that:
+          - "'{{ item.dest | regex_search('^(/etc|/opt|/var/lib)') }}' is not none"
+      loop: "{{ edpm_nova_extra_bind_mounts }}"
 
 - name: Create sync config dirs
   tags:

--- a/roles/edpm_nova/templates/nova_compute.json.j2
+++ b/roles/edpm_nova/templates/nova_compute.json.j2
@@ -29,5 +29,8 @@
         "/etc/nvme:/etc/nvme",
         "/var/lib/openstack/config/ceph:/var/lib/kolla/config_files/ceph:ro",
         "/etc/ssh/ssh_known_hosts:/etc/ssh/ssh_known_hosts:ro"
+{%- for bind_mount in edpm_nova_extra_bind_mounts %}
+        ,"{{ bind_mount.src }}:{{ bind_mount.dest }}:{{ bind_mount.options | default('ro') }}"
+{% endfor -%}
     ]
 }


### PR DESCRIPTION
This change add support for optionally addding a restrict
set of addtional host bind mounts to the nova_compute container

This functionality is intended only for certifed vendor
integrations not as a generic feature.

Closes: [OSPRH-7644](https://issues.redhat.com//browse/OSPRH-7644)
