### PR TITLE
Don't use override services to determine update

### DIFF
--- a/roles/edpm_update/defaults/main.yml
+++ b/roles/edpm_update/defaults/main.yml
@@ -27,4 +27,4 @@ edpm_update_enable_containers_update: true
 edpm_update_exclude_packages:
   - openvswitch
 
-edpm_update_running_services: "{{ edpm_services_override | default(edpm_services) }}"
+edpm_update_running_services: "{{ edpm_services }}"


### PR DESCRIPTION
This change uses the original edpm_services list to determine which services will be updated, rather than inheriting the servicesOverride. This ensures that all services applied on the nodeSet will be updated during the minor update workflow.

Jira: https://issues.redhat.com/browse/OSPRH-8107