### PR TITLE
Reworking file and directory ownership

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -43,6 +43,7 @@ jobs:
         - edpm_timezone
         - edpm_tuned
         - edpm_telemetry
+        - edpm_telemetry_logging
         - edpm_update
         - edpm_users
         - env_data

--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -7,11 +7,9 @@
       ansible.builtin.wait_for_connection:
         delay: "{{ edpm_wait_for_connection_delay | default(10) }}"
         timeout: "{{ edpm_wait_for_connection_timeout | default(600) }}"
-
 - name: Bootstrap node
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/ceph_client.yml
+++ b/playbooks/ceph_client.yml
@@ -3,7 +3,6 @@
 - name: Configure EDPM as client of Ceph
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/configure_network.yml
+++ b/playbooks/configure_network.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM Network
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/configure_os.yml
+++ b/playbooks/configure_os.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM Operating System Configure
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/configure_ovs_dpdk.yml
+++ b/playbooks/configure_ovs_dpdk.yml
@@ -3,7 +3,6 @@
 - name: Configure OvS DPDK
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   tasks:
     - name: Configure OvS DPDK configs
       ansible.builtin.import_role:

--- a/playbooks/frr.yml
+++ b/playbooks/frr.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM FRR
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/install_os.yml
+++ b/playbooks/install_os.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM Operating System Install
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
@@ -25,6 +24,8 @@
     - name: Install and configure time service using timesync system role
       ansible.builtin.include_role:
         name: "{{ lookup('ansible.builtin.env', 'EDPM_SYSTEMROLES', default='fedora.linux_system_roles') + '.timesync' }}"
+        apply:
+          become: true
       tags:
         - dataplane_chrony
     - name: Install edpm_logrotate_crond

--- a/playbooks/neutron_dhcp.yml
+++ b/playbooks/neutron_dhcp.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM Neutron DHCP agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/neutron_metadata.yml
+++ b/playbooks/neutron_metadata.yml
@@ -2,7 +2,6 @@
 - name: Deploy EDPM Neutron OVN Metadata agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/neutron_ovn.yaml
+++ b/playbooks/neutron_ovn.yaml
@@ -2,7 +2,6 @@
 - name: Deploy EDPM Neutron OVN agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/neutron_sriov.yml
+++ b/playbooks/neutron_sriov.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM Neutron SR-IOV agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/nova.yml
+++ b/playbooks/nova.yml
@@ -2,7 +2,6 @@
 
 - name: Deploy EDPM Nova storage infrastructure
   ansible.builtin.import_playbook: nova_storage.yml
-
 - name: Deploy EDPM Nova
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/nova_storage.yml
+++ b/playbooks/nova_storage.yml
@@ -2,7 +2,6 @@
 
 - name: Deploy Nova storage infrastructure
   hosts: all
-  become: true
   strategy: linear
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
@@ -12,13 +11,11 @@
         name: osp.edpm.edpm_iscsid
       tags:
         - edpm_iscsid
-
     - name: Deploy multipath daemon
       ansible.builtin.import_role:
         name: osp.edpm.edpm_multipathd
       tags:
         - edpm_multipathd
-
     - name: Support NVMe-oF protocols
       ansible.builtin.import_role:
         name: osp.edpm.edpm_nvmeof

--- a/playbooks/ovn.yml
+++ b/playbooks/ovn.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM OVN
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/ovn_bgp_agent.yml
+++ b/playbooks/ovn_bgp_agent.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM OVN BGP Agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/pre_adoption_validation.yml
+++ b/playbooks/pre_adoption_validation.yml
@@ -3,7 +3,6 @@
 - name: Validate adoption configuration
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/reboot.yml
+++ b/playbooks/reboot.yml
@@ -3,7 +3,6 @@
 - name: Reboot nodes if reboot is required
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   tasks:
     - name: Run edpm_reboot
       ansible.builtin.import_role:

