### PR TITLE
Fix CAcert mounting

### DIFF
--- a/roles/edpm_neutron_dhcp/tasks/configure.yml
+++ b/roles/edpm_neutron_dhcp/tasks/configure.yml
@@ -14,19 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Set cacert mount if present
-  block:
-    - name: Determine if cacert file exists
-      ansible.builtin.stat:
-        path: "{{ edpm_neutron_dhcp_tls_cacert_bundle_src }}"
-      register: cacert_bundle_exists
-
-    - name: Set ca_cert mount
-      ansible.builtin.set_fact:
-        edpm_neutron_dhcp_tls_cacert_volumes:
-          - "{{ edpm_neutron_dhcp_tls_cacert_bundle_src }}:{{ edpm_neutron_dhcp_tls_cacert_bundle_dest }}:ro,z"
-      when: cacert_bundle_exists.stat.exists
-
 - name: Configure neutron configuration files
   block:
     - name: Render neutron configuration files

--- a/roles/edpm_neutron_dhcp/tasks/run.yml
+++ b/roles/edpm_neutron_dhcp/tasks/run.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_neutron_dhcp_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_neutron_dhcp_tls_cacert_volumes:
+          - "{{ edpm_neutron_dhcp_tls_cacert_bundle_src }}:{{ edpm_neutron_dhcp_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Ensure /usr/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage

--- a/roles/edpm_neutron_metadata/tasks/configure.yml
+++ b/roles/edpm_neutron_metadata/tasks/configure.yml
@@ -14,19 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Set cacert mount if present
-  block:
-    - name: Determine if cacert file exists
-      ansible.builtin.stat:
-        path: "{{ edpm_neutron_metadata_tls_cacert_bundle_src }}"
-      register: cacert_bundle_exists
-
-    - name: Set cacert mount
-      ansible.builtin.set_fact:
-        edpm_neutron_metadata_tls_cacert_volumes:
-          - "{{ edpm_neutron_metadata_tls_cacert_bundle_src }}:{{ edpm_neutron_metadata_tls_cacert_bundle_dest }}:ro,z"
-      when: cacert_bundle_exists.stat.exists
-
 - name: Configure neutron configuration files
   block:
     - name: Render neutron config files

--- a/roles/edpm_neutron_metadata/tasks/run.yml
+++ b/roles/edpm_neutron_metadata/tasks/run.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_neutron_metadata_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set cacert mount
+      ansible.builtin.set_fact:
+        edpm_neutron_metadata_tls_cacert_volumes:
+          - "{{ edpm_neutron_metadata_tls_cacert_bundle_src }}:{{ edpm_neutron_metadata_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Ensure /usr/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage

--- a/roles/edpm_neutron_ovn/tasks/configure.yml
+++ b/roles/edpm_neutron_ovn/tasks/configure.yml
@@ -13,18 +13,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-- name: Set cacert mount if present
-  block:
-    - name: Determine if cacert file exists
-      ansible.builtin.stat:
-        path: "{{ edpm_neutron_ovn_tls_cacert_bundle_src }}"
-      register: cacert_bundle_exists
-
-    - name: Set ca_cert mount
-      ansible.builtin.set_fact:
-        edpm_neutron_ovn_tls_cacert_volumes:
-          - "{{ edpm_neutron_ovn_tls_cacert_bundle_src }}:{{ edpm_neutron_ovn_tls_cacert_bundle_dest }}:ro,z"
-      when: cacert_bundle_exists.stat.exists
 
 - name: Gather facts if they don't exist
   when: "'system' not in ansible_facts"

--- a/roles/edpm_neutron_ovn/tasks/run.yml
+++ b/roles/edpm_neutron_ovn/tasks/run.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_neutron_ovn_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_neutron_ovn_tls_cacert_volumes:
+          - "{{ edpm_neutron_ovn_tls_cacert_bundle_src }}:{{ edpm_neutron_ovn_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Ensure /usr/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage

--- a/roles/edpm_neutron_sriov/tasks/configure.yml
+++ b/roles/edpm_neutron_sriov/tasks/configure.yml
@@ -14,19 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Set cacert mount if present
-  block:
-    - name: Determine if cacert file exists
-      ansible.builtin.stat:
-        path: "{{ edpm_neutron_sriov_tls_cacert_bundle_src }}"
-      register: cacert_bundle_exists
-
-    - name: Set ca_cert mount
-      ansible.builtin.set_fact:
-        edpm_neutron_sriov_tls_cacert_volumes:
-          - "{{ edpm_neutron_sriov_tls_cacert_bundle_src }}:{{ edpm_neutron_sriov_tls_cacert_bundle_dest }}:ro,z"
-      when: cacert_bundle_exists.stat.exists
-
 - name: Configure neutron configuration files
   block:
     - name: Render neutron configuration files

--- a/roles/edpm_neutron_sriov/tasks/run.yml
+++ b/roles/edpm_neutron_sriov/tasks/run.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_neutron_sriov_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_neutron_sriov_tls_cacert_volumes:
+          - "{{ edpm_neutron_sriov_tls_cacert_bundle_src }}:{{ edpm_neutron_sriov_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Ensure /usr/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage

--- a/roles/edpm_ovn/tasks/configure.yml
+++ b/roles/edpm_ovn/tasks/configure.yml
@@ -14,19 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Set cacert mount if present
-  block:
-    - name: Determine if cacert file exists
-      ansible.builtin.stat:
-        path: "{{ edpm_ovn_controller_tls_cacert_bundle_src }}"
-      register: cacert_bundle_exists
-
-    - name: Set ca_cert mount
-      ansible.builtin.set_fact:
-        edpm_ovn_controller_tls_cacert_volumes:
-          - "{{ edpm_ovn_controller_tls_cacert_bundle_src }}:{{ edpm_ovn_controller_tls_cacert_bundle_dest }}:ro,z"
-      when: cacert_bundle_exists.stat.exists
-
 - name: Apply ovsdb configuration from configMaps
   block:
     - name: Check that config file exists

--- a/roles/edpm_ovn/tasks/run.yml
+++ b/roles/edpm_ovn/tasks/run.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_ovn_controller_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_ovn_controller_tls_cacert_volumes:
+          - "{{ edpm_ovn_controller_tls_cacert_bundle_src }}:{{ edpm_ovn_controller_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Ensure /usr/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage

--- a/roles/edpm_ovn_bgp_agent/tasks/configure.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/configure.yml
@@ -19,21 +19,6 @@
     name: osp.edpm.edpm_ovn
     tasks_from: "bootstrap.yml"
 
-- name: Set cacert mount if present
-  block:
-    - name: Determine if cacert file exists
-      ansible.builtin.stat:
-        path: "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}"
-      register: cacert_bundle_exists
-
-    - name: Set ca_cert mount
-      ansible.builtin.set_fact:
-        edpm_ovn_bgp_agent_tls_cacert_volumes:
-          - "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}:{{ edpm_ovn_bgp_agent_tls_cacert_bundle_dest }}:ro,z"
-        edpm_ovn_bgp_agent_local_ovn_cluster_tls_cacert_volumes:
-          - "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}:{{ edpm_ovn_bgp_agent_tls_cacert_bundle_dest }}:ro,z"
-      when: cacert_bundle_exists.stat.exists
-
 - name: Configure OVN BGP agent
   block:
     - name: Render OVN BGP agent config files

--- a/roles/edpm_ovn_bgp_agent/tasks/run.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/run.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_ovn_bgp_agent_tls_cacert_volumes:
+          - "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}:{{ edpm_ovn_bgp_agent_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Ensure /usr/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: osp.edpm.edpm_container_manage

--- a/roles/edpm_ovn_bgp_agent/tasks/run_ovn.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/run_ovn.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cacert mount if present
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}"
+      register: cacert_bundle_exists
+
+    - name: Set ca_cert mount
+      ansible.builtin.set_fact:
+        edpm_ovn_bgp_agent_local_ovn_cluster_tls_cacert_volumes:
+          - "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}:{{ edpm_ovn_bgp_agent_tls_cacert_bundle_dest }}:ro,z"
+      when: cacert_bundle_exists.stat.exists
+
 - name: Ensure /usr/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage


### PR DESCRIPTION
The logic to determine whether to mount a cacert bundle was mistakenly placed in configure.yml instead of run.yaml where the templates that use this logic are generated. (run.yaml and run_ovn.yaml)  This breaks updates which execute run.yaml instead of configure.yaml

This patch moves the logic to the right place.
Resolves: https://issues.redhat.com/browse/OSPRH-10450