### PR TITLE
Check for AnsibleUnicode or str for edpm_kernel_args

### DIFF
--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -65,7 +65,7 @@
   when:
     - cmdline is defined
     - edpm_kernel_args is defined
-    - edpm_kernel_args | type_debug == "AnsibleUnicode"
+    - edpm_kernel_args | type_debug in ["AnsibleUnicode", "str"]
     - cmdline is not regex( '^.*' ~ edpm_kernel_args ~ '\\s.*$' )
   block:
     # Leapp does not recognise grun entries starting other than GRUB


### PR DESCRIPTION
The type of edpm_kernel_args could be a str, so both types need to be
checked, otherwise the whole block is skipped.

Jira: [OSPRH-10007](https://issues.redhat.com//browse/OSPRH-10007)
Signed-off-by: James Slagle <jslagle@redhat.com>
