### PR TITLE
Restoring virt-pki-validate check in molecule test

### DIFF
--- a/roles/edpm_libvirt/molecule/default/verify.yml
+++ b/roles/edpm_libvirt/molecule/default/verify.yml
@@ -48,16 +48,20 @@
         key: libvirt
       register: libvirt_user
 
-    # TODO: Temporarily disabled until we can reconcile new rules
-    #       in the tool with our environment
-    # - name: validate tls with virt-pki-validate
-    #   become: true
-    #   ansible.builtin.shell: "virt-pki-validate"
-    #   register: virt_pki_validate
-    # - name: Assert that virt-pki-validate returns no errors
-    #   assert:
-    #     that:
-    #       - "virt_pki_validate.rc == 0"
+    - name: validate tls with virt-pki-validate
+      become: true
+      ansible.builtin.shell: "virt-pki-validate"
+      register: virt_pki_validate
+      failed_when: false
+    - name: Print virt-pki-validate output
+      debug:
+        msg: "{{ virt_pki_validate.stdout }}"
+    - name: Test result of virt-pki-validate
+      block:
+        - name: Assert that virt-pki-validate returns no errors
+          assert:
+            that: "{{ 'FAIL' not in virt_pki_validate.stdout }}"
+      when: virt_pki_validate.rc != 0
 
     - name: ensure we can connect to libvirt with virsh via tls
       # Note we need become because the client cert is owned by root

--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -22,9 +22,9 @@
   loop:
     - {"path": "/etc/tmpfiles.d/", "owner": "root", "group": "root"}
     - {"path": "/var/lib/edpm-config/firewall", "owner": "root", "group": "root"}
-    - {"path": "/etc/pki/libvirt", "owner": "root", "group": "root"}
-    - {"path": "/etc/pki/libvirt/private", "owner": "root", "group": "root"}
-    - {"path": "/etc/pki/CA", "owner": "root", "group": "root"}
+    - {"path": "/etc/pki/libvirt", "owner": "root", "group": "root", "mode": "0755"}
+    - {"path": "/etc/pki/libvirt/private", "owner": "root", "group": "root", "mode": "0755"}
+    - {"path": "/etc/pki/CA", "owner": "root", "group": "root", "mode": "0755"}
     - {"path": "/etc/pki/qemu", "owner": "root", "group": "qemu"}
 
 - name: Render libvirt config files
@@ -144,7 +144,7 @@
   become: true
   loop:
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt", "dest": "/etc/pki/libvirt/servercert.pem"}
-    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/libvirt/private/serverkey.pem"}
+    - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/libvirt/private/serverkey.pem", "mode": "0600"}
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.crt", "dest": "/etc/pki/libvirt/clientcert.pem"}
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/tls.key", "dest": "/etc/pki/libvirt/private/clientkey.pem"}
     - {"src": "{{ edpm_libvirt_tls_cert_src_dir }}/ca.crt", "dest": "/etc/pki/CA/cacert.pem"}
@@ -152,7 +152,7 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     remote_src: true
-    mode: "0644"
+    mode: "{{ item.mode | default('0644') }}"
     owner: "root"
     group: "root"
   when: edpm_libvirt_tls_certs_enabled


### PR DESCRIPTION
Resolves: [OSPCIX-393](https://issues.redhat.com//browse/OSPCIX-393) 

Permissions for directories are now set according to new virt-pki-validate recommendations. Instead of checking return code of the tool, we are now matching on output. This is because even a single warning changes rc to 1.