--- a/playbooks/run_os.yml
+++ b/playbooks/run_os.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM Operating System Run
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/select_kernel_ddp_package.yml
+++ b/playbooks/select_kernel_ddp_package.yml
@@ -3,7 +3,6 @@
 - name: Select Kernel DDP Package
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/sriov_derive_device_spec.yml
+++ b/playbooks/sriov_derive_device_spec.yml
@@ -3,7 +3,6 @@
 - name: Derive sriov device_spec
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/ssh_known_hosts.yml
+++ b/playbooks/ssh_known_hosts.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM SSH Known Hosts
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/playbooks/swift.yml
+++ b/playbooks/swift.yml
@@ -3,7 +3,6 @@
 - name: Deploy EDPM Swift
   hosts: all
   strategy: linear
-  become: true
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:

--- a/roles/edpm_container_manage/tasks/main.yml
+++ b/roles/edpm_container_manage/tasks/main.yml
@@ -24,6 +24,7 @@
   become: true
 
 - name: Generate containers configs data
+  become: true
   block:
     - name: "Find all matching configs configs for in {{ edpm_container_manage_config }}"
       container_config_data:

--- a/roles/edpm_container_rm/tasks/edpm_podman_container_rm.yml
+++ b/roles/edpm_container_rm/tasks/edpm_podman_container_rm.yml
@@ -21,6 +21,7 @@
   register: systemd_healthcheck_exists
 
 - name: "Tear-down healthcheck: [ {{ container }} ]"
+  become: true
   when:
     - systemd_healthcheck_exists.stat.exists
   block:
@@ -46,6 +47,7 @@
   register: systemd_exists
 
 - name: "Tear-down container: [ {{ container }} ]"
+  become: true
   when:
     - systemd_exists.stat.exists
   block:
@@ -66,6 +68,7 @@
   register: systemd_requires_exists
 
 - name: "Remove systemd requires: [ {{ container }} ]"
+  become: true
   ansible.builtin.file:
     path: "/etc/systemd/system/edpm_{{ container }}.service.requires"
     state: absent
@@ -73,12 +76,14 @@
     - systemd_requires_exists.stat.exists
 
 - name: Reload systemd services if needed
+  become: true
   when:
     - systemd_healthcheck_exists.stat.exists or systemd_exists.stat.exists or systemd_requires_exists.stat.exists
   ansible.builtin.systemd:
     daemon_reload: true
 
 - name: Stop and remove container if exists
+  become: true
   containers.podman.podman_container:
     name: "{{ container }}"
     state: absent

--- a/roles/edpm_container_standalone/tasks/main.yml
+++ b/roles/edpm_container_standalone/tasks/main.yml
@@ -18,6 +18,7 @@
 # "edpm_container_standalone" will search for and load any operating system variable file
 
 - name: "Ensure directory exists: {{ edpm_container_standalone_kolla_config_dir }}"
+  become: true
   ansible.builtin.file:
     path: "{{ edpm_container_standalone_kolla_config_dir }}"
     state: directory
@@ -25,6 +26,7 @@
     setype: container_file_t
 
 - name: Create kolla config files
+  become: true
   ansible.builtin.copy:
     content: "{{ item.value | to_nice_json }}"
     dest: "{{ edpm_container_standalone_kolla_config_dir ~ '/' ~ item.key ~ '.json' }}"
@@ -32,12 +34,14 @@
   loop: "{{ edpm_container_standalone_kolla_config_files | dict2items }}"
 
 - name: "Create config file {{ edpm_container_standalone_container_startup_config_dir + '/' + edpm_container_standalone_service }}"
+  become: true
   ansible.builtin.file:
     path: "{{ edpm_container_standalone_container_startup_config_dir }}/{{ edpm_container_standalone_service }}"
     state: directory
     mode: "0755"
 
 - name: "Render container definitions: [{{ edpm_container_standalone_service }} ]"
+  become: true
   ansible.builtin.copy:
     content: "{{ item.value | to_nice_json }}"
     dest: "{{ edpm_container_standalone_container_startup_config_dir }}/{{ edpm_container_standalone_service }}/{{ item.key }}.json"

--- a/roles/edpm_frr/tasks/configure.yml
+++ b/roles/edpm_frr/tasks/configure.yml
@@ -39,7 +39,6 @@
           Please check value of Ansible variable edpm_frr_bgp_uplinks.
 
 - name: Configure FRR
