### PR TITLE
Use edpm_service_types in edpm_update

### DIFF
--- a/roles/edpm_update/defaults/main.yml
+++ b/roles/edpm_update/defaults/main.yml
@@ -27,4 +27,4 @@ edpm_update_enable_containers_update: true
 edpm_update_exclude_packages:
   - openvswitch
 
-edpm_update_running_services: "{{ edpm_services }}"
+edpm_update_running_services: "{{ edpm_service_types }}"

--- a/roles/edpm_update/molecule/default/converge.yml
+++ b/roles/edpm_update/molecule/default/converge.yml
@@ -23,4 +23,4 @@
         name: osp.edpm.edpm_update
       vars:
         edpm_update_enable_containers_update: false
-        edpm_services: []
+        edpm_service_types: []


### PR DESCRIPTION
The list of service types is added as an ansible variable to the
inventory as edpm_service_types. This will be used instead of
edpm_services since service names could be any custom value.

edpm-ansible roles such as edpm_update, need a list of consistent
service identifiers (types instead of names), so it knows which other
roles to include for update tasks.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/962
Jira: https://issues.redhat.com/browse/OSPRH-8107
Signed-off-by: James Slagle <jslagle@redhat.com>
