### PR TITLE
Fix result check syntax

### DIFF
--- a/roles/edpm_bootstrap/tasks/download_cache.yml
+++ b/roles/edpm_bootstrap/tasks/download_cache.yml
@@ -6,7 +6,7 @@
     download_only: true
   become: true
   register: edpm_bootstrap_packages_bootstrap_download
-  until: edpm_bootstrap_packages_bootstrap_download.rc == 0
+  until: edpm_bootstrap_packages_bootstrap_download is succeeded
   retries: "{{ edpm_bootstrap_download_retries }}"
   delay: "{{ edpm_bootstrap_download_delay }}"
 
@@ -18,7 +18,7 @@
     download_only: true
   become: true
   register: edpm_bootstrap_legacy_network_packages_download
-  until: edpm_bootstrap_legacy_network_packages_download.rc == 0
+  until: edpm_bootstrap_legacy_network_packages_download is succeeded
   retries: "{{ edpm_bootstrap_download_retries }}"
   delay: "{{ edpm_bootstrap_download_delay }}"
 
@@ -31,6 +31,6 @@
     download_only: true
   become: true
   register: edpm_bootstrap_release_version_package_download
-  until: edpm_bootstrap_release_version_package_download.rc == 0
+  until: edpm_bootstrap_release_version_package_download is succeeded
   retries: "{{ edpm_bootstrap_download_retries }}"
   delay: "{{ edpm_bootstrap_download_delay }}"

--- a/roles/edpm_bootstrap/tasks/packages.yml
+++ b/roles/edpm_bootstrap/tasks/packages.yml
@@ -32,7 +32,7 @@
     - (edpm_bootstrap_release_version_package | list | length) > 0
   become: true
   register: edpm_bootstrap_release_version_package_install
-  until: edpm_bootstrap_release_version_package_install.rc == 0
+  until: edpm_bootstrap_release_version_package_install is succeeded
   retries: "{{ edpm_bootstrap_download_retries }}"
   delay: "{{ edpm_bootstrap_download_delay }}"
 
@@ -45,7 +45,7 @@
     - not ansible_check_mode | bool
     - (edpm_bootstrap_packages_bootstrap_result.rc | int) == 1
   register: edpm_bootstrap_packages_bootstrap_result
-  until: edpm_bootstrap_packages_bootstrap_result.rc == 0
+  until: edpm_bootstrap_packages_bootstrap_result is succeeded
   retries: "{{ edpm_bootstrap_download_retries }}"
   delay: "{{ edpm_bootstrap_download_delay }}"
   become: true
@@ -68,7 +68,7 @@
         name: "{{ edpm_bootstrap_legacy_network_packages }}"
         state: present
       register: edpm_bootstrap_legacy_network_packages_result
-      until: edpm_bootstrap_legacy_network_packages_result.rc == 0
+      until: edpm_bootstrap_legacy_network_packages_result is succeeded
       retries: "{{ edpm_bootstrap_download_retries }}"
       delay: "{{ edpm_bootstrap_download_delay }}"
     - name: Ensure network service is enabled

--- a/roles/edpm_kernel/tasks/download_cache.yml
+++ b/roles/edpm_kernel/tasks/download_cache.yml
@@ -7,6 +7,6 @@
   become: true
   when: edpm_kernel_extra_packages | length > 0
   register: _install_packages_result
-  until: _install_packages_result.rc == 0
+  until: _install_packages_result is succeeded
   retries: "{{ edpm_kernel_download_retries }}"
   delay: "{{ edpm_kernel_download_delay }}"

--- a/roles/edpm_kernel/tasks/main.yml
+++ b/roles/edpm_kernel/tasks/main.yml
@@ -26,7 +26,7 @@
         state: present
       register: _install_packages_result
       when: edpm_kernel_extra_packages | length > 0