-  become: true
   ansible.builtin.template:
     src: frr.conf.j2
     dest: "{{ edpm_frr_config_basedir }}/etc/frr/frr.conf"
@@ -49,7 +48,6 @@
   register: _frr_config_result
 
 - name: Configure FRR daemons
-  become: true
   ansible.builtin.template:
     src: daemons.j2
     dest: "{{ edpm_frr_config_basedir }}/etc/frr/daemons"

--- a/roles/edpm_frr/tasks/install.yml
+++ b/roles/edpm_frr/tasks/install.yml
@@ -21,6 +21,8 @@
     state: directory
     setype: "{{ item.setype }}"
     mode: "{{ item.mode }}"
+    owner: "{{ ansible_user | default(ansible_user_id) }}"
+    group: "{{ ansible_user | default(ansible_user_id) }}"
   loop:
     - {'path': /var/log/containers/frr, 'setype': container_file_t, 'mode': '0750'}
     - {'path': "{{ edpm_frr_config_basedir }}", 'setype': container_file_t, 'mode': '0750'}
@@ -44,7 +46,6 @@
       - "selinux"
 
 - name: Create directory {{ edpm_frr_config_basedir }}
-  become: true
   ansible.builtin.file:
     path: "{{ edpm_frr_config_basedir }}/etc/frr"
     recurse: true

--- a/roles/edpm_install_certs/tasks/adoption.yml
+++ b/roles/edpm_install_certs/tasks/adoption.yml
@@ -22,6 +22,7 @@
   register: requests
 
 - name: Backup certificate requests
+  become: true
   tags:
     - adoption
   ansible.builtin.copy:
@@ -32,6 +33,7 @@
   when: requests.matched != 0
 
 - name: Remove certificate requests
+  become: true
   tags:
     - adoption
   ansible.builtin.file:

--- a/roles/edpm_iscsid/tasks/run.yml
+++ b/roles/edpm_iscsid/tasks/run.yml
@@ -43,6 +43,7 @@
 # the manage_iscsid_stat changed.
 
 - name: Restart iscsid container to refresh /etcd/iscsid.conf
+  become: true
   when:
     - not manage_iscsid_stat.changed|bool
     - iscsi_restart_stat.stat.exists|bool
@@ -51,6 +52,7 @@
     state: restarted
 
 - name: Remove iscsid container restart sentinel file
+  become: true
   ansible.builtin.file:
     path: /etc/iscsi/.iscsid_restart_required
     state: absent

--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -51,6 +51,7 @@
   ansible.builtin.include_tasks: hugepages.yml
 
 - name: Check if the kernelargs entry is already present in the file
+  become: true
   ansible.builtin.replace:
     regexp: EDPM_KERNEL_ARGS
     dest: /etc/default/grub

--- a/roles/edpm_kernel/tasks/reboot.yaml
+++ b/roles/edpm_kernel/tasks/reboot.yaml
@@ -69,12 +69,14 @@
     msg: "Creating edpm_kernel file under reboot_required for applying kernel args settings"
 
 - name: Create a reboot_required directory if it does not exist
+  become: true
   ansible.builtin.file:
     path: /var/lib/openstack/reboot_required
     state: directory
     mode: '0755'
 
 - name: Create file for reboot required
+  become: true
   ansible.builtin.file:
     path: /var/lib/openstack/reboot_required/edpm_kernel
     state: touch

--- a/roles/edpm_kernel/tasks/upgrade_tasks.yml
+++ b/roles/edpm_kernel/tasks/upgrade_tasks.yml
@@ -15,11 +15,13 @@
 # under the License.
 
 - name: Fix grub entries to have name start with GRUB_
+  become: true
   ansible.builtin.replace:
     path: '/etc/default/grub'
     regexp: '^(EDPM_KERNEL_ARGS)(.*)'
     replace: 'GRUB_\1\2'
 - name: Fix grub entries in append statement
+  become: true
   ansible.builtin.replace:
     path: '/etc/default/grub'
     regexp: '(.*){(EDPM_KERNEL_ARGS)}(.*)'

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -152,7 +152,7 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     remote_src: true
-    mode: "0600"
+    mode: "0644"
     owner: "root"
     group: "root"
   when: edpm_libvirt_tls_certs_enabled

