### PR TITLE
Don't use log files on EDPM nodes for networking related services

### DIFF
--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -37,7 +37,6 @@ edpm_neutron_dhcp_common_volumes:
   - "{{ edpm_neutron_dhcp_agent_config_dir }}:/etc/neutron.conf.d:z"
   - "{{ edpm_neutron_dhcp_agent_lib_dir }}:/var/lib/neutron:shared,z"
   - /var/lib/kolla/config_files/neutron_dhcp_agent.json:/var/lib/kolla/config_files/config.json:ro
-  - /var/log/containers/neutron:/var/log/neutron:z
   - /run/openvswitch:/run/openvswitch:shared,z
   - "{{ edpm_neutron_dhcp_agent_lib_dir }}/dhcp_agent_haproxy_wrapper:/usr/local/bin/haproxy:ro"
   - "{{ edpm_neutron_dhcp_agent_lib_dir }}/dhcp_agent_dnsmasq_wrapper:/usr/local/bin/dnsmasq:ro"

--- a/roles/edpm_neutron_dhcp/meta/argument_specs.yml
+++ b/roles/edpm_neutron_dhcp/meta/argument_specs.yml
@@ -40,7 +40,6 @@ argument_specs:
           - "{{ edpm_neutron_dhcp_agent_config_dir }}:/etc/neutron.conf.d:z"
           - "{{ edpm_neutron_dhcp_agent_lib_dir }}:/var/lib/neutron:shared,z"
           - /var/lib/kolla/config_files/neutron_dhcp_agent.json:/var/lib/kolla/config_files/config.json:ro
-          - /var/log/containers/neutron:/var/log/neutron:z
           - /run/openvswitch:/run/openvswitch:shared,z
           - "{{ edpm_neutron_dhcp_agent_lib_dir }}/dhcp_agent_haproxy_wrapper:/usr/local/bin/haproxy:ro"
           - "{{ edpm_neutron_dhcp_agent_lib_dir }}/dhcp_agent_dnsmasq_wrapper:/usr/local/bin/dnsmasq:ro"

--- a/roles/edpm_neutron_dhcp/molecule/default/tests/test_neutron_dhcp.py
+++ b/roles/edpm_neutron_dhcp/molecule/default/tests/test_neutron_dhcp.py
@@ -105,9 +105,7 @@ class TestNeutronDHCP(unittest.TestCase):
                 "/var/lib/neutron/external/pids/",
                 "/var/lib/neutron/ns-metadata-proxy/",
                 "/var/lib/openstack/config/containers",
-                "/var/lib/config-data/ansible-generated/neutron-dhcp-agent",
-                "/var/log/containers/neutron",
-                "/var/log/containers/stdouts"]:
+                "/var/lib/config-data/ansible-generated/neutron-dhcp-agent"]:
             assert self.host.file(directory).is_directory
 
     def test_kolla_config_file_was_created(self):

--- a/roles/edpm_neutron_dhcp/tasks/install.yml
+++ b/roles/edpm_neutron_dhcp/tasks/install.yml
@@ -27,8 +27,6 @@
     - {'path': "/var/lib/openstack/config/containers", "mode": "0750"}
     - {'path': "/var/lib/neutron", "mode": "0750"}
     - {'path': "{{ edpm_neutron_dhcp_agent_config_dir }}", "mode": "0755"}
-    - {'path': "/var/log/containers/stdouts", "mode": "0755"}
-    - {'path': "/var/log/containers/neutron", "mode": "0755"}
     - {'path': "{{ edpm_neutron_dhcp_agent_lib_dir }}", "mode": "0755"}
     - {'path': "{{ edpm_neutron_dhcp_agent_lib_dir }}/kill_scripts", "mode": "0755"}
     - {'path': "{{ edpm_neutron_dhcp_agent_lib_dir }}/ns-metadata-proxy", "mode": "0755"}