-      until: _install_packages_result.rc == 0
+      until: _install_packages_result is succeeded
       retries: "{{ edpm_kernel_download_retries }}"
       delay: "{{ edpm_kernel_download_delay }}"
 

--- a/roles/edpm_libvirt/tasks/download_cache.yml
+++ b/roles/edpm_libvirt/tasks/download_cache.yml
@@ -5,6 +5,6 @@
     download_only: true
   become: true
   register: _install_packages_result
-  until: _install_packages_result.rc == 0
+  until: _install_packages_result is succeeded
   retries: "{{ edpm_libvirt_download_retries }}"
   delay: "{{ edpm_libvirt_download_delay }}"

--- a/roles/edpm_logrotate_crond/tasks/download_cache_packages.yml
+++ b/roles/edpm_logrotate_crond/tasks/download_cache_packages.yml
@@ -6,6 +6,6 @@
     download_only: true
   become: true
   register: edpm_logrotate_crond_cronie_package_download
-  until: edpm_logrotate_crond_cronie_package_download.rc == 0
+  until: edpm_logrotate_crond_cronie_package_download is succeeded
   retries: "{{ edpm_logrotate_crond_download_retries }}"
   delay: "{{ edpm_logrotate_crond_download_delay }}"

--- a/roles/edpm_logrotate_crond/tasks/install.yml
+++ b/roles/edpm_logrotate_crond/tasks/install.yml
@@ -21,7 +21,7 @@
     name: "{{ edpm_logrotate_crond_cronie_package }}"
     state: present
   register: edpm_logrotate_crond_cronie_package_download
-  until: edpm_logrotate_crond_cronie_package_download.rc == 0
+  until: edpm_logrotate_crond_cronie_package_download is succeeded
   retries: "{{ edpm_logrotate_crond_download_retries }}"
   delay: "{{ edpm_logrotate_crond_download_delay }}"
 

--- a/roles/edpm_network_config/tasks/download_cache.yml
+++ b/roles/edpm_network_config/tasks/download_cache.yml
@@ -18,6 +18,6 @@
     download_only: true
   become: true
   register: edpm_network_config_onc_download
-  until: edpm_network_config_onc_download.rc == 0
+  until: edpm_network_config_onc_download is succeeded
   retries: "{{ edpm_network_config_download_retries }}"
   delay: "{{ edpm_network_config_download_delay }}"

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -22,7 +22,7 @@
         name: "{{ edpm_network_config_systemrole_nmstate_dependencies }}"
         state: present
       register: nm_ovs_status
-      until: nm_ovs_status.rc == 0
+      until: nm_ovs_status is succeeded
       retries: "{{ edpm_network_config_download_retries }}"
       delay: "{{ edpm_network_config_download_delay }}"
     - name: Restart NetworkManager after plugin installation [nmstate]

--- a/roles/edpm_network_config/tasks/network_config.yml
+++ b/roles/edpm_network_config/tasks/network_config.yml
@@ -44,7 +44,7 @@
     name: os-net-config
     state: present
   register: edpm_network_config_onc_download
-  until: edpm_network_config_onc_download.rc == 0
+  until: edpm_network_config_onc_download is succeeded
   retries: "{{ edpm_network_config_download_retries }}"
   delay: "{{ edpm_network_config_download_delay }}"
 

--- a/roles/edpm_ovs/tasks/download_cache.yml
+++ b/roles/edpm_ovs/tasks/download_cache.yml
@@ -6,6 +6,6 @@
     state: "{{ dnf_state | default(omit) }}"
   become: true
   register: _install_packages_result
-  until: _install_packages_result.rc == 0
+  until: _install_packages_result is succeeded
   retries: "{{ edpm_ovs_download_retries }}"
   delay: "{{ edpm_ovs_download_delay }}"

--- a/roles/edpm_podman/tasks/buildah_login.yml
+++ b/roles/edpm_podman/tasks/buildah_login.yml
@@ -20,7 +20,7 @@
     name: "{{ edpm_buildah_package }}"
     state: present
   register: edpm_buildah_package_download
