### PR TITLE
nftables: disable logging of dropped packets by default

### DIFF
--- a/roles/edpm_nftables/defaults/main.yml
+++ b/roles/edpm_nftables/defaults/main.yml
@@ -20,3 +20,4 @@
 # All variables within this role should have a prefix of "edpm_nftables_"
 edpm_nftables_src: /var/lib/edpm-config/firewall
 edpm_nftables_default_chains_prefix: EDPM
+edpm_nftables_debug: false

--- a/roles/edpm_nftables/tasks/configure.yml
+++ b/roles/edpm_nftables/tasks/configure.yml
@@ -26,9 +26,9 @@
         mode: "0750"
 
     - name: Push default ruleset snipet
-      ansible.builtin.copy:
+      ansible.builtin.template:
         dest: "{{ edpm_nftables_src }}/edpm-nftables-base.yaml"
-        src: 00-base-rules.yaml
+        src: base-rules.yaml.j2
         mode: "0644"
 
 - name: IPtables compatibility layout

--- a/roles/edpm_nftables/templates/base-rules.yaml.j2
+++ b/roles/edpm_nftables/templates/base-rules.yaml.j2
@@ -28,6 +28,7 @@
     state:
       - NEW
   rule_name: 004 accept ipv6 dhcpv6
+{%- if edpm_nftables_debug -%}
 - rule:
     jump: LOG
     limit: 20/min
@@ -38,3 +39,4 @@
     prefix: 'DROPPING: '
     state: []
   rule_name: 999 log all
+{%- endif -%}


### PR DESCRIPTION
Depending on the console redirection configured on boot, logging packets before dropping them may cause excessive latency issues. Sometimes this can even stall a CPU for 200ms with some UART controllers and console=ttyS0.

In most openstack deployments, the is a bridge that may receive random DHCP requests. For example, when creating a lot of SRIOV VFs, NetworkManager will try to configure them with DHCP and broadcast packets. This causes the packets to be received by all overcloud nodes and be dropped, e.g:

```
kernel: IN=ens8f0v2 OUT= MAC=ff:ff:ff:ff:ff:ff:2a:75:ff:3d:02:f0:08:00 SRC=0.0.0.0 DST=255.255.255.255 LEN=327 TOS=0x00 PREC=0xC0 TTL=64 ID=0 DF PROTO=UDP SPT=68 DPT=67 LEN=307
```

I could not find any motivation for the existence of this LOG rule. Not event in puppet tripleo where this log rule was first introduced in 2015.

I think this rule has no real purpose and should be removed. There are counters for dropped packets in nftables. And if users want to know what packets are dropped, they can see them using tcpdump.

The LOG rule can be restored using the edpm_nftables_debug role variable.

Link: https://github.com/stackforge/puppet-openstack-cloud/commit/5102e5130ae4