### PR TITLE
Add multinode tempest job to edpm-ansible

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -76,3 +76,6 @@
     parent: edpm-ansible-molecule-base
     vars:
       TEST_RUN: edpm_telemetry
+- job:
+    name: edpm-ansible-tempest-multinode
+    parent: openstack-operator-tempest-multinode

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -5,6 +5,7 @@
       - podified-multinode-edpm-baremetal-pipeline
     github-check:
       jobs:
+        - edpm-ansible-tempest-multinode
         - edpm-ansible-molecule-edpm_bootstrap
         - edpm-ansible-molecule-edpm_podman
         - edpm-ansible-molecule-edpm_module_load


### PR DESCRIPTION
Without it, we miss testing some of the roles like edpm-ssh-known-hosts.

Let's see if adding a parent from openstack-operator works. Else we have to copy the full definition.

jira: https://issues.redhat.com/browse/OSPRH-10307
