### PR TITLE
Change action for config with `restart` in container_manage to `created`

### DIFF
--- a/plugins/modules/edpm_container_manage.py
+++ b/plugins/modules/edpm_container_manage.py
@@ -317,6 +317,7 @@ class EdpmContainerManage:
             # NOTE(mwhahaha): converation from edpm format to podman as
             # systemd handles this restart config
             opts['restart'] = False
+            opts['state'] = 'created'
         if 'stop_grace_period' in opts:
             opts['stop_timeout'] = opts.pop('stop_grace_period')
 


### PR DESCRIPTION
Don't start container if restarted is set

If the container_manage is called with `restart` set, it means the
systemd handles the restart. In such case, we do not want containers to
be started because they will be started later by the systemd.

Resolves: [OSPRH-9812](https://issues.redhat.com//browse/OSPRH-9812)