### PR TITLE
Gather ssh key ansible facts for edpm-ssh-known-hosts

### DIFF
--- a/roles/edpm_ssh_known_hosts/tasks/main.yml
+++ b/roles/edpm_ssh_known_hosts/tasks/main.yml
@@ -46,6 +46,15 @@
       when:
         - _ssh_known_hosts.stat.exists | bool
 
+    - name: Gather facts if they don't exist
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - "ssh_host_key_rsa_public"
+          - "ssh_host_key_ed25519_public"
+          - "ssh_host_key_ecdsa_public"
+
     - name: Set ssh_known_hosts fact
       run_once: true
       ansible.builtin.set_fact:


### PR DESCRIPTION
This was missing from the PR which changed gather_facts default to false.