--- a/roles/edpm_libvirt/tasks/post-install.yml
+++ b/roles/edpm_libvirt/tasks/post-install.yml
@@ -32,12 +32,12 @@
     - install
     - post-libvirt
     - ceph
-  become: true
   when:
     - found_confs.files is defined
     - found_confs.files | length > 0
   block:
     - name: Extract FSIDs from Ceph configuration files
+      become: true
       ansible.builtin.shell: |
         set -o pipefail;
         echo {{ (item | basename).split('.')[0] }}

--- a/roles/edpm_libvirt/tasks/virsh-secret.yml
+++ b/roles/edpm_libvirt/tasks/virsh-secret.yml
@@ -19,6 +19,7 @@
     state: absent
 
 - name: Register cephx_key
+  become: true
   ansible.builtin.command: "awk '$1 == \"key\" {print $3}' {{ key_path }}"
   no_log: true
   register: cephx_key

--- a/roles/edpm_neutron_metadata/tasks/install.yml
+++ b/roles/edpm_neutron_metadata/tasks/install.yml
@@ -15,6 +15,7 @@
 # under the License.
 
 - name: Create persistent directories
+  become: true
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
@@ -31,6 +32,7 @@
     - {'path': "{{ edpm_neutron_metadata_agent_lib_dir }}/external/pids", "mode": "0755"}
 
 - name: Enable virt_sandbox_use_netlink for healthcheck
+  become: true
   ansible.posix.seboolean:
     name: virt_sandbox_use_netlink
     persistent: true

--- a/roles/edpm_neutron_ovn/tasks/install.yml
+++ b/roles/edpm_neutron_ovn/tasks/install.yml
@@ -15,11 +15,14 @@
 # under the License.
 
 - name: Create persistent directories
+  become: true
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
     setype: "container_file_t"
     mode: "{{ item.mode | default(omit) }}"
+    owner: "{{ ansible_user | default(ansible_user_id) }}"
+    group: "{{ ansible_user | default(ansible_user_id) }}"
   loop:
     - {'path': "{{ edpm_neutron_ovn_agent_config_dir }}"}
     - {'path': "/var/log/containers/neutron"}

--- a/roles/edpm_nova/tasks/configure.yml
+++ b/roles/edpm_nova/tasks/configure.yml
@@ -16,7 +16,6 @@
         - nova
 
     - name: Assert edpm_nova_extra_bind_mounts source directories exist
-      become: true
       ansible.builtin.assert:
         that:
           - "source_dir_results.results | map(attribute='stat.exists') | list"

--- a/roles/edpm_ovn/tasks/bootstrap.yml
+++ b/roles/edpm_ovn/tasks/bootstrap.yml
@@ -15,11 +15,13 @@
 # under the License.
 
 - name: Ensure the Openvswitch package is installed
+  become: true
   ansible.builtin.package:
     name: openvswitch
     state: present
 
 - name: Ensure the OVS service is running
+  become: true
   ansible.builtin.systemd:
     name: openvswitch
     state: started

--- a/roles/edpm_ovn/tasks/cleanup.yml
+++ b/roles/edpm_ovn/tasks/cleanup.yml
@@ -15,6 +15,7 @@
 # under the License.
 
 - name: Cleanup hw-offload when no longer required
+  become: true
   ansible.builtin.shell: >
     ovs-vsctl remove open . other_config hw-offload
   register: cleanup_hw_offload
@@ -23,6 +24,7 @@
   when: not edpm_enable_hw_offload | bool
 
 - name: Get OVN CMS Options from the local OVSDB
+  become: true
   ansible.builtin.shell: >
     ovs-vsctl get Open_vSwitch . external_ids:ovn-cms-options | sed 's/\"//g'
   register: cleanup_ovn_cms_options
@@ -58,6 +60,7 @@
         cleanup_ovn_cms_options: "{{ cleanup_ovn_cms_options | combine(filtered_azs | default({})) }}"
 
 - name: Set updated OVN CMS Options to the local OVSDB
+  become: true
   ansible.builtin.shell: >
     ovs-vsctl set Open_vSwitch . external_ids:ovn-cms-options={{ cleanup_ovn_cms_options.stdout }}
   register: cleanup_ovn_cms_options_set
