### PR TITLE
Cleanup Tripleo systemd services from the /etc/systemd location also

### DIFF
--- a/roles/edpm_tripleo_cleanup/molecule/default/converge.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/converge.yml
@@ -7,3 +7,4 @@
       vars:
         edpm_old_tripleo_services:
           - fake-tripleo-service
+          - fake-etc-tripleo-service

--- a/roles/edpm_tripleo_cleanup/molecule/default/create_mock_service.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/create_mock_service.yml
@@ -6,14 +6,10 @@
     dest: "{{ item.path }}/{{ item.service_name }}.service"
     mode: '0644'
 
-- name: Enable mock service
+- name: Enable and start mock service
   become: true
   ansible.builtin.systemd_service:
     name: "{{ item.service_name }}"
     enabled: true
-
-- name: Start mock service
-  become: true
-  ansible.builtin.systemd_service:
-    name: "{{ item.service_name }}"
     state: started
+    daemon_reload: true

--- a/roles/edpm_tripleo_cleanup/molecule/default/create_mock_service.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/create_mock_service.yml
@@ -1,0 +1,19 @@
+---
+- name: Create mock service
+  become: true
+  ansible.builtin.copy:
+    src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/test-data/fake-tripleo-service.service"
+    dest: "{{ item.path }}/{{ item.service_name }}.service"
+    mode: '0644'
+
+- name: Enable mock service
+  become: true
+  ansible.builtin.systemd_service:
+    name: "{{ item.service_name }}"
+    enabled: true
+
+- name: Start mock service
+  become: true
+  ansible.builtin.systemd_service:
+    name: "{{ item.service_name }}"
+    state: started

--- a/roles/edpm_tripleo_cleanup/molecule/default/prepare.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/prepare.yml
@@ -21,21 +21,8 @@
       test_deps_extra_packages:
         - podman
   tasks:
-    - name: Create mock service
-      become: true
-      ansible.builtin.copy:
-        src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/test-data/fake-tripleo-service.service"
-        dest: /usr/lib/systemd/system/fake-tripleo-service.service
-        mode: '0644'
-
-    - name: Enable mock service
-      become: true
-      ansible.builtin.systemd_service:
-        name: fake-tripleo-service
-        enabled: true
-
-    - name: Start mock service
-      become: true
-      ansible.builtin.systemd_service:
-        name: fake-tripleo-service
-        state: started
+    - name: Create mock services
+      include_tasks: create_mock_service.yml
+      loop:
+        - { service_name: 'fake-tripleo-service', path: '/usr/lib/systemd/system' }
+        - { service_name: 'fake-etc-tripleo-service', path: '/etc/systemd/system' }

--- a/roles/edpm_tripleo_cleanup/molecule/default/verify.yml
+++ b/roles/edpm_tripleo_cleanup/molecule/default/verify.yml
@@ -3,8 +3,11 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Check if unit file exists and fail if it does
+    - name: Check if unit files exist and fail if it does
       ansible.builtin.file:
-        path: /usr/lib/systemd/system/fake-tripleo-service.service
+        path: "{{ item.path }}/{{ item.service_name }}.service"
         state: absent
       check_mode: true
+      loop:
+        - { service_name: 'fake-tripleo-service', path: '/usr/lib/systemd/system' }
+        - { service_name: 'fake-etc-tripleo-service', path: '/etc/systemd/system' }

--- a/roles/edpm_tripleo_cleanup/tasks/main.yml
+++ b/roles/edpm_tripleo_cleanup/tasks/main.yml
@@ -66,11 +66,12 @@
 - name: Remove unit files
   tags:
     - adoption
-  become: true
-  ansible.builtin.file:
-    path: /usr/lib/systemd/system/{{ item }}.service
-    state: absent
-  loop: "{{ tripleo_services }}"
+  ansible.builtin.include_tasks: remove_unit_files.yml
+  loop:
+    - /usr/lib/systemd/system
+    - /etc/systemd/system
+  loop_control:
+    loop_var: path
   when: edpm_remove_tripleo_unit_files
 
 - name: Adopt (stop tracking) certs from tripleo

--- a/roles/edpm_tripleo_cleanup/tasks/remove_unit_files.yml
+++ b/roles/edpm_tripleo_cleanup/tasks/remove_unit_files.yml
@@ -1,0 +1,9 @@
+---
+- name: "Remove unit files from the location: {{ path }}"
+  become: true
+  ansible.builtin.file:
+    path: "{{ path }}/{{ service_name }}.service"
+    state: absent
+  loop: "{{ tripleo_services }}"
+  loop_control:
+    loop_var: service_name


### PR DESCRIPTION
Previously edpm_tripleo_cleanup role was cleaning old service files only from the /usr/lib/systemd/system location but it seems that some services, like e.g. neutron and nova related things have their service files created in the /etc/systemd/system location.

This patch adds cleaning of the service files also from the /etc/systemd/system location.

Closes-bug: #[OSPRH-6703](https://issues.redhat.com//browse/OSPRH-6703)