--- a/roles/edpm_neutron_dhcp/templates/kolla_config/neutron_dhcp_agent.yaml.j2
+++ b/roles/edpm_neutron_dhcp/templates/kolla_config/neutron_dhcp_agent.yaml.j2
@@ -6,9 +6,6 @@ config_files:
     perm: '0600'
 permissions:
   - owner: neutron:neutron
-    path: /var/log/neutron
-    recurse: true
-  - owner: neutron:neutron
     path: /var/lib/neutron
     recurse: true
   - optional: true

--- a/roles/edpm_neutron_dhcp/templates/neutron.conf.j2
+++ b/roles/edpm_neutron_dhcp/templates/neutron.conf.j2
@@ -1,5 +1,4 @@
 [DEFAULT]
-log_file = /var/log/neutron/neutron-dhcp-agent.log
 debug = {{ edpm_neutron_dhcp_DEFAULT_debug }}
 rpc_response_timeout = {{ edpm_neutron_dhcp_DEFAULT_rpc_response_timeout }}
 transport_url = {{ edpm_neutron_dhcp_DEFAULT_transport_url }}

--- a/roles/edpm_neutron_dhcp/templates/wrappers/kill-script.j2
+++ b/roles/edpm_neutron_dhcp/templates/wrappers/kill-script.j2
@@ -3,6 +3,4 @@
 set -x
 {%- endif %}
 
-LOG_FILE=/var/log/neutron/kill-script.log
-
 {% include 'kill-script_common_part.j2' %}

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -12,7 +12,6 @@ edpm_neutron_metadata_images_download_retries: 5
 
 edpm_neutron_metadata_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_metadata_service_name }}"
 edpm_neutron_metadata_agent_config_dir: /var/lib/config-data/ansible-generated/neutron-ovn-metadata-agent
-edpm_neutron_metadata_agent_log_dir: "/var/log/neutron"
 edpm_neutron_metadata_agent_lib_dir: "/var/lib/neutron"
 
 edpm_neutron_metadata_agent_image: "quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified"
@@ -21,7 +20,6 @@ edpm_neutron_metadata_common_volumes:
   - /run/openvswitch:/run/openvswitch:z
   - "{{ edpm_neutron_metadata_agent_config_dir }}:/etc/neutron.conf.d:z"
   - /run/netns:/run/netns:shared
-  - /var/log/containers/neutron:/var/log/neutron:z
   - /var/lib/kolla/config_files/ovn_metadata_agent.json:/var/lib/kolla/config_files/config.json:ro
   - "{{ edpm_neutron_metadata_agent_lib_dir }}:/var/lib/neutron:shared,z"
   - "{{ edpm_neutron_metadata_agent_lib_dir }}/ovn_metadata_haproxy_wrapper:/usr/local/bin/haproxy:ro"

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -20,10 +20,6 @@ argument_specs:
         default: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
         description: ''
         type: str
-      edpm_neutron_metadata_agent_log_dir:
-        default: /var/log/neutron
-        description: ''
-        type: str
       edpm_neutron_metadata_agent_lib_dir:
         default: "/var/lib/neutron"
         description: |
@@ -110,7 +106,6 @@ argument_specs:
           - /run/openvswitch:/run/openvswitch:z
           - '{{ edpm_neutron_metadata_agent_config_dir }}:/etc/neutron.conf.d:z'
           - /run/netns:/run/netns:shared
-          - /var/log/containers/neutron:/var/log/neutron:z
           - /var/lib/kolla/config_files/ovn_metadata_agent.json:/var/lib/kolla/config_files/config.json:ro
           - "{{ edpm_neutron_metadata_agent_lib_dir }}:/var/lib/neutron:shared,z"
           - "{{ edpm_neutron_metadata_agent_lib_dir }}/ovn_metadata_haproxy_wrapper:/usr/local/bin/haproxy:ro"

