### PR TITLE
Fix ansible roles to always mount the cacerts

### DIFF
--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -42,10 +42,9 @@ edpm_neutron_dhcp_common_volumes:
   - "{{ edpm_neutron_dhcp_agent_lib_dir }}/dhcp_agent_dnsmasq_wrapper:/usr/local/bin/dnsmasq:ro"
   - "{{ edpm_neutron_dhcp_agent_lib_dir }}/kill_scripts:/etc/neutron/kill_scripts:ro"
 
-edpm_neutron_dhcp_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_neutron_dhcp_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_neutron_dhcp_service_name }}"
-edpm_neutron_dhcp_tls_volumes:
-  - "{{ edpm_neutron_dhcp_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
+edpm_neutron_dhcp_tls_cacert_bundle_src: "/var/lib/openstack/cacerts/{{ edpm_neutron_dhcp_service_name }}/tls-ca-bundle.pem"
+edpm_neutron_dhcp_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+edpm_neutron_dhcp_tls_cacert_volumes: []
 
 # Sidecar containers settings
 edpm_neutron_dhcp_sidecar_debug: false

--- a/roles/edpm_neutron_dhcp/meta/argument_specs.yml
+++ b/roles/edpm_neutron_dhcp/meta/argument_specs.yml
@@ -46,11 +46,6 @@ argument_specs:
           - "{{ edpm_neutron_dhcp_agent_lib_dir }}/kill_scripts:/etc/neutron/kill_scripts:ro"
         description: List of volumes in a mount point form.
         type: list
-      edpm_neutron_dhcp_tls_enabled:
-        default: false
-        description: >
-          Should TLS cacerts be configured for neutron dhcp
-        type: bool
       edpm_neutron_dhcp_sidecar_debug:
         default: false
         description: "Enable or disable DEBUG mode in the sidecar wrappers scripts"

--- a/roles/edpm_neutron_dhcp/tasks/configure.yml
+++ b/roles/edpm_neutron_dhcp/tasks/configure.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_neutron_dhcp_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_neutron_dhcp_tls_cacert_volumes:
+          - "{{ edpm_neutron_dhcp_tls_cacert_bundle_src }}:{{ edpm_neutron_dhcp_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Configure neutron configuration files
   block:
     - name: Render neutron configuration files

--- a/roles/edpm_neutron_dhcp/templates/neutron_dhcp_agent.yaml.j2
+++ b/roles/edpm_neutron_dhcp/templates/neutron_dhcp_agent.yaml.j2
@@ -9,12 +9,8 @@ volumes:
   {% set edpm_neutron_dhcp_volumes = [] %}
   {%- set edpm_neutron_dhcp_volumes =
           edpm_neutron_dhcp_volumes +
-          edpm_neutron_dhcp_common_volumes %}
-{%- if edpm_neutron_dhcp_tls_enabled | bool %}
-  {%- set edpm_neutron_dhcp_volumes =
-          edpm_neutron_dhcp_volumes +
-          edpm_neutron_dhcp_tls_volumes %}
-{%- endif -%}
+          edpm_neutron_dhcp_common_volumes +
+          edpm_neutron_dhcp_tls_cacert_volumes %}
   {{ edpm_neutron_dhcp_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -57,9 +57,11 @@ edpm_neutron_metadata_agent_ovn_ovsdb_probe_interval: '60000'
 # tls
 edpm_neutron_metadata_agent_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 
+edpm_neutron_metadata_tls_cacert_bundle_src: "/var/lib/openstack/cacerts/{{ edpm_neutron_metadata_service_name }}/tls-ca-bundle.pem"
+edpm_neutron_metadata_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+edpm_neutron_metadata_tls_cacert_volumes: []
+
 edpm_neutron_metadata_tls_volumes:
   - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
   - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
   - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
-  - "/var/lib/openstack/cacerts/{{ edpm_neutron_metadata_service_name }}/tls-ca-bundle.pem:\
-    /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -137,4 +137,3 @@ argument_specs:
           - /var/lib/openstack/certs/neutron_metadata_agent/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z
           - /var/lib/openstack/certs/neutron_metadata_agent/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
           - /var/lib/openstack/certs/neutron_metadata_agent/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
-          - /var/lib/openstack/cacerts/neutron_metadata_agent/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z

--- a/roles/edpm_neutron_metadata/tasks/configure.yml
+++ b/roles/edpm_neutron_metadata/tasks/configure.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_neutron_metadata_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set cacert mount
+      ansible.builtin.set_fact:
+        edpm_neutron_metadata_tls_cacert_volumes:
+          - "{{ edpm_neutron_metadata_tls_cacert_bundle_src }}:{{ edpm_neutron_metadata_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Configure neutron configuration files
   block:
     - name: Render neutron config files

--- a/roles/edpm_neutron_metadata/templates/ovn_metadata_agent.yaml.j2
+++ b/roles/edpm_neutron_metadata/templates/ovn_metadata_agent.yaml.j2
@@ -1,7 +1,8 @@
 {%- set edpm_neutron_metadata_volumes = [] %}
 {%- set edpm_neutron_metadata_volumes =
         edpm_neutron_metadata_volumes +
-        edpm_neutron_metadata_common_volumes %}
+        edpm_neutron_metadata_common_volumes +
+        edpm_neutron_metadata_tls_cacert_volumes %}
 {%- if edpm_neutron_metadata_agent_tls_enabled | bool %}
 {%- set edpm_neutron_metadata_volumes =
         edpm_neutron_metadata_volumes +

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -21,12 +21,14 @@ edpm_neutron_ovn_common_volumes:
   - /var/lib/kolla/config_files/ovn_agent.json:/var/lib/kolla/config_files/config.json:ro
 
 edpm_neutron_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_neutron_ovn_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_neutron_ovn_service_name }}"
