### PR TITLE
Disable firewalld when present, status not-found

### DIFF
--- a/roles/edpm_nftables/tasks/service-bootstrap.yml
+++ b/roles/edpm_nftables/tasks/service-bootstrap.yml
@@ -44,6 +44,7 @@
         masked: true
       when:
         - ansible_facts.services["firewalld.service"] is defined
+        - ansible_facts.services["firewalld.service"]["status"] != "not-found"
 
     - name: Ensure nftables service is enabled and running
       ansible.builtin.systemd:


### PR DESCRIPTION
Follow up from comment in:
https://github.com/openstack-k8s-operators/edpm-ansible/pull/691

Adding the additional when condition if
status is not-found.