--- a/roles/edpm_neutron_metadata/tasks/install.yml
+++ b/roles/edpm_neutron_metadata/tasks/install.yml
@@ -25,7 +25,6 @@
     mode: "{{ item.mode | default(omit) }}"
   loop:
     - {'path': "{{ edpm_neutron_metadata_agent_config_dir }}"}
-    - {'path': "/var/log/containers/neutron"}
     - {'path': "{{ edpm_neutron_metadata_agent_lib_dir }}", "mode": "0755"}
     - {'path': "{{ edpm_neutron_metadata_agent_lib_dir }}/kill_scripts", "mode": "0755"}
     - {'path': "{{ edpm_neutron_metadata_agent_lib_dir }}/ovn-metadata-proxy", "mode": "0755"}

--- a/roles/edpm_neutron_metadata/templates/kolla_ovn_metadata_agent.yaml.j2
+++ b/roles/edpm_neutron_metadata/templates/kolla_ovn_metadata_agent.yaml.j2
@@ -1,13 +1,10 @@
-command: "neutron-ovn-metadata-agent --log-file={{ edpm_neutron_metadata_agent_log_dir }}/ovn-metadata-agent.log"
+command: "neutron-ovn-metadata-agent"
 config_files:
   - source: /etc/neutron.conf.d/01-rootwrap.conf
     dest: /etc/neutron/rootwrap.conf
     owner: root:root
     perm: '0600'
 permissions:
-  - owner: neutron:neutron
-    path: /var/log/neutron
-    recurse: true
   - owner: neutron:neutron
     path: /var/lib/neutron
     recurse: true

--- a/roles/edpm_neutron_metadata/templates/wrappers/common_part.j2
+++ b/roles/edpm_neutron_metadata/templates/wrappers/common_part.j2
@@ -1,7 +1,7 @@
 {% raw -%}
 
 CLI="nsenter --net=/run/netns/${NETNS} --preserve-credentials -m -t 1 podman"
-LOGGING="--log-driver k8s-file --log-opt path=/var/log/containers/stdouts/${NAME}.log"
+LOGGING="--log-driver journald"
 
 LIST=$($CLI ps -a --filter name=${NAME_PREFIX}- --format '{{.ID}}:{{.Names}}:{{.Status}}' | awk '{print $1}')
 

--- a/roles/edpm_neutron_metadata/templates/wrappers/kill-script.j2
+++ b/roles/edpm_neutron_metadata/templates/wrappers/kill-script.j2
@@ -3,6 +3,4 @@
 set -x
 {%- endif %}
 
-LOG_FILE={{ edpm_neutron_metadata_agent_log_dir }}/kill-script.log
-
 {% include 'kill-script_common_part.j2' %}

--- a/roles/edpm_neutron_metadata/templates/wrappers/kill-script_common_part.j2
+++ b/roles/edpm_neutron_metadata/templates/wrappers/kill-script_common_part.j2
@@ -2,13 +2,6 @@ add_date() {
   echo "$(date) $@"
 }
 
-# Set up script logging for debugging purpose.
-# It will be taken care of by logrotate since there is the .log
-# suffix.
-exec 3>&1 4>&2
-trap 'exec 2>&4 1>&3' 0 1 2 3
-exec 1>>$LOG_FILE 2>&1
-
 SIG=$1
 PID=$2
 NETNS=$(ip netns identify ${PID})

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -12,14 +12,12 @@ edpm_neutron_ovn_images_download_retries: 5
 
 edpm_neutron_ovn_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_ovn_service_name }}"
 edpm_neutron_ovn_agent_config_dir: /var/lib/config-data/ansible-generated/neutron-ovn-agent
-edpm_neutron_ovn_agent_log_dir: "/var/log/neutron"
 
 edpm_neutron_ovn_agent_image: "quay.io/podified-antelope-centos9/openstack-neutron-ovn-agent:current-podified"
 
 edpm_neutron_ovn_common_volumes:
   - /run/openvswitch:/run/openvswitch:z
   - "{{ edpm_neutron_ovn_agent_config_dir }}:/etc/neutron.conf.d:z"
