### PR TITLE
tripleo_cleanup: Fix a task that was always skipped and it shouldn't be

### DIFF
--- a/roles/edpm_tripleo_cleanup/defaults/main.yml
+++ b/roles/edpm_tripleo_cleanup/defaults/main.yml
@@ -24,16 +24,16 @@ edpm_remove_tripleo_unit_files: true
 
 # Keep services listed
 edpm_service_removal_skip_list:
-  - tripleo_swift_account_auditor
-  - tripleo_swift_account_reaper
-  - tripleo_swift_account_replicator
-  - tripleo_swift_account_server
-  - tripleo_swift_container_auditor
-  - tripleo_swift_container_replicator
-  - tripleo_swift_container_server
-  - tripleo_swift_container_updater
-  - tripleo_swift_object_auditor
-  - tripleo_swift_object_expirer
-  - tripleo_swift_object_replicator
-  - tripleo_swift_object_server
-  - tripleo_swift_object_updater
+  - tripleo_swift_account_auditor.service
+  - tripleo_swift_account_reaper.service
+  - tripleo_swift_account_replicator.service
+  - tripleo_swift_account_server.service
+  - tripleo_swift_container_auditor.service
+  - tripleo_swift_container_replicator.service
+  - tripleo_swift_container_server.service
+  - tripleo_swift_container_updater.service
+  - tripleo_swift_object_auditor.service
+  - tripleo_swift_object_expirer.service
+  - tripleo_swift_object_replicator.service
+  - tripleo_swift_object_server.service
+  - tripleo_swift_object_updater.service

--- a/roles/edpm_tripleo_cleanup/tasks/main.yml
+++ b/roles/edpm_tripleo_cleanup/tasks/main.yml
@@ -34,12 +34,9 @@
   block:
     - name: Get all services
       ansible.builtin.service_facts:
-    - name: Filter for tripleo services
+    - name: Filter for tripleo services and skip the ones in skip list
       ansible.builtin.set_fact:
-        tripleo_services: "{{ ansible_facts.services.keys() | select('contains', 'tripleo') }}"
-    - name: Filter services in skip list
-      ansible.builtin.set_fact:
-        tripleo_services: "{{ tripleo_services | reject('in', edpm_service_removal_skip_list ) }}"
+        tripleo_services: "{{ ansible_facts.services.keys() | select('contains', 'tripleo') | reject('in', edpm_service_removal_skip_list ) }}"
 
 - name: Stop and disable tripleo services
   tags:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -50,3 +50,4 @@
               - ^roles/edpm_ovn/*
               - ^roles/edpm_neutron_metadata/*
               - ^roles/edpm_pre_adoption_validation/*
+              - ^roles/edpm_tripleo_cleanup/*


### PR DESCRIPTION
Apparently the 'when' condition on a block is not evaluated only before the block begins executing, but it is evaluated for each task separately. That means that if the fact that is used in the 'when' condition changes during the block execution, it affects whether the following tasks in the block will execute or not.

In our case, the "Filter for tripleo services" task set the tripleo_services fact, and due to that the following "Filter services in skip list" task never executed because the "when" condition on the block says to execute only if tripleo_services is empty.

I've pulled the two set_fact tasks into a single one to get around this issue, since i didn't want to pollute the facts list with a temporary fact. (Facts can't be undefined.)

Resolves: [OSPRH-8584](https://issues.redhat.com/browse/OSPRH-8584)