### PR TITLE
[OSPRH-8216] Cache telemetry and swift images

### DIFF
--- a/roles/edpm_download_cache/tasks/container_images.yml
+++ b/roles/edpm_download_cache/tasks/container_images.yml
@@ -94,6 +94,18 @@
     name: osp.edpm.edpm_neutron_dhcp
     tasks_from: download_cache.yml
 
+- name: Download images for edpm_telemetry role
+  when: '"telemetry" in edpm_download_cache_running_services'
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_telemetry
+    tasks_from: download_cache.yml
+
+- name: Download images for edpm_swift role
+  when: '"swift" in edpm_download_cache_running_services'
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_swift
+    tasks_from: download_cache.yml
+
 - name: Download images for edpm_logrotate_crond role
   when: ("install-os" in edpm_download_cache_running_services) or
         ("configure-os" in edpm_download_cache_running_services) or

--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -34,3 +34,7 @@ edpm_telemetry_certs: "/var/lib/openstack/certs/{{ edpm_telemetry_service_name }
 edpm_telemetry_cacerts: "/var/lib/openstack/cacerts/{{ edpm_telemetry_service_name }}"
 # If TLS should be enabled for telemetry
 edpm_telemetry_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
+# seconds between retries for download tasks
+edpm_telemetry_image_download_delay: 5
+# number of retries for download tasks
+edpm_telemetry_image_download_retries: 5

--- a/roles/edpm_telemetry/tasks/download_cache.yml
+++ b/roles/edpm_telemetry/tasks/download_cache.yml
@@ -1,0 +1,28 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Download needed container images
+  containers.podman.podman_image:
+    name: "{{ item }}"
+  loop:
+    - "{{ edpm_telemetry_ceilometer_compute_image }}"
+    - "{{ edpm_telemetry_ceilometer_ipmi_image }}"
+    - "{{ edpm_telemetry_node_exporter_image }}"
+  become: true
+  register: edpm_telemetry_images_download
+  until: edpm_telemetry_images_download.failed == false
+  retries: "{{ edpm_telemetry_image_download_retries }}"
+  delay: "{{ edpm_telemetry_image_download_delay }}"


### PR DESCRIPTION
This PR adds telemetry and swift to download_cache.

After the download_cache service runs I can see the ceilometer, node exporter and swift images correctly downloaded on the compute node.