@@ -68,6 +71,7 @@
     - cleanup_ovn_cms_options.stdout != ""
 
 - name: Clear OVN CMS Options if updated string is empty
+  become: true
   ansible.builtin.shell: >
     ovs-vsctl remove Open_vSwitch . external_ids ovn-cms-options
   register: cleanup_ovn_cms_options_remove

--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -80,6 +80,7 @@
         edpm_ovn_ovs_other_config: "{{ edpm_ovn_ovs_other_config | combine(hw_offload) }}"
 
 - name: Configure OVS external_ids
+  become: true
   ansible.builtin.shell: >
     ovs-vsctl set open . {% for key, value in edpm_ovn_ovs_external_ids.items() -%} external_ids:{{ key }}={{ value }} {% endfor %}
   register: ovs_external_ids
@@ -88,6 +89,7 @@
   when: edpm_ovn_ovs_external_ids | length > 0
 
 - name: Configure OVS other_config
+  become: true
   ansible.builtin.shell: >
     ovs-vsctl set open . {% for key, value in edpm_ovn_ovs_other_config.items() %} other_config:{{ key }}={{ value }} {% endfor %}
   register: ovs_other_config
@@ -96,6 +98,7 @@
   when: edpm_ovn_ovs_other_config | length > 0
 
 - name: Add OVS Manager
+  become: true
   block:
     - name: Check if OVS Manager already exists
       ansible.builtin.shell: |

--- a/roles/edpm_ovn/tasks/firewall.yml
+++ b/roles/edpm_ovn/tasks/firewall.yml
@@ -15,6 +15,7 @@
 # under the License.
 
 - name: Inject firewall rules for OVN
+  become: true
   osp.edpm.edpm_nftables_snippet:
     dest: /var/lib/edpm-config/firewall/ovn.yaml
     content: |

--- a/roles/edpm_ovn/tasks/install.yml
+++ b/roles/edpm_ovn/tasks/install.yml
@@ -15,17 +15,21 @@
 # under the License.
 
 - name: Create persistent directories
+  become: true
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
     setype: "container_file_t"
     mode: "{{ item.mode | default(omit) }}"
+    owner: "{{ item.owner | default(ansible_user) | default(ansible_user_id) }}"
+    group: "{{ item.group | default(ansible_user) | default(ansible_user_id) }}"
   loop:
     - {'path': /var/log/containers/openvswitch, 'mode': '0750'}
     - {'path': /var/lib/edpm-config/firewall, 'mode': '0750'}
-    - {'path': /var/lib/openvswitch/ovn}
+    - {'path': /var/lib/openvswitch/ovn, "owner": "openvswitch", "group": "openvswitch"}
 
 - name: Enable virt_sandbox_use_netlink for healthcheck
+  become: true
   ansible.posix.seboolean:
     name: virt_sandbox_use_netlink
     persistent: true

--- a/roles/edpm_ovn_bgp_agent/tasks/configure_ovn.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/configure_ovn.yml
@@ -20,6 +20,7 @@
     tasks_from: "bootstrap.yml"
 
 - name: Configure OVS external_ids
+  become: true
   ansible.builtin.shell: >
     ovs-vsctl set open . {% for key, value in edpm_ovn_bgp_agent_local_ovn_ovs_external_ids.items() -%} external_ids:{{ key }}={{ value }} {% endfor %}
   register: ovn_ovs_external_ids

--- a/roles/edpm_ovn_bgp_agent/tasks/install.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/install.yml
@@ -21,6 +21,8 @@
     state: directory
     setype: "{{ item.setype }}"
     mode: "{{ item.mode }}"
+    owner: "{{ ansible_user | default(ansible_user_id) }}"
+    group: "{{ ansible_user | default(ansible_user_id) }}"
   loop:
     - {'path': /var/log/containers/ovn-bgp-agent, 'setype': container_file_t, 'mode': '0750'}
     - {'path': "{{ edpm_ovn_bgp_agent_config_basedir }}", 'setype': container_file_t, 'mode': '0750'}