+edpm_neutron_ovn_tls_cacert_bundle_src: "/var/lib/openstack/cacerts/{{ edpm_neutron_ovn_service_name }}/tls-ca-bundle.pem"
+edpm_neutron_ovn_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+edpm_neutron_ovn_tls_cacert_volumes: []
+
 edpm_neutron_ovn_tls_volumes:
   - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
   - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
   - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
-  - "{{ edpm_neutron_ovn_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
 # Neutron conf
 # DEFAULT

--- a/roles/edpm_neutron_ovn/meta/argument_specs.yml
+++ b/roles/edpm_neutron_ovn/meta/argument_specs.yml
@@ -86,7 +86,7 @@ argument_specs:
       edpm_neutron_ovn_tls_enabled:
         default: false
         description: >
-          Should TLS certs and cacerts be configured for neutron ovn agent
+          Should TLS certs be configured for neutron ovn agent
         type: bool
       edpm_neutron_ovn_agent_config_src:
         default: "/var/lib/openstack/configs/neutron-ovn"

--- a/roles/edpm_neutron_ovn/tasks/configure.yml
+++ b/roles/edpm_neutron_ovn/tasks/configure.yml
@@ -13,6 +13,18 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_neutron_ovn_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_neutron_ovn_tls_cacert_volumes:
+          - "{{ edpm_neutron_ovn_tls_cacert_bundle_src }}:{{ edpm_neutron_ovn_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
 
 - name: Configure neutron configuration files
   block:

