### PR TITLE
Disable firewalld service in `edpm_nftables` role

### DIFF
--- a/roles/edpm_nftables/tasks/service-bootstrap.yml
+++ b/roles/edpm_nftables/tasks/service-bootstrap.yml
@@ -36,6 +36,13 @@
         - ansible_facts.services[item] is defined
         - ansible_facts.services[item]["status"] != "not-found"
 
+    - name: Ensure firewalld service is disabled
+      ansible.builtin.systemd:
+        name: firewalld
+        enabled: false
+        state: stopped
+        masked: true
+
     - name: Ensure nftables service is enabled and running
       ansible.builtin.systemd:
         name: nftables


### PR DESCRIPTION
Since we are defining firewall rules with `edpm_nftables` role (using `nftables` service), it's useless and potentially harmful keep firewalld enabled and running on the host.

Fixes: https://issues.redhat.com/browse/OSPRH-7739

Signed-off-by: Roberto Alfieri <ralfieri@redhat.com>