### PR TITLE
Ensure fact cache is cleared before running frr molecule

### DIFF
--- a/roles/edpm_frr/molecule/default/converge.yml
+++ b/roles/edpm_frr/molecule/default/converge.yml
@@ -17,6 +17,7 @@
 - name: Converge
   hosts: all
   become: true
+  gather_facts: false
   vars:
     edpm_download_cache_podman_auth_file: "" # Override since the file doesn't exist
   pre_tasks:

--- a/roles/edpm_ovn_bgp_agent/molecule/default/converge.yml
+++ b/roles/edpm_ovn_bgp_agent/molecule/default/converge.yml
@@ -16,7 +16,7 @@
 
 - name: Converge
   hosts: all
-  gather_facts: true
+  gather_facts: false
   become: true
   roles:
     - role: "edpm_ovn_bgp_agent"


### PR DESCRIPTION
This change ensures fact_cache is cleared prior to converging the FRR molecule job. This ensures we are testing our role in conditions that we can expect to represent a real deployment.

Jira: https://issues.redhat.com/browse/OSPRH-10353
Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/764