-  - /var/log/containers/neutron:/var/log/neutron:z
   - /var/lib/kolla/config_files/ovn_agent.json:/var/lib/kolla/config_files/config.json:ro
 
 edpm_neutron_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"

--- a/roles/edpm_neutron_ovn/meta/argument_specs.yml
+++ b/roles/edpm_neutron_ovn/meta/argument_specs.yml
@@ -16,10 +16,6 @@ argument_specs:
         default: quay.io/podified-antelope-centos9/openstack-neutron-ovn-agent:current-podified
         description: The container image to use to deploy Neutron OVN agent
         type: str
-      edpm_neutron_ovn_agent_log_dir:
-        default: /var/log/neutron
-        description: Log directory to be used by Neutron OVN agent
-        type: str
       edpm_neutron_ovn_agent_DEFAULT_debug:
         default: 'True'
         description: Enable debug mode
@@ -84,7 +80,6 @@ argument_specs:
         default:
           - /run/openvswitch:/run/openvswitch:z
           - '{{ edpm_neutron_ovn_agent_config_dir }}:/etc/neutron.conf.d:z'
-          - /var/log/containers/neutron:/var/log/neutron:z
           - /var/lib/kolla/config_files/ovn_agent.json:/var/lib/kolla/config_files/config.json:ro
         description: Volume mounts for Neutron OVN agent
         type: list

--- a/roles/edpm_neutron_ovn/tasks/install.yml
+++ b/roles/edpm_neutron_ovn/tasks/install.yml
@@ -25,4 +25,3 @@
     group: "{{ ansible_user | default(ansible_user_id) }}"
   loop:
     - {'path': "{{ edpm_neutron_ovn_agent_config_dir }}"}
-    - {'path': "/var/log/containers/neutron"}

--- a/roles/edpm_neutron_ovn/templates/kolla_ovn_agent.yaml.j2
+++ b/roles/edpm_neutron_ovn/templates/kolla_ovn_agent.yaml.j2
@@ -1,13 +1,10 @@
-command: "neutron-ovn-agent --log-file={{ edpm_neutron_ovn_agent_log_dir }}/ovn-agent.log"
+command: "neutron-ovn-agent"
 config_files:
   - source: /etc/neutron.conf.d/01-rootwrap.conf
     dest: /etc/neutron/rootwrap.conf
     owner: root:root
     perm: '0600'
 permissions:
-  - owner: neutron:neutron
-    path: /var/log/neutron
-    recurse: true
   - owner: neutron:neutron
     path: /var/lib/neutron
     recurse: true

--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -37,7 +37,6 @@ edpm_neutron_sriov_common_volumes:
   - "{{ edpm_neutron_sriov_agent_config_dir }}:/etc/neutron.conf.d:z"
   - /var/lib/neutron:/var/lib/neutron:shared,z
   - /var/lib/kolla/config_files/neutron_sriov_agent.json:/var/lib/kolla/config_files/config.json:ro
-  - /var/log/containers/neutron:/var/log/neutron:z
 
 edpm_neutron_sriov_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 edpm_neutron_sriov_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_neutron_sriov_service_name }}"

--- a/roles/edpm_neutron_sriov/meta/argument_specs.yml
+++ b/roles/edpm_neutron_sriov/meta/argument_specs.yml
@@ -35,7 +35,6 @@ argument_specs:
           - "{{ edpm_neutron_sriov_agent_config_dir }}:/etc/neutron.conf.d:z"
           - /var/lib/neutron:/var/lib/neutron:shared,z
           - /var/lib/kolla/config_files/neutron_sriov_agent.json:/var/lib/kolla/config_files/config.json:ro
