### PR TITLE
Allow setting Zebra graceful_restart time

### DIFF
--- a/roles/edpm_frr/defaults/main.yml
+++ b/roles/edpm_frr/defaults/main.yml
@@ -64,6 +64,7 @@ edpm_frr_watchfrr: true
 edpm_frr_watchfrr_options: ''
 edpm_frr_zebra: true
 edpm_frr_zebra_nht_resolve_via_default: true
+edpm_frr_zebra_graceful_restart_time: ''
 edpm_frr_conf_custom_globals: ''
 edpm_frr_conf_custom_router_bgp: ''
 edpm_frr_conf_custom_ipv4: ''

--- a/roles/edpm_frr/meta/argument_specs.yml
+++ b/roles/edpm_frr/meta/argument_specs.yml
@@ -202,3 +202,7 @@ argument_specs:
         default: true
         description: ''
         type: bool
+      edpm_frr_zebra_graceful_restart_time:
+        default: ''
+        description: Zebra graceful_restart time (seconds)
+        type: str

--- a/roles/edpm_frr/templates/daemons.j2
+++ b/roles/edpm_frr/templates/daemons.j2
@@ -24,7 +24,11 @@ fabricd=no
 #
 # Command line options for the daemons
 #
+{% if edpm_frr_zebra_graceful_restart_time != '' %}
+zebra_options=("-A 127.0.0.1 -r -K {{ edpm_frr_zebra_graceful_restart_time |int }}")
+{% else %}
 zebra_options=("-A 127.0.0.1 -r")
+{% endif %}
 bgpd_options=("-A 127.0.0.1")
 ospfd_options=("-A 127.0.0.1")
 ospf6d_options=("-A ::1")


### PR DESCRIPTION
https://docs.frrouting.org/en/latest/zebra.html#cmdoption-zebra-K

"If this option is specified, the graceful restart time is TIME seconds. Zebra, when started, will read in routes. Those routes that Zebra identifies that it was the originator of will be swept in TIME seconds. If no time is specified then we will sweep those routes immediately."