-  until: edpm_buildah_package_download.rc == 0
+  until: edpm_buildah_package_download is succeeded
   retries: "{{ edpm_podman_download_retries }}"
   delay: "{{ edpm_podman_download_delay }}"
 

--- a/roles/edpm_podman/tasks/download_cache.yml
+++ b/roles/edpm_podman/tasks/download_cache.yml
@@ -8,6 +8,6 @@
     download_only: true
   become: true
   register: edpm_podman_packages_download
-  until: edpm_podman_packages_download.rc == 0
+  until: edpm_podman_packages_download is succeeded
   retries: "{{ edpm_podman_download_retries }}"
   delay: "{{ edpm_podman_download_delay }}"

--- a/roles/edpm_podman/tasks/install.yml
+++ b/roles/edpm_podman/tasks/install.yml
@@ -22,7 +22,7 @@
         name: "{{ edpm_podman_package }}"
         state: present
       register: edpm_podman_package_download
-      until: edpm_podman_package_download.rc == 0
+      until: edpm_podman_package_download is succeeded
       retries: "{{ edpm_podman_download_retries }}"
       delay: "{{ edpm_podman_download_delay }}"
 

--- a/roles/edpm_sshd/tasks/download_cache.yml
+++ b/roles/edpm_sshd/tasks/download_cache.yml
@@ -6,6 +6,6 @@
     download_only: true
   become: true
   register: edpm_sshd_packages_download
-  until: edpm_sshd_packages_download.rc == 0
+  until: edpm_sshd_packages_download is succeeded
   retries: "{{ edpm_sshd_download_retries }}"
   delay: "{{ edpm_sshd_download_delay }}"

--- a/roles/edpm_sshd/tasks/install.yml
+++ b/roles/edpm_sshd/tasks/install.yml
@@ -23,7 +23,7 @@
         name: "{{ edpm_sshd_packages }}"
         state: present
       register: _sshd_install_result
-      until: _sshd_install_result.rc == 0
+      until: _sshd_install_result is succeeded
       retries: "{{ edpm_sshd_download_retries }}"
       delay: "{{ edpm_sshd_download_delay }}"
 

--- a/roles/edpm_tuned/tasks/download_cache.yml
+++ b/roles/edpm_tuned/tasks/download_cache.yml
@@ -6,6 +6,6 @@
     download_only: true
   become: true
   register: edpm_tuned_system_packages_download
-  until: edpm_tuned_system_packages_download.rc == 0
+  until: edpm_tuned_system_packages_download is succeeded
   retries: "{{ edpm_tuned_download_retries }}"
   delay: "{{ edpm_tuned_download_delay }}"

--- a/roles/edpm_tuned/tasks/install.yml
+++ b/roles/edpm_tuned/tasks/install.yml
@@ -20,6 +20,6 @@
     name: "{{ edpm_tuned_system_packages }}"
     state: present
   register: edpm_tuned_system_packages_download
-  until: edpm_tuned_system_packages_download.rc == 0
+  until: edpm_tuned_system_packages_download is succeeded
   retries: "{{ edpm_tuned_download_retries }}"
   delay: "{{ edpm_tuned_download_delay }}"


### PR DESCRIPTION
Otherwise it fails with below in case the package is not available, i.e correct repos are not enabled.

ASK [osp.edpm.edpm_bootstrap : Deploy network-scripts required for deprecated network service] ***
fatal: [edpm-compute-1]: FAILED! => {"msg": "The conditional check 'edpm_bootstrap_legacy_network_packages_result.rc == 0' failed. The error was: error while evaluating conditional (edpm_bootstrap_legacy_network_packages_result.rc == 0): 'dict object' has no attribute 'rc'. 'dict object' has no attribute 'rc'"}

jira: https://issues.redhat.com/browse/OSPRH-8911