### PR TITLE
Stylistic adjustments for modules, plugins and filters

### DIFF
--- a/plugins/action/container_systemd.py
+++ b/plugins/action/container_systemd.py
@@ -15,7 +15,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import copy

--- a/plugins/filter/haskey.yml
+++ b/plugins/filter/haskey.yml
@@ -7,18 +7,18 @@ DOCUMENTATION:
   short_description: Retrun dictionaries with given key
   description: |
     This filter will take a list of dictionaries (data)
-    and will return the dictionnaries which have a certain key given
+    and will return the dictionaries which have a certain key given
     in parameter with 'attribute'.
     If reverse is set to True, the returned list won't contain dictionaries
     which have the attribute.
-    If any is set to True, the returned list will match any value in
+    If any_value is set to True, the returned list will match any value in
     the list of values for "value" parameter which has to be a list.
     If we want to exclude items which have certain key(s); these keys
     should be added to the excluded_keys list. If excluded_keys is used
     with reverse, we'll just exclude the items which had a key from
     excluded_keys in the reversed list.
 EXAMPLES: |
-  "{{ all_containers_hash | osp.edpm.dict_to_list | osp.edpm.haskey(attribute='restart', value=['always','unless-stopped'], any=True) | default([]) }}"
+  "{{ all_containers_hash | osp.edpm.dict_to_list | osp.edpm.haskey(attribute='restart', value=['always','unless-stopped'], any_value=True) | default([]) }}"
 RETURN:
   _value:
     description: dictionaries containing key

--- a/plugins/filter/helpers.py
+++ b/plugins/filter/helpers.py
@@ -118,7 +118,7 @@ class FilterModule:
 
         return to_delete
 