-          - /var/log/containers/neutron:/var/log/neutron:z
         description: List of volumes in a mount point form.
         type: list
       edpm_neutron_sriov_tls_enabled:

--- a/roles/edpm_neutron_sriov/molecule/default/verify.yml
+++ b/roles/edpm_neutron_sriov/molecule/default/verify.yml
@@ -15,8 +15,6 @@
         - "/var/lib/openstack/config/containers"
         - "/var/lib/kolla/config_files/neutron_sriov_agent.json"
         - "/var/lib/config-data/ansible-generated/neutron-sriov-agent"
-        - "/var/log/containers/neutron"
-        - "/var/log/containers/stdouts"
 
     - name: ensure systemd services are defined and functional
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_systemd_unit.yaml"
@@ -27,19 +25,6 @@
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_podman.yaml"
       loop:
         - "neutron_sriov_agent"
-
-    - name: ensure that log file for neutron-sriov-agent exist
-      become: true
-      block:
-        - name: Check if file /var/log/containers/neutron/neutron-sriov-nic-agent.log exist
-          ansible.builtin.stat:
-            path: /var/log/containers/neutron/neutron-sriov-nic-agent.log
-          register: log_file
-        - name: Assert file /var/log/containers/neutron/neutron-sriov-nic-agent.log exist
-          ansible.builtin.assert:
-            that:
-              - log_file.stat.exists
-            fail_msg: "File /var/log/containers/neutron/neutron-sriov-nic-agent.log does not exist"
 
     - name: Ensure that 10-neutron-sriov.conf was copied into the container
       block:

--- a/roles/edpm_neutron_sriov/tasks/install.yml
+++ b/roles/edpm_neutron_sriov/tasks/install.yml
@@ -27,8 +27,6 @@
     - {'path': "/var/lib/openstack/config/containers", "mode": "0755", "owner": "{{ ansible_user }}", "group": "{{ ansible_user }}"}
     - {'path': "/var/lib/neutron", "mode": "0750"}
     - {'path': "{{ edpm_neutron_sriov_agent_config_dir }}", "mode": "0755", "owner": "{{ ansible_user }}", "group": "{{ ansible_user }}"}
-    - {'path': "/var/log/containers/stdouts"}
-    - {'path': "/var/log/containers/neutron"}
   tags:
     - install
     - neutron

--- a/roles/edpm_neutron_sriov/templates/kolla_config/neutron_sriov_agent.yaml.j2
+++ b/roles/edpm_neutron_sriov/templates/kolla_config/neutron_sriov_agent.yaml.j2
@@ -6,9 +6,6 @@ config_files:
     perm: '0600'
 permissions:
   - owner: neutron:neutron
-    path: /var/log/neutron
-    recurse: true
-  - owner: neutron:neutron
     path: /var/lib/neutron
     recurse: true
   - optional: true

--- a/roles/edpm_neutron_sriov/templates/neutron.conf.j2
+++ b/roles/edpm_neutron_sriov/templates/neutron.conf.j2
@@ -1,5 +1,4 @@
 [DEFAULT]
-log_file = /var/log/neutron/neutron-sriov-nic-agent.log
 debug = {{ edpm_neutron_sriov_DEFAULT_debug }}
 rpc_response_timeout = {{ edpm_neutron_sriov_DEFAULT_rpc_response_timeout }}
 transport_url = {{ edpm_neutron_sriov_DEFAULT_transport_url }}

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -60,8 +60,6 @@ edpm_ovn_controller_common_volumes:
   - /lib/modules:/lib/modules:ro
   - /run:/run
   - /var/lib/openvswitch/ovn:/run/ovn:shared,z
-  - /var/log/containers/openvswitch:/var/log/openvswitch:z
-  - /var/log/containers/openvswitch:/var/log/ovn:z
   - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
 
 edpm_ovn_controller_tls_volumes:

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -54,8 +54,6 @@ argument_specs:
           - /lib/modules:/lib/modules:ro
           - /run:/run
           - /var/lib/openvswitch/ovn:/run/ovn:shared,z
