### PR TITLE
Use OCP registries.conf with disconnected

### DIFF
--- a/roles/edpm_podman/defaults/main.yml
+++ b/roles/edpm_podman/defaults/main.yml
@@ -100,3 +100,6 @@ edpm_podman_kube_sa_path: /run/secrets/kubernetes.io/serviceaccount
 edpm_podman_kube_registry_url: default-route-openshift-image-registry.apps-crc.testing
 
 edpm_podman_auth_file: ~/.config/containers/auth.json
+
+edpm_podman_registries_conf: ""
+edpm_podman_disconnected_ocp: false

--- a/roles/edpm_podman/meta/argument_specs.yml
+++ b/roles/edpm_podman/meta/argument_specs.yml
@@ -153,3 +153,13 @@ argument_specs:
         type: str
         default: ~/.config/containers/auth.json
         description: Location of authentication file to be used by podman.
+      edpm_podman_registries_conf:
+        type: str
+        default: ""
+        description: "The registries.conf file contents that we will use on each node"
+      edpm_podman_disconnected_ocp:
+        type: bool
+        default: false
+        description: >
+          Indicates whether the OCP environment we're deployed from is using a custom
+          registry and specifically a ImageContentSourcePolicy to set registry mirrors.

--- a/roles/edpm_podman/tasks/install.yml
+++ b/roles/edpm_podman/tasks/install.yml
@@ -104,6 +104,17 @@
         group: root
         setype: etc_t
         mode: "0644"
+      when: not edpm_podman_disconnected_ocp
+
+    - name: Write containers registries.conf
+      ansible.builtin.template:
+        src: "{{ edpm_podman_registries_conf }}"
+        dest: /etc/containers/registries.conf
+        owner: root
+        group: root
+        setype: etc_t
+        mode: "0644"
+      when: edpm_podman_disconnected_ocp
 
     - name: Write containers.conf
       community.general.ini_file:


### PR DESCRIPTION
If we determine that the OCP cluster is deployed using a disconnected or private registry we will use OCP's registries.conf for consistency purposes. This change adds two values 'edpm_podman_registries_conf' and 'edpm_podman_disconnected_ocp'. These values are both provided to us via the openstack-operator dataplane utils package based on the logic implemented in: https://github.com/openstack-k8s-operators/openstack-operator/pull/1098

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1098
Jira: https://issues.redhat.com/browse/OSPRH-10304