-    def haskey(self, data, attribute, value=None, reverse=False, any=False,
+    def haskey(self, data, attribute, value=None, reverse=False, any_value=False,
                excluded_keys=[]):
         """Return dict data with a specific key.
 
@@ -127,7 +127,7 @@ class FilterModule:
         in parameter with 'attribute'.
         If reverse is set to True, the returned list won't contain dictionaries
         which have the attribute.
-        If any is set to True, the returned list will match any value in
+        If any_value is set to True, the returned list will match any value in
         the list of values for "value" parameter which has to be a list.
         If we want to exclude items which have certain key(s); these keys
         should be added to the excluded_keys list. If excluded_keys is used
@@ -151,11 +151,11 @@ class FilterModule:
                     if value is None:
                         return_list.append(i)
                     else:
-                        if isinstance(value, list) and any:
+                        if isinstance(value, list) and any_value:
                             if v[attribute] in value:
                                 return_list.append({k: v})
-                        elif any:
-                            raise TypeError("value has to be a list if any is "
+                        elif any_value:
+                            raise TypeError("value has to be a list if any_value is "
                                             "set to True.")
                         else:
                             if v[attribute] == value:

--- a/plugins/filter/helpers.py
+++ b/plugins/filter/helpers.py
@@ -123,7 +123,7 @@ class FilterModule:
         """Return dict data with a specific key.
 
         This filter will take a list of dictionaries (data)
-        and will return the dictionnaries which have a certain key given
+        and will return the dictionaries which have a certain key given
         in parameter with 'attribute'.
         If reverse is set to True, the returned list won't contain dictionaries
         which have the attribute.

--- a/plugins/modules/edpm_container_manage.py
+++ b/plugins/modules/edpm_container_manage.py
@@ -169,7 +169,7 @@ class EdpmContainerManage:
         rc, out, err = self.module.run_command(['podman', b'--version'])
         if rc != 0 or not out or 'version' not in out:
             self.module.fail_json(msg=f"Can not determine podman version. Captured error: {err} ")
-        return out.split('versio')[1].strip()
+        return out.split('version')[1].strip()
 
     def _container_opts_defaults(self):
         default = {}

--- a/plugins/modules/edpm_container_manage.py
+++ b/plugins/modules/edpm_container_manage.py
@@ -168,7 +168,7 @@ class EdpmContainerManage:
     def _get_version(self):
         rc, out, err = self.module.run_command(['podman', b'--version'])
         if rc != 0 or not out or 'version' not in out:
-            self.module.fail_json(msg='Can not determine podman version')
+            self.module.fail_json(msg=f"Can not determine podman version. Captured error: {err} ")
         return out.split('versio')[1].strip()
 
     def _container_opts_defaults(self):

--- a/plugins/modules/edpm_container_manage.py
+++ b/plugins/modules/edpm_container_manage.py
@@ -335,10 +335,10 @@ class EdpmContainerManage:
 
             if success or retries <= 0:
                 break
-            else:
-                self.module.warn(f'Remaining retries for {name}: {retries}')
-                retries -= 1
-                time.sleep(retry_sleep)
+
+            self.module.warn(f'Remaining retries for {name}: {retries}')
+            retries -= 1
+            time.sleep(retry_sleep)
 
         return (name, success)
 

--- a/plugins/modules/edpm_container_manage.py
+++ b/plugins/modules/edpm_container_manage.py
@@ -165,12 +165,6 @@ class EdpmContainerManage:
                             configs[override_config][mk] = mv
         return configs
 
-    def _get_version(self):
-        rc, out, err = self.module.run_command(['podman', b'--version'])
-        if rc != 0 or not out or 'version' not in out:
-            self.module.fail_json(msg=f"Can not determine podman version. Captured error: {err} ")
-        return out.split('version')[1].strip()
-
     def _container_opts_defaults(self):
         default = {}
         opts = ARGUMENTS_SPEC_CONTAINER

--- a/plugins/modules/edpm_derive_pci_passthrough_devicespec.py
+++ b/plugins/modules/edpm_derive_pci_passthrough_devicespec.py
@@ -141,7 +141,7 @@ def get_pciaddr_dict_from_usraddr(pci_addr):
         dbs_all.extend(dbs_fields)
         dbs_checked = [s.strip() or ANY for s in dbs_all]
 
-        ''' domain, bus, slot = dbs_checked '''
+        # domain, bus, slot = dbs_checked
         pci_dict['domain'], pci_dict['bus'], pci_dict['slot'] = dbs_checked
 
     pci_dict['domain'] = get_pci_field_val(pci_dict['domain'], MAX_DOMAIN, '%04x')
@@ -334,9 +334,8 @@ def match_pf_details(user_config, pf_name, is_non_nic_pf):
             # If NON NIC Part PF matches, then add the complete device
             return ADD_PF_PCI_ADDRESS
         else:
-            """ In case of NIC Partitioning PF, add the VFs only (excluding NIC Part VFs)
-                when the product id is not given or product_id matches that of VF
-            """
+            # In case of NIC Partitioning PF, add the VFs only (excluding NIC Part VFs)
+            # when the product id is not given or product_id matches that of VF
             return ADD_VF_PCI_ADDRESS
     elif ('product_id' not in user_config
           or pf_product[-4:] == user_config['product_id'][-4:]):
@@ -344,15 +343,13 @@ def match_pf_details(user_config, pf_name, is_non_nic_pf):
             # If product id of NON NIC Part VF matches, then add the complete device
             return ADD_PF_PCI_ADDRESS
         else:
-            """ When the user_config address matches that of the NIC Partitioned PF,
-                the PF must be removed from the user_config. So return the status such
-                that the caller ignores this user_config if this user_config is very
-                specific to the NIC Partitioned PF
-            """
+            # When the user_config address matches that of the NIC Partitioned PF,
+            # the PF must be removed from the user_config. So return the status such
+            # that the caller ignores this user_config if this user_config is very
+            # specific to the NIC Partitioned PF
             return DEL_USER_CONFIG
     else:
-        """ The Product ID neither belongs to VF nor PF, simply ignore matching
-        """
+        # The Product ID neither belongs to VF nor PF, simply ignore matching
         return KEEP_USER_CONFIG
 
 
@@ -405,7 +402,7 @@ def get_passthrough_config(user_config, pf_name,
     pci_passthrough = []
     del_user_config = False
 
-    """ Get the regex of the address fields """
+    # Get the regex of the address fields.
     if 'address' in user_config:
         if isinstance(user_config['address'], dict):
             addr_dict = user_config['address']
@@ -416,8 +413,8 @@ def get_passthrough_config(user_config, pf_name,
         user_address_pattern = ("[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:"
                                 "[0-9a-fA-F]{2}.[0-7]")
 
-    """ If address mentioned in user_config is PF, then get all VFs belonging to that PF
-    """
+    # If address mentioned in user_config is PF, then get all VFs belonging to that PF
+
     available_vfs = get_available_vf_pci_addresses_by_ifname(pf_name, allocated_pci)
 
     # get the pci address of the PF
@@ -427,10 +424,10 @@ def get_passthrough_config(user_config, pf_name,
     # Match the user_config address with the PF's address
     if user_address_regex.match(parent_pci_address):
         match_id = match_pf_details(user_config, pf_name, is_non_nic_pf)
-        """ if the address matches and there is no mismatch in
-        product id's of PF, then add the PF's provided its not a
-        NIC Partitioning PF
-        """
+        # if the address matches and there is no mismatch in
+        # product id's of PF, then add the PF's provided its not a
+        # NIC Partitioning PF
+
         if match_id == ADD_PF_PCI_ADDRESS:
             sel_addr.append(parent_pci_address)
         elif match_id == ADD_VF_PCI_ADDRESS:
@@ -442,16 +439,16 @@ def get_passthrough_config(user_config, pf_name,
         elif match_id == DEL_USER_CONFIG:
             del_user_config = True
 
-        """ Match the user_config address with the VF's address
-        A Regex of addresses could match both the VF and PF's.
-        If it matches the PF, all available VFs would be included anyway,
-        so it will be inclusive even if the address matches the VFs of the same PF
-        Also if product id is specified, it must match that of the VF's.
-        If product id is not mentioned in user_config, its assumed to have
-        matched and is left to address matching for derived configuration.
-        If Address is not mentioned, then all available VF's (excluding NIC partitioned VFs)
-        with the matching product id shall be added to the derived configuration.
-        """
+        # Match the user_config address with the VF's address
+        # A Regex of addresses could match both the VF and PF's.
+        # If it matches the PF, all available VFs would be included anyway,
+        # so it will be inclusive even if the address matches the VFs of the same PF
+        # Also if product id is specified, it must match that of the VF's.
+        # If product id is not mentioned in user_config, its assumed to have
+        # matched and is left to address matching for derived configuration.
+        # If Address is not mentioned, then all available VF's (excluding NIC partitioned VFs)
+        # with the matching product id shall be added to the derived configuration.
+
     else:
         pf_path = os.path.join(SYS_CLASS_NET_PATH, pf_name, "device")
         vendor, vf_product = get_pci_device_info_by_ifname(pf_path, 'virtfn0')
@@ -464,13 +461,13 @@ def get_passthrough_config(user_config, pf_name,
             if not sel_addr:
                 for vf_addr in allocated_pci:
                     if user_address_regex.match(str(vf_addr)):
-                        """ When the user_config address matches that of the NIC Partitioned VF,
-                        the VF must be removed from the user_config. So return the status such
-                        that the caller ignores this user_config if this user_config is very
-                        specific to the NIC Partitioned VF. If the user_config resulted in the
-                        derivations of other configurations, the derived configuration shall
-                        replace the original user_config.
-                        """
+                        # When the user_config address matches that of the NIC Partitioned VF,
+                        # the VF must be removed from the user_config. So return the status such
+                        # that the caller ignores this user_config if this user_config is very
+                        # specific to the NIC Partitioned VF. If the user_config resulted in the
+                        # derivations of other configurations, the derived configuration shall
+                        # replace the original user_config.
+
                         del_user_config = True
 
     if sel_addr:
@@ -497,10 +494,9 @@ def get_passthrough_config_for_all_pf(user_config,
         if passthrough_tmp:
             derived_config.extend(passthrough_tmp)
 
-    """
-    If there is no config added from NIC Part nics, then skip parsing the
-    NON NIC Partitioned PFs.
-    """
+    # If there is no config added from NIC Part nics, then skip parsing the
+    # NON NIC Partitioned PFs.
+
     if (derived_config or del_user_config):
         for pf in non_nic_partition_pfs:
             passthrough_tmp, status = get_passthrough_config(
@@ -570,9 +566,9 @@ def generate_combined_configuration(user_configs, system_configs,
             passthrough_tmp, del_user_config = get_passthrough_config_for_all_pf(
                 user_config, system_configs, allocated_pci)
 
-            """ If del_user_config is set, do not add to derived_config or
-                user_config_copy
-            """
+            # If del_user_config is set, do not add to derived_config or
+            # user_config_copy
+
             if not del_user_config:
                 if passthrough_tmp:
                     derived_config.extend(passthrough_tmp)
@@ -597,10 +593,9 @@ def _run_derive_pci(user_configs,
     user_config_copy, derived = generate_combined_configuration(
         user_configs, system_configs, sriov_phydev_map)
 
-    """ If the derivation does not bring in any changes, the user_config_copy list
-        and user_configs shall be same. The pci_passthrough_devspec
-        shall be updated only when there is a change needed due to NIC Partition
-    """
+    # If the derivation does not bring in any changes, the user_config_copy list
+    # and user_configs shall be same. The pci_passthrough_devspec
+    # shall be updated only when there is a change needed due to NIC Partition
     if user_config_copy != user_configs:
         print("NOTE: user_configs is updated, use this as nova confgmap")
         pci_passthrough['device_spec'] = (user_config_copy + derived)

--- a/plugins/modules/edpm_os_net_config.py
+++ b/plugins/modules/edpm_os_net_config.py
@@ -184,9 +184,8 @@ def _has_link(interface):
         with open('/sys/class/net/{}/carrier'.format(interface)) as f:
             has_link = int(f.read().strip())
     except FileNotFoundError:
-        has_link = 0
-    if has_link == 1:
-        return True
+        return False
+    return has_link == 1
 
 
 def main():

--- a/plugins/modules/edpm_os_net_config.py
+++ b/plugins/modules/edpm_os_net_config.py
@@ -234,7 +234,7 @@ def main():
         results['msg'] = ("Successfully run %s." % cmd)
     if run.returncode == 2 and detailed_exit_codes:
         # NOTE: dprince this udev rule can apparently leak DHCP processes?
-        # https://bugs.launchpad.net/edpm/+bug/1538259
+        # https://bugs.launchpad.net/tripleo/+bug/1538259
         # until we discover the root cause we can simply disable the
         # rule because networking has already been configured at this point
         udev_file = '/etc/udev/rules.d/99-dhcp-all-interfaces.rules'

--- a/plugins/modules/edpm_os_net_config_mappings.py
+++ b/plugins/modules/edpm_os_net_config_mappings.py
@@ -152,8 +152,8 @@ def run(module):
     data = module.params['net_config_data_lookup']
     if isinstance(data, dict) and data:
         results['mapping'] = _get_mappings(data)
-
-    results['changed'] = True if results['mapping'] else False
+    # Check if mapping contains anything
+    results['changed'] = bool(results['mapping'])
 
     module.exit_json(**results)
 

--- a/roles/edpm_container_manage/tasks/create.yml
+++ b/roles/edpm_container_manage/tasks/create.yml
@@ -42,7 +42,7 @@
   vars:
     container_config: >
       {{ all_containers_hash | osp.edpm.dict_to_list |
-      osp.edpm.haskey(attribute='restart', value=['always', 'unless-stopped'], any=True) |
+      osp.edpm.haskey(attribute='restart', value=['always', 'unless-stopped'], any_value=True) |
       default([]) }}
   when:
     - edpm_container_manage_cli == 'podman'


### PR DESCRIPTION
We have accumulated quite a bit of idiosyncracies in our python code. This doesn't resolve all of them by any means, but it does take care of some of the most egregious ones. Dead code, useless imports, duplication and typos are all included. 

None of these changes should alter the way our code works. I've tried to avoid veering into full on refactor with this. That being said there is one minor change of `osp.edpm.haskey` filter API. However the filter in question is only used by one role, so it shouldn't have any adverse effects. 

Normally I would squash this. But since most of these are rather disjoint issues, I can't help but feel that it would make a mess of blame for whoever will follow. So I'm keeping the commits separate, unless people insist on squashing.