### PR TITLE
Increase default space for logs

### DIFF
--- a/roles/edpm_growvols/defaults/main.yml
+++ b/roles/edpm_growvols/defaults/main.yml
@@ -18,7 +18,7 @@
 growvols_args: >
   /=8GB
   /tmp=1GB
-  /var/log=10GB
+  /var/log=25GB
   /var/log/audit=2GB
   /home=1GB
   /var=100%


### PR DESCRIPTION
We're getting increasing field feedback for OSP17.1 that the default amount of space for logs is insufficent. As such, posting this change to align and hopefully head off issues. This is likely less of an issue as the reports have largely been centered around controllers, but overall it is best to keep some level of alignment.

https://bugzilla.redhat.com/show_bug.cgi?id=2280656 https://issues.redhat.com/browse/OSP-32120