### PR TITLE
[edpm_kernel] Improved kernel args block conditions

### DIFF
--- a/roles/edpm_kernel/molecule/kernelargs-update-substring/converge.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-substring/converge.yml
@@ -18,46 +18,14 @@
   hosts: all
   become: true
   pre_tasks:
+    - name: Importing test_vars
+      include_vars: "test_vars.yml"
     - name: Backing up /etc/default/grub
       import_tasks: ../../resources/molecule/backup_grub.yml
   tasks:
-    - name: First pass with custom variable
-      block:
-        - name: create kernelargs entry with the older name
-          lineinfile:
-            dest: /etc/default/grub
-            regexp: '^EDPM_KERNEL_ARGS.*'
-            insertafter: '^GRUB_CMDLINE_LINUX.*'
-            line: 'EDPM_KERNEL_ARGS=" {{ edpm_kernel_args }} "'
-        - name: create append entry with older name
-          lineinfile:
-            dest: /etc/default/grub
-            line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${EDPM_KERNEL_ARGS}"'
-            insertafter: '^EDPM_KERNEL_ARGS.*'
-        - include_role:
-            name: osp.edpm.edpm_kernel
-            tasks_from: kernelargs.yml
-          vars:
-            edpm_kernel_defer_reboot: true
+    - include_role:
+        name: osp.edpm.edpm_kernel
+        tasks_from: kernelargs.yml
       vars:
-        edpm_kernel_args: "isolcpus=1,3,5,7,9,11,13,15"
-    - name: Second pass with custom variable (substring of the first)
-      block:
-        - name: create kernelargs entry with the older name
-          lineinfile:
-            dest: /etc/default/grub
-            regexp: '^EDPM_KERNEL_ARGS.*'
-            insertafter: '^GRUB_CMDLINE_LINUX.*'
-            line: 'EDPM_KERNEL_ARGS=" {{ edpm_kernel_args }} "'
-        - name: create append entry with older name
-          lineinfile:
-            dest: /etc/default/grub
-            line: 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX:+$GRUB_CMDLINE_LINUX }${EDPM_KERNEL_ARGS}"'
-            insertafter: '^EDPM_KERNEL_ARGS.*'
-        - include_role:
-            name: osp.edpm.edpm_kernel
-            tasks_from: kernelargs.yml
-          vars:
-            edpm_kernel_defer_reboot: true
-      vars:
-        edpm_kernel_args: "isolcpus=1,3,5,7,9"
+        edpm_kernel_defer_reboot: true
+        cmdline: "{{ _mocked_cmdline }}"

--- a/roles/edpm_kernel/molecule/kernelargs-update-substring/test_vars.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-substring/test_vars.yml
@@ -1,0 +1,3 @@
+expected_line: 'GRUB_EDPM_KERNEL_ARGS=" default_hugepagesz=2048 hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 isolcpus=1 "'
+_mocked_cmdline: default_hugepagesz=2M hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 isolcpus=1,3
+edpm_kernel_args: default_hugepagesz=2M hugepagesz=2048 hugepages=10 hugepagesz=4096 hugepages=10 isolcpus=1

--- a/roles/edpm_kernel/molecule/kernelargs-update-substring/verify.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-substring/verify.yml
@@ -19,30 +19,34 @@
   hosts: all
   become: true
   gather_facts: false
-  vars:
-    tripleo_kernel_args: "isolcpus=1,3,5,7,9"
+  pre_tasks:
+    - name: Importing test_vars
+      include_vars: "test_vars.yml"
   tasks:
-    - name: Check if the variable is applied to the grub file
-      lineinfile:
-        path: /etc/default/grub
-        line: 'GRUB_EDPM_KERNEL_ARGS=" {{ tripleo_kernel_args }} "'
-        state: present
-      check_mode: true
-      register: grub
-      failed_when: (grub is changed) or (grub is failed)
-    - name: Check if the older name entries are removed
-      lineinfile:
-        path: /etc/default/grub
-        regexp: '^EDPM_KERNEL_ARGS.*'
-        state: absent
-      check_mode: true
-      register: grub
-      failed_when: (grub is changed) or (grub is failed)
-    - name: Check if the older name entries are removed for append
-      lineinfile:
-        path: /etc/default/grub
-        regexp: '.*{EDPM_KERNEL_ARGS}.*'
-        state: absent
-      check_mode: true
-      register: grub
-      failed_when: (grub is changed) or (grub is failed)
+    - name: Grub config validation
+      block:
+        - name: Check if the kernel args is applied to the grub file
+          lineinfile:
+            path: /etc/default/grub
+            line: "{{ expected_line }}"
+            state: present
+          check_mode: true
+          register: grub
+          failed_when: (grub is changed) or (grub is failed)
+        - name: Checking reboot_required
+          fail:
+            msg: |
+              reboot_required is defined and reboot_required is enabled
+          when:
+            - reboot_required is defined and reboot_required
+      rescue:
+        - name: Output /etc/default/grub
+          import_tasks: ../../resources/molecule/print_grub_content.yml
+        - name: Grub config validation failed
+          fail:
+            msg: |
+              reboot_required is defined and reboot_required is enabled: {{ reboot_required | default(false) }}
+              Grub config validation failed. Expected:
+              {{ expected_line }}
+              Validation task returned:
+              {{ grub }}

--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -64,8 +64,9 @@
   become: true
   when:
     - cmdline is defined
-    - edpm_kernel_args|string
-    - not (cmdline | regex_search( '^.*' + edpm_kernel_args + '.*$' | string ))
+    - edpm_kernel_args is defined
+    - edpm_kernel_args | type_debug == "AnsibleUnicode"
+    - cmdline is not regex( '^.*' ~ edpm_kernel_args ~ '\\s.*$' )
   block:
     # Leapp does not recognise grun entries starting other than GRUB
     # It results wrong formatting of entries in file /etc/default/grub


### PR DESCRIPTION
The conditions required to enter the kernel args configuration block have been refactored.

The regular expression that checks for the `edpm_kernel_args` variable value presence in the command line arguments has been rewritten to intercept the substrings of the same parameters.

Also, the molecule test for this particular scenario, `kernelargs-update-substring` has been rewritten to catch these kind of errors.