### PR TITLE
Don't fail in validating arguments if ansible_facts have not been gathered yet

### DIFF
--- a/roles/edpm_frr/meta/argument_specs.yml
+++ b/roles/edpm_frr/meta/argument_specs.yml
@@ -143,7 +143,7 @@ argument_specs:
         description: ''
         type: str
       edpm_frr_hostname:
-        default: '{{ ansible_facts[''hostname''] }}'
+        default: '{{ ansible_facts[''hostname''] | default("")}}'
         description: Dynamically retrieved from ansible facts.
         type: str
       edpm_frr_image:


### PR DESCRIPTION
We collect  ansible_facts when required, don't fail when validating arguments.

Jira: https://issues.redhat.com/browse/OSPRH-10338