--- a/roles/edpm_neutron_ovn/templates/ovn_agent.yaml.j2
+++ b/roles/edpm_neutron_ovn/templates/ovn_agent.yaml.j2
@@ -9,7 +9,8 @@ volumes:
   {% set edpm_neutron_ovn_volumes = [] %}
   {%- set edpm_neutron_ovn_volumes =
           edpm_neutron_ovn_volumes +
-          edpm_neutron_ovn_common_volumes %}
+          edpm_neutron_ovn_common_volumes +
+          edpm_neutron_ovn_tls_cacert_volumes %}
 {%- if edpm_neutron_ovn_tls_enabled | bool %}
 {%- set edpm_neutron_ovn_volumes =
         edpm_neutron_ovn_volumes +

--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -38,10 +38,9 @@ edpm_neutron_sriov_common_volumes:
   - /var/lib/neutron:/var/lib/neutron:shared,z
   - /var/lib/kolla/config_files/neutron_sriov_agent.json:/var/lib/kolla/config_files/config.json:ro
 
-edpm_neutron_sriov_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
-edpm_neutron_sriov_tls_ca_src_dir: "/var/lib/openstack/cacerts/{{ edpm_neutron_sriov_service_name }}"
-edpm_neutron_sriov_tls_volumes:
-  - "{{ edpm_neutron_sriov_tls_ca_src_dir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
+edpm_neutron_sriov_tls_cacert_bundle_src: "/var/lib/openstack/cacerts/{{ edpm_neutron_sriov_service_name }}/tls-ca-bundle.pem"
+edpm_neutron_sriov_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+edpm_neutron_sriov_tls_cacert_volumes: []
 
 # neutron.conf
 # DEFAULT

--- a/roles/edpm_neutron_sriov/meta/argument_specs.yml
+++ b/roles/edpm_neutron_sriov/meta/argument_specs.yml
@@ -37,11 +37,6 @@ argument_specs:
           - /var/lib/kolla/config_files/neutron_sriov_agent.json:/var/lib/kolla/config_files/config.json:ro
         description: List of volumes in a mount point form.
         type: list
-      edpm_neutron_sriov_tls_enabled:
-        default: false
-        description: >
-          Should TLS cacerts be configured for neutron sriov
-        type: bool
       edpm_neutron_sriov_DEFAULT_debug:
         default: false
         description: "Enable or disable DEBUG mode in the Neutron agent"

--- a/roles/edpm_neutron_sriov/tasks/configure.yml
+++ b/roles/edpm_neutron_sriov/tasks/configure.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_neutron_sriov_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_neutron_sriov_tls_cacert_volumes:
+          - "{{ edpm_neutron_sriov_tls_cacert_bundle_src }}:{{ edpm_neutron_sriov_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Configure neutron configuration files
   block:
     - name: Render neutron configuration files

--- a/roles/edpm_neutron_sriov/templates/neutron_sriov_agent.yaml.j2
+++ b/roles/edpm_neutron_sriov/templates/neutron_sriov_agent.yaml.j2
@@ -7,12 +7,8 @@ volumes:
   {% set edpm_neutron_sriov_volumes = [] %}
   {%- set edpm_neutron_sriov_volumes =
           edpm_neutron_sriov_volumes +
-          edpm_neutron_sriov_common_volumes %}
-{%- if edpm_neutron_sriov_tls_enabled | bool %}
-  {%- set edpm_neutron_sriov_volumes =
-          edpm_neutron_sriov_volumes +
-          edpm_neutron_sriov_tls_volumes %}
-{%- endif -%}
+          edpm_neutron_sriov_common_volumes +
+          edpm_neutron_sriov_tls_cacert_volumes %}
   {{ edpm_neutron_sriov_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -62,11 +62,14 @@ edpm_ovn_controller_common_volumes:
   - /var/lib/openvswitch/ovn:/run/ovn:shared,z
   - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
 
+edpm_ovn_controller_tls_cacert_bundle_src: "/var/lib/openstack/cacerts/{{ edpm_ovn_service_name }}/tls-ca-bundle.pem"
+edpm_ovn_controller_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+edpm_ovn_controller_tls_cacert_volumes: []
+
 edpm_ovn_controller_tls_volumes:
   - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
   - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
   - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
-  - "/var/lib/openstack/cacerts/{{ edpm_ovn_service_name }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
 edpm_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -62,7 +62,6 @@ argument_specs:
           - /var/lib/openstack/certs/ovn/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z
           - /var/lib/openstack/certs/ovn/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
           - /var/lib/openstack/certs/ovn/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
-          - /var/lib/openstack/cacerts/ovn/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z
         description: List of TLS volumes in a mount point form.
         type: list
       edpm_ovn_dbs:

--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_ovn_controller_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_ovn_controller_tls_cacert_volumes:
+          - "{{ edpm_ovn_controller_tls_cacert_bundle_src }}:{{ edpm_ovn_controller_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Apply ovsdb configuration from configMaps
   block:
     - name: Check that config file exists

--- a/roles/edpm_ovn/templates/ovn_controller.yaml.j2
+++ b/roles/edpm_ovn/templates/ovn_controller.yaml.j2
@@ -1,7 +1,8 @@
 {%- set edpm_ovn_controller_volumes = [] %}
 {%- set edpm_ovn_controller_volumes =
         edpm_ovn_controller_volumes +
-        edpm_ovn_controller_common_volumes %}
+        edpm_ovn_controller_common_volumes +
+        edpm_ovn_controller_tls_cacert_volumes %}
 {%- if edpm_ovn_tls_enabled | bool %}
 {%- set edpm_ovn_controller_volumes =
         edpm_ovn_controller_volumes +

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -64,13 +64,16 @@ edpm_ovn_bgp_agent_common_volumes:
   - /run/frr:/run/frr:shared,z
   - /run/openvswitch:/run/openvswitch:shared,z
 
+edpm_ovn_bgp_agent_tls_cacert_bundle_src: "/var/lib/openstack/cacerts/{{ edpm_ovn_bgp_agent_service_name }}/tls-ca-bundle.pem"
+edpm_ovn_bgp_agent_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+edpm_ovn_bgp_agent_tls_cacert_volumes: []
+
 edpm_ovn_bgp_agent_tls_volumes:
   - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
   - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
   - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
-  - "/var/lib/openstack/cacerts/{{ edpm_ovn_bgp_agent_service_name }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 
-  # we need to add the InternalTLSCAFile and do a if/then/else in case tls-e
+# we need to add the InternalTLSCAFile and do a if/then/else in case tls-e
 
 # seconds between retries for download tasks
 edpm_ovn_bgp_agent_images_download_delay: 5
@@ -125,3 +128,4 @@ edpm_ovn_bgp_agent_local_ovn_northd_volumes:
   - /var/lib/kolla/config_files/northd.json:/var/lib/kolla/config_files/config.json:ro
 
 edpm_ovn_bgp_agent_local_ovn_cluster_tls_volumes: "{{ edpm_ovn_bgp_agent_tls_volumes }}"
+edpm_ovn_bgp_agent_local_ovn_cluster_tls_cacert_volumes: "{{ edpm_ovn_bgp_agent_tls_cacert_volumes }}"

--- a/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
+++ b/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
@@ -145,4 +145,3 @@ argument_specs:
           - "/var/lib/openstack/certs/ovn-bgp-agent/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
           - "/var/lib/openstack/certs/ovn-bgp-agent/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
           - "/var/lib/openstack/certs/ovn-bgp-agent/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
-          - "/var/lib/openstack/cacerts/ovn-bgp-agent/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"

--- a/roles/edpm_ovn_bgp_agent/tasks/configure.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/configure.yml
@@ -19,6 +19,21 @@
     name: osp.edpm.edpm_ovn
     tasks_from: "bootstrap.yml"
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_ovn_bgp_agent_tls_cacert_volumes:
+          - "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}:{{ edpm_ovn_bgp_agent_tls_cacert_bundle_dest }}:ro,z"
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_cacert_volumes:
+          - "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}:{{ edpm_ovn_bgp_agent_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Configure OVN BGP agent
   block:
     - name: Render OVN BGP agent config files

--- a/roles/edpm_ovn_bgp_agent/templates/bgp_ovn_controller.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/bgp_ovn_controller.yaml.j2
@@ -2,7 +2,8 @@
 {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
         edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-        edpm_ovn_bgp_agent_local_ovn_controller_volumes %}
+        edpm_ovn_bgp_agent_local_ovn_controller_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_cacert_volumes %}
 {%- if edpm_enable_internal_tls|bool %}
 {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +

--- a/roles/edpm_ovn_bgp_agent/templates/nb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/nb_db_server.yaml.j2
@@ -2,7 +2,8 @@
 {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
         edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-        edpm_ovn_bgp_agent_local_ovn_nb_volumes %}
+        edpm_ovn_bgp_agent_local_ovn_nb_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_cacert_volumes %}
 {%- if edpm_enable_internal_tls|bool %}
 {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +

--- a/roles/edpm_ovn_bgp_agent/templates/northd.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/northd.yaml.j2
@@ -2,7 +2,8 @@
 {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
         edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-        edpm_ovn_bgp_agent_local_ovn_northd_volumes %}
+        edpm_ovn_bgp_agent_local_ovn_northd_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_cacert_volumes %}
 {%- if edpm_enable_internal_tls|bool %}
 {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +

--- a/roles/edpm_ovn_bgp_agent/templates/ovn_bgp_agent.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/ovn_bgp_agent.yaml.j2
@@ -1,7 +1,8 @@
 {%- set edpm_ovn_bgp_agent_volumes = [] %}
 {%- set edpm_ovn_bgp_agent_volumes =
         edpm_ovn_bgp_agent_volumes +
-        edpm_ovn_bgp_agent_common_volumes %}
+        edpm_ovn_bgp_agent_common_volumes +
+        edpm_ovn_bgp_agent_tls_cacert_volumes %}
 {%- if edpm_ovn_bgp_agent_local_ovn_routing|bool %}
 {%- set edpm_ovn_bgp_agent_volumes =
         edpm_ovn_bgp_agent_volumes +

--- a/roles/edpm_ovn_bgp_agent/templates/sb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/sb_db_server.yaml.j2
@@ -2,7 +2,8 @@
 {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +
         edpm_ovn_bgp_agent_local_ovn_cluster_common_volumes +
-        edpm_ovn_bgp_agent_local_ovn_sb_volumes %}
+        edpm_ovn_bgp_agent_local_ovn_sb_volumes +
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_cacert_volumes %}
 {%- if edpm_enable_internal_tls|bool %}
 {%- set edpm_ovn_bgp_agent_local_ovn_cluster_volumes =
         edpm_ovn_bgp_agent_local_ovn_cluster_volumes +

--- a/roles/edpm_telemetry/tasks/configure.yml
+++ b/roles/edpm_telemetry/tasks/configure.yml
@@ -27,6 +27,11 @@
   loop:
     - {"path": "{{ edpm_telemetry_config_dest }}"}
 
+- name: Determine if cacert file exists
+  ansible.builtin.stat:
+    path: "{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem"
+  register: ca_bundle_stat_res
+
 - name: Render ceilometer config files
   tags:
     - edpm_telemetry
@@ -81,6 +86,8 @@
     mode: 0644
   with_fileglob:
     - ../templates/*.j2
+  vars:
+    ca_bundle_exists: "{{ ca_bundle_stat_res.stat.exists }}"
 
 - name: Check that tls.crt exists
   ansible.builtin.stat:

--- a/roles/edpm_telemetry/templates/ceilometer_agent_compute.json.j2
+++ b/roles/edpm_telemetry/templates/ceilometer_agent_compute.json.j2
@@ -17,7 +17,7 @@
         "/etc/pki/tls/certs/ca-bundle.trust.crt:/etc/pki/tls/certs/ca-bundle.trust.crt:ro",
         "/etc/localtime:/etc/localtime:ro",
         "/etc/pki/ca-trust/source/anchors:/etc/pki/ca-trust/source/anchors:ro",
-{% if edpm_telemetry_tls_certs_enabled %}
+{% if ca_bundle_exists|bool %}
 	"{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z",
 {% endif %}
         "/dev/log:/dev/log"

--- a/roles/edpm_telemetry/templates/ceilometer_agent_ipmi.json.j2
+++ b/roles/edpm_telemetry/templates/ceilometer_agent_ipmi.json.j2
@@ -16,7 +16,7 @@
         "/etc/pki/tls/certs/ca-bundle.trust.crt:/etc/pki/tls/certs/ca-bundle.trust.crt:ro",
         "/etc/localtime:/etc/localtime:ro",
         "/etc/pki/ca-trust/source/anchors:/etc/pki/ca-trust/source/anchors:ro",
-{% if edpm_telemetry_tls_certs_enabled %}
+{% if ca_bundle_exists|bool %}
         "{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z",
 {% endif %}
         "/dev/log:/dev/log"


### PR DESCRIPTION
If cacerts are present, they should be mounted
even if tls_enabled is not set as they could contain third party certs.

Fixes edpm_neutron_ovn, edpm_ovn, neutron_sriov,
neutron_metadata, edpm_ovn_bgp_agent, edpm_neutron_dhcp, telemetry

Jira: https://issues.redhat.com//browse/OSPRH-9451