### PR TITLE
Change pattern for detecting pre-adopted versus edpm nodes

### DIFF
--- a/roles/edpm_reboot/defaults/main.yaml
+++ b/roles/edpm_reboot/defaults/main.yaml
@@ -18,7 +18,7 @@
 # All variables intended for modification should be placed in this file.
 
 edpm_reboot_strategy: auto
-edpm_reboot_old_tripleo_node_config_dir: /var/lib/config-data
+edpm_reboot_old_tripleo_node_config_dir: /var/lib/config-data/puppet-generated
 edpm_reboot_edpm_node_config_dir: /var/lib/openstack/config
 edpm_reboot_timeout_reboot: 3600
 edpm_reboot_post_reboot_delay: 60

--- a/roles/edpm_reboot/meta/argument_specs.yml
+++ b/roles/edpm_reboot/meta/argument_specs.yml
@@ -13,7 +13,7 @@ argument_specs:
         default: auto
       edpm_reboot_old_tripleo_node_config_dir:
         type: path
-        default: /var/lib/config-data
+        default: /var/lib/config-data/puppet-generated
         description: Path to check for tripleo pre-adopted nodes
       edpm_reboot_edpm_node_config_dir:
         type: path

--- a/roles/edpm_reboot/molecule/pre-adoption/converge.yml
+++ b/roles/edpm_reboot/molecule/pre-adoption/converge.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Create reboot_required directory
+      ansible.builtin.file:
+        path: /var/lib/openstack/reboot_required/
+        state: directory
+        mode: '0755'
+    - name: Create sample file in /var/lib/openstack/reboot_required/
+      ansible.builtin.file:
+        path: /var/lib/openstack/reboot_required/edpm_kernel
+        state: touch
+        mode: '0600'
+    - name: Run reboot role
+      ansible.builtin.include_role:
+        name: "osp.edpm.edpm_reboot"

--- a/roles/edpm_reboot/molecule/pre-adoption/molecule.yml
+++ b/roles/edpm_reboot/molecule/pre-adoption/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  config_options:
+    defaults:
+      callbacks_enabled: profile_tasks, timer, yaml
+      interpreter_python: auto_silent
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - verify
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_reboot/molecule/pre-adoption/prepare.yml
+++ b/roles/edpm_reboot/molecule/pre-adoption/prepare.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare test_deps
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: osp.edpm.env_data
+  tasks:
+    - name: Create nova config directory
+      ansible.builtin.file:
+        path: /var/lib/config-data/puppet-generated
+        state: directory
+        mode: "0775"
+
+    - name: Create nova_libvirt.md5sum file
+      ansible.builtin.copy:
+        dest: /var/lib/config-data/puppet-generated/nova_libvirt.md5sum
+        mode: "0644"
+        owner: root
+        group: root
+        content: |
+          2b719b64bde94c1c5e8bd9445957asd2


### PR DESCRIPTION
Change edpm_reboot_old_tripleo_node_config_dir to check for tripleo files in /var/lib/config-data/puppet-generated instead of /var/lib/config-data. Path /var/lib/config-data is still being used in edpm for storing configs whereas puppet-generated is suppose to be used only in 17/wallaby. This will make sure for greenfield auto mode is back working, but reboot is skipped on tripleo nodes during adoption.

Resolves: [OSPRH-8415](https://issues.redhat.com//browse/OSPRH-8415)