### PR TITLE
Remove start_order from container configs

### DIFF
--- a/roles/edpm_frr/templates/frr.yaml.j2
+++ b/roles/edpm_frr/templates/frr.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 0
 image: "{{ edpm_frr_image }}"
 net: host
 privileged: false

--- a/roles/edpm_neutron_dhcp/templates/neutron_dhcp_agent.yaml.j2
+++ b/roles/edpm_neutron_dhcp/templates/neutron_dhcp_agent.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_neutron_dhcp_image }}"
 net: host
 pid: host

--- a/roles/edpm_neutron_metadata/templates/ovn_metadata_agent.yaml.j2
+++ b/roles/edpm_neutron_metadata/templates/ovn_metadata_agent.yaml.j2
@@ -7,7 +7,6 @@
         edpm_neutron_metadata_volumes +
         edpm_neutron_metadata_tls_volumes %}
 {%- endif -%}
-start_order: 2
 image: "{{ edpm_neutron_metadata_agent_image }}"
 net: host
 pid: host

--- a/roles/edpm_neutron_ovn/templates/ovn_agent.yaml.j2
+++ b/roles/edpm_neutron_ovn/templates/ovn_agent.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 2
 image: "{{ edpm_neutron_ovn_agent_image }}"
 net: host
 privileged: true

--- a/roles/edpm_neutron_sriov/templates/neutron_sriov_agent.yaml.j2
+++ b/roles/edpm_neutron_sriov/templates/neutron_sriov_agent.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_neutron_sriov_image }}"
 net: host
 privileged: true

--- a/roles/edpm_ovn/templates/ovn_controller.yaml.j2
+++ b/roles/edpm_ovn/templates/ovn_controller.yaml.j2
@@ -7,7 +7,6 @@
         edpm_ovn_controller_volumes +
         edpm_ovn_controller_tls_volumes %}
 {%- endif -%}
-start_order: 1
 image: "{{ edpm_ovn_controller_agent_image }}"
 net: host
 privileged: true

--- a/roles/edpm_ovn_bgp_agent/templates/bgp_ovn_controller.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/bgp_ovn_controller.yaml.j2
@@ -8,7 +8,6 @@
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
         edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes %}
 {%- endif -%}
-start_order: 1
 image: "{{ edpm_ovn_bgp_agent_local_ovn_controller_image }}"
 net: host
 privileged: true

--- a/roles/edpm_ovn_bgp_agent/templates/nb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/nb_db_server.yaml.j2
@@ -8,7 +8,6 @@
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
         edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes %}
 {%- endif -%}
-start_order: 1
 image: "{{ edpm_ovn_bgp_agent_local_ovn_nb_db_image }}"
 net: host
 privileged: true

--- a/roles/edpm_ovn_bgp_agent/templates/northd.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/northd.yaml.j2
@@ -8,7 +8,6 @@
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
         edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes %}
 {%- endif -%}
-start_order: 1
 image: "{{ edpm_ovn_bgp_agent_local_ovn_northd_image }}"
 net: host
 privileged: true

--- a/roles/edpm_ovn_bgp_agent/templates/ovn_bgp_agent.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/ovn_bgp_agent.yaml.j2
@@ -17,7 +17,6 @@
         edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes %}
 {%- endif %}
 {%- endif -%}
-start_order: 0
 image: "{{ edpm_ovn_bgp_agent_image }}"
 net: host
 privileged: true

--- a/roles/edpm_ovn_bgp_agent/templates/sb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/sb_db_server.yaml.j2
@@ -8,7 +8,6 @@
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
         edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes %}
 {%- endif -%}
-start_order: 1
 image: "{{ edpm_ovn_bgp_agent_local_ovn_sb_db_image }}"
 net: host
 privileged: true

--- a/roles/edpm_swift/templates/rsync.yaml.j2
+++ b/roles/edpm_swift/templates/rsync.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_object_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_account_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/swift_account_auditor.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_account_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_account_reaper.yaml.j2
+++ b/roles/edpm_swift/templates/swift_account_reaper.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_account_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_account_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/swift_account_replicator.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_account_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_account_server.yaml.j2
+++ b/roles/edpm_swift/templates/swift_account_server.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_account_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_container_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/swift_container_auditor.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_container_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_container_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/swift_container_replicator.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_container_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_container_server.yaml.j2
+++ b/roles/edpm_swift/templates/swift_container_server.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_container_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_container_updater.yaml.j2
+++ b/roles/edpm_swift/templates/swift_container_updater.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_container_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_object_auditor.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_auditor.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_object_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_object_expirer.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_expirer.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_proxy_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_object_replicator.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_replicator.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_object_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_object_server.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_server.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_object_image }}"
 net: host
 pid: host

--- a/roles/edpm_swift/templates/swift_object_updater.yaml.j2
+++ b/roles/edpm_swift/templates/swift_object_updater.yaml.j2
@@ -1,4 +1,3 @@
-start_order: 1
 image: "{{ edpm_swift_object_image }}"
 net: host
 pid: host


### PR DESCRIPTION
They have no relevance atm as containers are started individually with edpm_container_manage/edpm_container_standalone.