--- a/roles/edpm_ovn_bgp_agent/tasks/install_ovn.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/install_ovn.yml
@@ -15,6 +15,7 @@
 # under the License.
 
 - name: Create persistent directories for in-node ovn cluster
+  become: true
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
@@ -25,6 +26,7 @@
     - {'path': /var/lib/openvswitch/ovn, 'setype': container_file_t}
 
 - name: Enable virt_sandbox_use_netlink for healthcheck
+  become: true
   ansible.posix.seboolean:
     name: virt_sandbox_use_netlink
     persistent: true
@@ -34,6 +36,7 @@
     - ansible_facts.selinux.status == "enabled"
 
 - name: Copy in cleanup script
+  become: true
   ansible.builtin.copy:
     src: ovn-bgp-agent-cleanup
     dest: '/usr/libexec/ovn-bgp-agent-cleanup'
@@ -41,6 +44,7 @@
     mode: '0755'
 
 - name: Copy in cleanup service
+  become: true
   ansible.builtin.copy:
     src: ovn-bgp-agent-cleanup.service
     dest: '/usr/lib/systemd/system/ovn-bgp-agent-cleanup.service'
@@ -48,6 +52,7 @@
     mode: '0644'
 
 - name: Enabling the cleanup service
+  become: true
   ansible.builtin.service:
     name: ovn-bgp-agent-cleanup
     enabled: true

--- a/roles/edpm_podman/tasks/configure.yml
+++ b/roles/edpm_podman/tasks/configure.yml
@@ -20,6 +20,7 @@
   ansible.builtin.import_tasks: login-kube-registry.yml
   when: edpm_podman_login_kube_registry|bool
 - name: Configure edpm_container_manage to generate systemd drop-in dependencies
+  become: true
   ansible.builtin.copy:
     dest: /etc/sysconfig/podman_drop_in
     mode: "0644"
@@ -30,6 +31,7 @@
       those constraints are enforced on reboot/shutdown.
   when: edpm_podman_systemd_drop_in_dependencies|bool
 - name: Configure edpm_container_manage to not generate drop-in dependencies
+  become: true
   ansible.builtin.file:
     path: /etc/sysconfig/podman_drop_in
     state: absent

--- a/roles/edpm_reboot/tasks/main.yaml
+++ b/roles/edpm_reboot/tasks/main.yaml
@@ -15,6 +15,7 @@
 # under the License.
 
 - name: Make sure yum-utils is installed
+  become: true
   ansible.builtin.dnf:
     name: yum-utils
 
@@ -30,6 +31,7 @@
 
 - name: Create reboot file for needs-restarting
   when: needs_restarting_output.rc == 1
+  become: true
   block:
     - name: Create a reboot_required directory if it does not exist
       ansible.builtin.file:

--- a/roles/edpm_reboot/tasks/reboot.yaml
+++ b/roles/edpm_reboot/tasks/reboot.yaml
@@ -15,11 +15,13 @@
 # under the License.
 
 - name: Reboot nodes
+  become: true
   ansible.builtin.reboot:
     post_reboot_delay: "{{ edpm_reboot_post_reboot_delay }}"
     reboot_timeout: "{{ edpm_reboot_timeout_reboot }}"
 
 - name: Remove reboot_required directory
+  become: true
   ansible.builtin.file:
     path: /var/lib/openstack/reboot_required
     state: absent

--- a/roles/edpm_sshd/tasks/configure.yml
+++ b/roles/edpm_sshd/tasks/configure.yml
@@ -16,7 +16,6 @@
 
 
 - name: Run sshd tasks as root
-  become: true
   block:
     - name: PasswordAuthentication notice
       ansible.builtin.debug:
@@ -51,6 +50,7 @@
         - ('Banner' in edpm_sshd_server_options or 'PrintMotd' in edpm_sshd_server_options)
 
     - name: Configure the banner text
+      become: true
       ansible.builtin.copy:
         content: "{{ edpm_sshd_banner_text }}"
         dest: /etc/issue
@@ -59,6 +59,7 @@
         - edpm_sshd_banner_enabled | bool
 
     - name: Configure the motd banner
+      become: true
       ansible.builtin.copy:
         content: "{{ edpm_sshd_message_of_the_day }}"
         dest: /etc/motd
