### PR TITLE
Ensure firewalld service is disabled if present

### DIFF
--- a/roles/edpm_nftables/tasks/service-bootstrap.yml
+++ b/roles/edpm_nftables/tasks/service-bootstrap.yml
@@ -17,6 +17,14 @@
 - name: Gather service facts
   ansible.builtin.service_facts:
 
+- name: Ensure firewalld service is disabled, stopped, and masked if it exists
+  ansible.builtin.systemd:
+    name: firewalld
+    enabled: false
+    state: stopped
+    masked: true
+  when: ansible_facts.services["firewalld.service"] is defined
+
 - name: Switch firewall engine
   become: true
   when:
@@ -35,13 +43,6 @@
       when:
         - ansible_facts.services[item] is defined
         - ansible_facts.services[item]["status"] != "not-found"
-
-    - name: Ensure firewalld service is disabled
-      ansible.builtin.systemd:
-        name: firewalld
-        enabled: false
-        state: stopped
-        masked: true
 
     - name: Ensure nftables service is enabled and running
       ansible.builtin.systemd:


### PR DESCRIPTION
configure-os-edpm-deployment-pre-ceph-openstack-edpm pod fails at 'Ensure firewalld service is disabled' task

Fixes:  https://issues.redhat.com/browse/OSPCIX-352