### PR TITLE
Disable martian packts logging as default

### DIFF
--- a/roles/edpm_kernel/vars/main.yml
+++ b/roles/edpm_kernel/vars/main.yml
@@ -41,7 +41,7 @@ edpm_kernel_sysctl_settings:
   net.ipv4.conf.all.arp_notify:
     value: 1
   net.ipv4.conf.all.log_martians:
-    value: 1
+    value: 0
   net.ipv4.conf.all.rp_filter:
     value: 1
   net.ipv4.conf.all.secure_redirects:
@@ -51,7 +51,7 @@ edpm_kernel_sysctl_settings:
   net.ipv4.conf.default.accept_redirects:
     value: 0
   net.ipv4.conf.default.log_martians:
-    value: 1
+    value: 0
   net.ipv4.conf.default.secure_redirects:
     value: 0
   net.ipv4.conf.default.send_redirects:


### PR DESCRIPTION
Logging martian packets is done via printk. Depending on the default console configuration, it may cause writing on a serial line. Some UART controllers are slow, and it may stall CPUs for up to 200ms. When this logging happens, it causes random latency issues.

Disable logging of martian packets by default. It can be enabled for debugging purposes.