@@ -79,6 +80,7 @@
          {{ edpm_sshd_server_options }}
 
     - name: Adjust ssh server configuration
+      become: true
       ansible.builtin.template:
         dest: /etc/ssh/sshd_config
         src: sshd_config_block.j2
@@ -91,6 +93,7 @@
         _sshd_config_result_changed: _sshd_config_result.changed
 
     - name: Configure firewall for the service
+      become: true
       when:
         - edpm_sshd_configure_firewall|bool
       block:

--- a/roles/edpm_telemetry/tasks/configure.yml
+++ b/roles/edpm_telemetry/tasks/configure.yml
@@ -20,9 +20,9 @@
     path: "{{ item.path }}"
     state: directory
     setype: "{{ item.setype | default('container_file_t') }}"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: "{{ item.mode | default('750') }}"
+    owner: "{{ ansible_user | default(ansible_user_id) }}"
+    group: "{{ ansible_user | default(ansible_user_id) }}"
+    mode: "{{ item.mode | default('0750') }}"
     recurse: true
   loop:
     - {"path": "{{ edpm_telemetry_config_dest }}"}
@@ -93,7 +93,6 @@
   register: tls_key_stat
 
 - name: Configure tls if present
-  become: true
   when:
     - tls_crt_stat.stat.exists and tls_key_stat.stat.exists
   block:
@@ -104,6 +103,7 @@
         src: node_exporter.yaml.j2
 
     - name: Change the owner of the crt
+      become: true
       ansible.builtin.file:
         path: "{{ edpm_telemetry_certs }}/tls.crt"
         mode: "0644"
@@ -111,6 +111,7 @@
         group: ceilometer
 
     - name: Change the owner of the key
+      become: true
       ansible.builtin.file:
         path: "{{ edpm_telemetry_certs }}/tls.key"
         mode: "0644"

--- a/roles/edpm_telemetry_logging/tasks/configure.yml
+++ b/roles/edpm_telemetry_logging/tasks/configure.yml
@@ -22,12 +22,12 @@
   register: rsyslog_service_state
 
 - name: Configure rsyslog if present
-  become: true
   when:
     - (rsyslog_service_state is success) and
       ((rsyslog_service_state.status['SubState'] | lower) == 'running')
   block:
     - name: Install openssl module support for rsyslog
+      become: true
       ansible.builtin.dnf:
         name: rsyslog-openssl
         state: present
@@ -42,7 +42,6 @@
         remote_src: "{{ telemetry_test | default('false') }}"
 
     - name: Deploy rsyslog configuration
-      become: true
       ansible.builtin.copy:
         src: "{{ edpm_telemetry_logging_config_src }}/10-telemetry.conf"
         dest: "{{ edpm_telemetry_rsyslog_config_dest }}/10-telemetry.conf"

--- a/roles/edpm_timezone/tasks/configure.yml
+++ b/roles/edpm_timezone/tasks/configure.yml
@@ -16,6 +16,7 @@
 
 
 - name: Set timezone
+  become: true
   community.general.timezone:
     name: "{{ edpm_timezone }}"
   register: _timezone_result

--- a/roles/edpm_tuned/tasks/configure.yml
+++ b/roles/edpm_tuned/tasks/configure.yml
@@ -15,9 +15,12 @@
 # under the License.
 
 - name: Ensure profile directory exists
+  become: true
   ansible.builtin.file:
     path: "/etc/tuned/{{ edpm_tuned_profile }}"
     state: directory
+    owner: "{{ ansible_user | default(ansible_user_id) }}"
+    group: "{{ ansible_user | default(ansible_user_id) }}"
     mode: '0755'
   when:
     - (edpm_tuned_custom_profile is defined) and ((edpm_tuned_custom_profile | length) > 0)


### PR DESCRIPTION
Playbook level becomes are not a good idea. We should only give the minimum set of permissions possible rather than all at once.

I'm going to test how the deployment behaves once I disable these and progressively add becomes to tasks in roles. Eventually I aim to arrive at minimum viable number of tasks with root access. 

Fixes: https://issues.redhat.com/browse/OSPRH-3763