### PR TITLE
Use edpm_ovs role for ovs installation

### DIFF
--- a/roles/edpm_neutron_dhcp/tasks/bootstrap.yml
+++ b/roles/edpm_neutron_dhcp/tasks/bootstrap.yml
@@ -16,5 +16,5 @@
 
 - name: Ensure Openvswitch installed and running
   ansible.builtin.include_role:
-    name: osp.edpm.edpm_ovn
-    tasks_from: "bootstrap.yml"
+    name: osp.edpm.edpm_ovs
+    tasks_from: "install.yml"

--- a/roles/edpm_neutron_metadata/tasks/bootstrap.yml
+++ b/roles/edpm_neutron_metadata/tasks/bootstrap.yml
@@ -16,5 +16,5 @@
 
 - name: Ensure Openvswitch installed and running
   ansible.builtin.include_role:
-    name: osp.edpm.edpm_ovn
-    tasks_from: "bootstrap.yml"
+    name: osp.edpm.edpm_ovs
+    tasks_from: "install.yml"

--- a/roles/edpm_neutron_ovn/tasks/bootstrap.yml
+++ b/roles/edpm_neutron_ovn/tasks/bootstrap.yml
@@ -16,5 +16,5 @@
 
 - name: Ensure Openvswitch installed and running
   ansible.builtin.include_role:
-    name: osp.edpm.edpm_ovn
-    tasks_from: "bootstrap.yml"
+    name: osp.edpm.edpm_ovs
+    tasks_from: "install.yml"

--- a/roles/edpm_ovn/tasks/bootstrap.yml
+++ b/roles/edpm_ovn/tasks/bootstrap.yml
@@ -14,14 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Ensure the Openvswitch package is installed
-  become: true
-  ansible.builtin.package:
-    name: openvswitch
-    state: present
-
-- name: Ensure the OVS service is running
-  become: true
-  ansible.builtin.systemd:
-    name: openvswitch
-    state: started
+- name: Ensure Openvswitch installed and running
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_ovs
+    tasks_from: "install.yml"

--- a/roles/edpm_ovn_bgp_agent/tasks/configure.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/configure.yml
@@ -16,8 +16,8 @@
 
 - name: Ensure Openvswitch installed and running
   ansible.builtin.include_role:
-    name: osp.edpm.edpm_ovn
-    tasks_from: "bootstrap.yml"
+    name: osp.edpm.edpm_ovs
+    tasks_from: "install.yml"
 
 - name: Set cacert mount if present
   block:

--- a/roles/edpm_ovn_bgp_agent/tasks/configure_ovn.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/configure_ovn.yml
@@ -16,8 +16,8 @@
 
 - name: Ensure Openvswitch installed and running
   ansible.builtin.include_role:
-    name: osp.edpm.edpm_ovn
-    tasks_from: "bootstrap.yml"
+    name: osp.edpm.edpm_ovs
+    tasks_from: "install.yml"
 
 - name: Configure OVS external_ids
   become: true


### PR DESCRIPTION
Currently each depending role has his own version of
ovs installation with hardcoded package name, this leads
to ovs upgrade during adoption and cause network downtime.
Reusing edpm_ovs role for ovs installation to avoid
the issue as it has option to override rpm name and
override is used during adoption to avoid ovs upgrade.

Related-Issue: [OSPRH-10283](https://issues.redhat.com//browse/OSPRH-10283)