-          - /var/log/containers/openvswitch:/var/log/openvswitch:z
-          - /var/log/containers/openvswitch:/var/log/ovn:z
           - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
         description: List of volumes in a mount point form.
         type: list

--- a/roles/edpm_ovn/tasks/install.yml
+++ b/roles/edpm_ovn/tasks/install.yml
@@ -24,7 +24,6 @@
     owner: "{{ item.owner | default(ansible_user) | default(ansible_user_id) }}"
     group: "{{ item.group | default(ansible_user) | default(ansible_user_id) }}"
   loop:
-    - {'path': /var/log/containers/openvswitch, 'mode': '0750'}
     - {'path': /var/lib/edpm-config/firewall, 'mode': '0750'}
     - {'path': /var/lib/openvswitch/ovn, "owner": "openvswitch", "group": "openvswitch"}
 

--- a/roles/edpm_ovn/templates/kolla_ovn_controller.yaml.j2
+++ b/roles/edpm_ovn/templates/kolla_ovn_controller.yaml.j2
@@ -1,8 +1,1 @@
-command: "/usr/bin/ovn-controller --pidfile --log-file unix:/run/openvswitch/db.sock {% if edpm_ovn_tls_enabled | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% endif %}"
-permissions:
-  - path: /var/log/openvswitch
-    owner: root:root
-    recurse: true
-  - path: /var/log/ovn
-    owner: root:root
-    recurse: true
+command: "/usr/bin/ovn-controller --pidfile unix:/run/openvswitch/db.sock {% if edpm_ovn_tls_enabled | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% endif %}"

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -111,8 +111,6 @@ edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes:
   - /lib/modules:/lib/modules:ro
   - /run:/run
   - /var/lib/openvswitch/ovn:/run/ovn:shared,z
-  - /var/log/containers/openvswitch:/var/log/openvswitch:z
-  - /var/log/containers/openvswitch:/var/log/ovn:z
 
 edpm_ovn_bgp_agent_local_ovn_controller_volumes:
   - /var/lib/kolla/config_files/bgp_ovn_controller.json:/var/lib/kolla/config_files/config.json:ro

--- a/roles/edpm_ovn_bgp_agent/molecule/default/verify.yml
+++ b/roles/edpm_ovn_bgp_agent/molecule/default/verify.yml
@@ -9,7 +9,6 @@
       ansible.builtin.include_tasks: "{{test_helper_dir}}/verify_dir.yaml"
       loop:
         - "/var/lib/config-data/ansible-generated/ovn-bgp-agent/etc/ovn-bgp-agent/bgp-agent.conf"
-        - "/var/log/containers/ovn-bgp-agent"
         - "/var/lib/edpm-config/container-startup-config/ovn_bgp_agent"
 
     - name: ensure podman container exists and are running

--- a/roles/edpm_ovn_bgp_agent/tasks/install.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/install.yml
@@ -24,7 +24,6 @@
     owner: "{{ ansible_user | default(ansible_user_id) }}"
     group: "{{ ansible_user | default(ansible_user_id) }}"
   loop:
-    - {'path': /var/log/containers/ovn-bgp-agent, 'setype': container_file_t, 'mode': '0750'}
     - {'path': "{{ edpm_ovn_bgp_agent_config_basedir }}", 'setype': container_file_t, 'mode': '0750'}
 
 - name: Create directory {{ edpm_ovn_bgp_agent_config_basedir }}

--- a/roles/edpm_ovn_bgp_agent/tasks/install_ovn.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/install_ovn.yml
@@ -22,7 +22,6 @@
     setype: "{{ item.setype }}"
     mode: "{{ item.mode | default(omit) }}"
   loop:
