### PR TITLE
Releasing version constraint to allow versions 2.15.0

### DIFF
--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,5 +1,5 @@
 # this is required for the docs build jobs
-ansible-core==2.14.6
+ansible-core>=2.15.0
 sphinx>=2.0.0,!=2.1.0 # BSD
 reno>=3.1.0 # Apache-2.0
 doc8>=0.8.1 # Apache-2.0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 ---
 
-requires_ansible: ">=2.14.0,<2.15.0"
+requires_ansible: ">=2.15.0"

--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -1,4 +1,4 @@
-ansible-core==2.14.6
+ansible-core>=2.15.0
 molecule>=5.1.0,<6.0.0
 molecule-plugins[podman,vagrant]>=23.5.0
 pytest-testinfra

--- a/openstack_ansibleee/Dockerfile
+++ b/openstack_ansibleee/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/creator-ee:v0.14.1 as builder
+FROM quay.io/ansible/creator-ee:v0.21.0 as builder
 
 ARG REMOTE_SOURCE=.
 ARG REMOTE_SOURCE_DIR=/var/tmp/edpm-ansible
@@ -8,7 +8,7 @@ RUN cd $REMOTE_SOURCE_DIR && \
     ansible-galaxy collection install -U --timeout 120 -r requirements.yml --collections-path "/usr/share/ansible/collections" && \
     ansible-galaxy collection install -U $REMOTE_SOURCE_DIR --collections-path "/usr/share/ansible/collections"
 
-FROM quay.io/ansible/creator-ee:v0.14.1 as runner
+FROM quay.io/ansible/creator-ee:v0.21.0 as runner
 
 RUN \
 microdnf install -y \

--- a/roles/edpm_bootstrap/molecule/molecule_config.yaml
+++ b/roles/edpm_bootstrap/molecule/molecule_config.yaml
@@ -22,7 +22,7 @@ provisioner:
   log: true
   config_options:
     interpreter_python: auto_silent
-    callback_whitelist: profile_tasks, timer, yaml
+    callbacks_enabled: profile_tasks, timer, yaml
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml
 


### PR DESCRIPTION
We can safely move on to the 2.15.* as there were no real breaking changes, with possible exception of `callback_whitelist`. [0]


[0] https://github.com/ansible/ansible/blob/stable-2.15/changelogs/CHANGELOG-v2.15.rst#id34 