### PR TITLE
Add edpm_extra_mounts role to configure default and extra mounts

### DIFF
--- a/playbooks/configure_os.yml
+++ b/playbooks/configure_os.yml
@@ -51,3 +51,9 @@
         tasks_from: configure.yml
       tags:
         - edpm_firewall
+    - name: Configure default and extra mounts (for hugepages and nfs)
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_extra_mounts
+        tasks_from: extra_mounts.yml
+      tags:
+        - edpm_extra_mounts

--- a/roles/edpm_extra_mounts/defaults/main.yml
+++ b/roles/edpm_extra_mounts/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of "edpm_extra_mounts"
+edpm_extra_mounts_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
+edpm_extra_mounts_hide_sensitive_logs: true
+
+edpm_extra_mounts: []
+edpm_default_mounts: [
+  {name: 'hugepages1G', path: '/dev/hugepages1G', opts: 'pagesize=1G', fstype: 'hugetlbfs'},
+  {name: 'hugepages2M', path: /dev/hugepages2M, opts: 'pagesize=2M', fstype: 'hugetlbfs'}]

--- a/roles/edpm_extra_mounts/handlers/main.yml
+++ b/roles/edpm_extra_mounts/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/roles/edpm_extra_mounts/meta/argument_specs.yml
+++ b/roles/edpm_extra_mounts/meta/argument_specs.yml
@@ -1,0 +1,34 @@
+---
+argument_specs:
+  # ./roles/edpm_extra_mounts/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_extra_mounts role.
+    options:
+      edpm_extra_mounts:
+        type: list
+        default: []
+        description: |
+          A list of additional mounts (e.g. for nfs) to be added to the edpm compute node.
+          The list should be in the form of a list of dictionaries with the
+          following keys:
+          - name: The name of the mount by default /var/lib/nova/instances
+          - path: The path to the mount
+          - opts: The options to set for the mount
+          - fstype: The filesystem type by default nfs4
+      edpm_default_mounts:
+        type: list
+        default: [
+          {name: 'hugepages1G', path: '/dev/hugepages1g', opts: 'pagesize=1G', fstype: 'hugetlbfs'},
+          {name: 'hugepages2M', path: /dev/hugepages2M, opts: 'pagesize=2M', fstype: 'hugetlbfs'}]
+        description: |
+          A list of mounts by default it is used to create hugepage mounts to be added to the edpm compute node.
+          The list should be in the form of a list of dictionaries with the
+          following keys:
+          - name: The name of the hugepage mount
+          - path: The path to the hugepage mount, this will be crated
+          - opts: The options to set for the hugepage mount
+          - fstype: The filesystem type by default hugetlbfs
+          Optional keys:
+          - owner: The owner of the mount
+          - group: The group of the mount
+          - mode: The mode of the mount

--- a/roles/edpm_extra_mounts/meta/main.yml
+++ b/roles/edpm_extra_mounts/meta/main.yml
@@ -1,0 +1,42 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_extra_mounts
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: osp
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_extra_mounts/molecule/default/collections.yml
+++ b/roles/edpm_extra_mounts/molecule/default/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+- name: community.general

--- a/roles/edpm_extra_mounts/molecule/default/converge.yml
+++ b/roles/edpm_extra_mounts/molecule/default/converge.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include edpm_extra_mounts"
+      ansible.builtin.include_role:
+        name: "osp.edpm.edpm_extra_mounts"
+        tasks_from: "extra_mounts.yml"
+      vars:
+        edpm_extra_mounts: []
+        edpm_default_mounts:
+          - name: 'hugepages1G'
+            path: '/dev/hugepages1G'
+            opts: 'pagesize=1G'
+            fstype: 'hugetlbfs'
+          - name: 'hugepages2MB'
+            path: '/dev/hugepages2MB'
+            opts: 'pagesize=2M'
+            fstype: 'hugetlbfs'

--- a/roles/edpm_extra_mounts/molecule/default/molecule.yml
+++ b/roles/edpm_extra_mounts/molecule/default/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_extra_mounts/molecule/default/prepare.yml
+++ b/roles/edpm_extra_mounts/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+    - role: env_data

