### PR TITLE
Disable firewalld only when present

### DIFF
--- a/roles/edpm_nftables/tasks/service-bootstrap.yml
+++ b/roles/edpm_nftables/tasks/service-bootstrap.yml
@@ -42,6 +42,8 @@
         enabled: false
         state: stopped
         masked: true
+      when:
+        - ansible_facts.services["firewalld.service"] is defined
 
     - name: Ensure nftables service is enabled and running
       ansible.builtin.systemd:


### PR DESCRIPTION
Under some OS firewalld is not present, leading to the disabling task to fail. Avoid disabling it if not present.