### PR TITLE
Re-introduce a become: true that was previously wrongly removed

### DIFF
--- a/roles/edpm_telemetry/molecule/default/converge.yml
+++ b/roles/edpm_telemetry/molecule/default/converge.yml
@@ -7,5 +7,3 @@
         name: "osp.edpm.edpm_telemetry"
       vars:
         telemetry_test: true
-        ansible_user: root
-        ansible_user_dir: /root

--- a/roles/edpm_telemetry_logging/molecule/default/converge.yml
+++ b/roles/edpm_telemetry_logging/molecule/default/converge.yml
@@ -7,5 +7,3 @@
         name: "osp.edpm.edpm_telemetry_logging"
       vars:
         telemetry_test: true
-        ansible_user: root
-        ansible_user_dir: /root

--- a/roles/edpm_telemetry_logging/tasks/configure.yml
+++ b/roles/edpm_telemetry_logging/tasks/configure.yml
@@ -42,6 +42,7 @@
         remote_src: "{{ telemetry_test | default('false') }}"
 
     - name: Deploy rsyslog configuration
+      become: true
       ansible.builtin.copy:
         src: "{{ edpm_telemetry_logging_config_src }}/10-telemetry.conf"
         dest: "{{ edpm_telemetry_rsyslog_config_dest }}/10-telemetry.conf"


### PR DESCRIPTION
It was detected in the CI of the PR https://github.com/openstack-k8s-operators/telemetry-operator/pull/457