--- a/roles/edpm_extra_mounts/molecule/default/verify.yml
+++ b/roles/edpm_extra_mounts/molecule/default/verify.yml
@@ -1,0 +1,15 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: compute-1
+  gather_facts: false
+  vars:
+    test_helper_dir: "../../../../molecule/test-helpers"
+  tasks:
+    - name: ensure expected directories exist
+      ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_dir.yaml"
+      loop:
+        # common directories
+        - "/dev/hugepages1G"
+        - "/dev/hugepages2MB"

--- a/roles/edpm_extra_mounts/molecule/molecule_config.yaml
+++ b/roles/edpm_extra_mounts/molecule/molecule_config.yaml
@@ -1,0 +1,31 @@
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+platforms:
+  - name: compute-1
+    groups:
+      - compute
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          compute-1:
+            ctlplane_ip: 10.0.0.3
+            canonical_hostname: edpm-0.localdomain
+
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+     - destroy
+     - create
+     - prepare
+     - converge
+     - verify

--- a/roles/edpm_extra_mounts/molecule/vagrant/README.md
+++ b/roles/edpm_extra_mounts/molecule/vagrant/README.md
@@ -1,0 +1,27 @@
+*********************************
+Vagrant driver installation guide
+*********************************
+
+Requirements
+============
+
+* Vagrant
+* Libvirt
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule-plugins[vagrant]\>=23.5.0'
+
+23.5.0+ is required to avoid a bug in the vagrant driver where molecule utils were not being imported correctly.
+This molecule env will be used for local development only and the default delegated env will be used for ci. As
+As a result, it's important that this scenario merely contains the info required to prepare the VM and calls the prepare, converge, and verify playbooks from default to keep them in sync.

--- a/roles/edpm_extra_mounts/molecule/vagrant/collections.yml
+++ b/roles/edpm_extra_mounts/molecule/vagrant/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_extra_mounts/molecule/vagrant/molecule.yml
+++ b/roles/edpm_extra_mounts/molecule/vagrant/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+    type: libvirt
+    options:
+      memory: 8192
+      cpus: 8
+  provision: no
+  parallel: true
+  # default_box: 'generic/rocky9'
+  default_box: 'generic/centos9s'
+platforms:
+- name: compute
+  provider_options:
+    cpu_mode: 'host-passthrough'
+    nested: true
+    machine_type: 'q35'
+  groups:
+    - compute-1
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../default/converge.yml
+    prepare: ../default/prepare.yml
+  inventory:
+    hosts:
+      all:
+        hosts:
+          compute:
+            ctlplane_ip: 10.0.0.3
+            canonical_hostname: edpm-0.localdomain
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+     - destroy
+     - create
+     - prepare
+     - converge
+     - verify

--- a/roles/edpm_extra_mounts/molecule/vagrant/verify.yml
+++ b/roles/edpm_extra_mounts/molecule/vagrant/verify.yml
@@ -1,0 +1,4 @@
+---
+
+- name: run default scenario verify playbooks
+  ansible.builtin.import_playbook: ../default/verify.yml

--- a/roles/edpm_extra_mounts/tasks/extra_mounts.yml
+++ b/roles/edpm_extra_mounts/tasks/extra_mounts.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create host directories for edpm_default_mounts
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    mode: "{{ item.mode | default('0775') }}"
+  loop: "{{ edpm_default_mounts }}"
+  tags:
+    - extra_mounts
+
+- name: Mount extra and default directories
+  become: true
+  ansible.posix.mount:
+    name: "{{ item.name }}"
+    src: "{{ item.path }}"
+    fstype: "{{ item.fstype }}"
+    opts: "{{ item.opts }}"
+    state: mounted
+  loop: "{{ edpm_default_mounts | zip(edpm_extra_mounts) | list }}"
+  tags:
+    - extra_mounts

--- a/roles/edpm_extra_mounts/tasks/main.yml
+++ b/roles/edpm_extra_mounts/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/roles/edpm_extra_mounts/vars/main.yml
+++ b/roles/edpm_extra_mounts/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "edpm_extra_mounts"


### PR DESCRIPTION
Default mounts are added early on bootstrap stage, by default create 1GB and 2MB huge pages
Extra mounts are empty by default and
are required to allow mounting /var/lib/nova/instance in nfs. This part is called on configure-os stage when network elements are created

Closes: https://issues.redhat.com/browse/OSPRH-7088