-    - {'path': /var/log/containers/openvswitch, 'setype': container_file_t, 'mode': '0750'}
     - {'path': /var/lib/openvswitch/ovn, 'setype': container_file_t}
 
 - name: Enable virt_sandbox_use_netlink for healthcheck

--- a/roles/edpm_ovn_bgp_agent/templates/kolla_config/bgp_ovn_controller.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/kolla_config/bgp_ovn_controller.yaml.j2
@@ -1,8 +1,1 @@
 command: "/usr/bin/ovn-controller -n bgp --pidfile=/var/run/openvswitch/bgp-ovn-controller.pid unix:/var/run/openvswitch/db.sock {% if edpm_ovn_bgp_agent_internal_tls_enable | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% endif %}"
-permissions:
-  - path: /var/log/openvswitch
-    owner: root:root
-    recurse: true
-  - path: /var/log/ovn
-    owner: root:root
-    recurse: true

--- a/roles/edpm_ovn_bgp_agent/templates/kolla_config/nb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/kolla_config/nb_db_server.yaml.j2
@@ -1,8 +1,1 @@
 command: "/usr/share/ovn/scripts/ovn-ctl --no-monitor run_nb_ovsdb {% if edpm_ovn_bgp_agent_internal_tls_enable | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% else %} --db-nb-create-insecure-remote=yes {% endif %}"
-permissions:
-  - path: /var/log/openvswitch
-    owner: root:root
-    recurse: true
-  - path: /var/log/ovn
-    owner: root:root
-    recurse: true

--- a/roles/edpm_ovn_bgp_agent/templates/kolla_config/northd.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/kolla_config/northd.yaml.j2
@@ -1,9 +1,2 @@
 #command: "/usr/share/ovn/scripts/ovn-ctl start_northd --ovnnb-db=unix:/var/run/ovn/ovnnb_db.sock --ovnsb-db=unix:/var/run/ovn/ovnsb_db.sock "
 command: "/usr/bin/ovn-northd --ovnnb-db=unix:/var/run/ovn/ovnnb_db.sock --ovnsb-db=unix:/var/run/ovn/ovnsb_db.sock {% if edpm_ovn_bgp_agent_internal_tls_enable | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% endif %}"
-permissions:
-  - path: /var/log/openvswitch
-    owner: root:root
-    recurse: true
-  - path: /var/log/ovn
-    owner: root:root
-    recurse: true

--- a/roles/edpm_ovn_bgp_agent/templates/kolla_config/ovn_bgp_agent.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/kolla_config/ovn_bgp_agent.yaml.j2
@@ -4,13 +4,3 @@ config_files:
     dest: /etc/ovn-bgp-agent/
     merge: true
     preserve_properties: true
-permissions:
-  - path: /var/log/ovn-bgp-agent
-    owner: ovn-bgp:ovn-bgp
-    recurse: true
-  - path: /var/log/openvswitch
-    owner: root:root
-    recurse: true
-  - path: /var/log/ovn
-    owner: root:root
-    recurse: true

--- a/roles/edpm_ovn_bgp_agent/templates/kolla_config/sb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/kolla_config/sb_db_server.yaml.j2
@@ -1,8 +1,1 @@
 command: "/usr/share/ovn/scripts/ovn-ctl --no-monitor run_sb_ovsdb {% if edpm_ovn_bgp_agent_internal_tls_enable | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% else %} --db-sb-create-insecure-remote=yes  {% endif %}"
-permissions:
-  - path: /var/log/openvswitch
-    owner: root:root
-    recurse: true
-  - path: /var/log/ovn
-    owner: root:root
-    recurse: true


### PR DESCRIPTION
Neutron services were changed only on OCP side as part of [1] but it was forgotten to change EDPM side too, tracked by [2]. This patch series removes logging to files and relies only on journald.

[1] https://issues.redhat.com/browse/OSPRH-154
[2] https://issues.redhat.com/browse/OSPRH-9248