### PR TITLE
frr and ovn-bgp-agent molecule tests don't gather facts

### DIFF
--- a/roles/edpm_frr/meta/argument_specs.yml
+++ b/roles/edpm_frr/meta/argument_specs.yml
@@ -143,7 +143,7 @@ argument_specs:
         description: ''
         type: str
       edpm_frr_hostname:
-        default: '{{ ansible_facts[''hostname''] | default("")}}'
+        default: '{{ ansible_facts[''hostname''] }}'
         description: Dynamically retrieved from ansible facts.
         type: str
       edpm_frr_image:

--- a/roles/edpm_frr/molecule/default/converge.yml
+++ b/roles/edpm_frr/molecule/default/converge.yml
@@ -16,6 +16,7 @@
 
 - name: Converge
   hosts: all
+  gather_facts: false
   become: true
   vars:
     edpm_download_cache_podman_auth_file: "" # Override since the file doesn't exist

--- a/roles/edpm_ovn_bgp_agent/molecule/default/converge.yml
+++ b/roles/edpm_ovn_bgp_agent/molecule/default/converge.yml
@@ -16,7 +16,7 @@
 
 - name: Converge
   hosts: all
-  gather_facts: true
+  gather_facts: false
   become: true
   roles:
     - role: "edpm_ovn_bgp_agent"


### PR DESCRIPTION
Recently, edpm-ansible roles were updated to not gather facts by default:
https://github.com/openstack-k8s-operators/edpm-ansible/pull/755

frr and ovn-bgp-agent molecule tests are updated to not gather facts as well.