### PR TITLE
Fix creating huge pages

### DIFF
--- a/roles/edpm_extra_mounts/defaults/main.yml
+++ b/roles/edpm_extra_mounts/defaults/main.yml
@@ -23,5 +23,5 @@ edpm_extra_mounts_hide_sensitive_logs: true
 
 edpm_extra_mounts: []
 edpm_default_mounts: [
-  {name: 'hugepages1G', path: '/dev/hugepages1G', opts: 'pagesize=1G', fstype: 'hugetlbfs'},
-  {name: 'hugepages2M', path: /dev/hugepages2M, opts: 'pagesize=2M', fstype: 'hugetlbfs'}]
+  {path: '/dev/hugepages1G', opts: 'pagesize=1G', fstype: 'hugetlbfs', group: 'hugetlbfs'},
+  {path: /dev/hugepages2M, opts: 'pagesize=2M', fstype: 'hugetlbfs', group: 'hugetlbfs'}]

--- a/roles/edpm_extra_mounts/meta/argument_specs.yml
+++ b/roles/edpm_extra_mounts/meta/argument_specs.yml
@@ -11,21 +11,20 @@ argument_specs:
           A list of additional mounts (e.g. for nfs) to be added to the edpm compute node.
           The list should be in the form of a list of dictionaries with the
           following keys:
-          - name: The name of the mount by default /var/lib/nova/instances
-          - path: The path to the mount
+          - path: Path to the mount point by default /var/lib/nova/instances
+          - src: Device (or NFS volume, or something else) to be mounted on path.
           - opts: The options to set for the mount
           - fstype: The filesystem type by default nfs4
       edpm_default_mounts:
         type: list
         default: [
-          {name: 'hugepages1G', path: '/dev/hugepages1g', opts: 'pagesize=1G', fstype: 'hugetlbfs'},
-          {name: 'hugepages2M', path: /dev/hugepages2M, opts: 'pagesize=2M', fstype: 'hugetlbfs'}]
+          {path: '/dev/hugepages1g', opts: 'pagesize=1G', fstype: 'hugetlbfs'},
+          {path: /dev/hugepages2M, opts: 'pagesize=2M', fstype: 'hugetlbfs'}]
         description: |
           A list of mounts by default it is used to create hugepage mounts to be added to the edpm compute node.
           The list should be in the form of a list of dictionaries with the
           following keys:
-          - name: The name of the hugepage mount
-          - path: The path to the hugepage mount, this will be crated
+          - path: Path to the mount point eg. /dev/hugepages1g
           - opts: The options to set for the hugepage mount
           - fstype: The filesystem type by default hugetlbfs
           Optional keys:

--- a/roles/edpm_extra_mounts/molecule/default/converge.yml
+++ b/roles/edpm_extra_mounts/molecule/default/converge.yml
@@ -25,11 +25,10 @@
       vars:
         edpm_extra_mounts: []
         edpm_default_mounts:
-          - name: 'hugepages1G'
-            path: '/dev/hugepages1G'
+          - path: '/dev/hugepages1G'
             opts: 'pagesize=1G'
             fstype: 'hugetlbfs'
-          - name: 'hugepages2MB'
-            path: '/dev/hugepages2MB'
+            group: 'hugetlbfs'
+          - path: '/dev/hugepages2MB'
             opts: 'pagesize=2M'
             fstype: 'hugetlbfs'

--- a/roles/edpm_extra_mounts/tasks/extra_mounts.yml
+++ b/roles/edpm_extra_mounts/tasks/extra_mounts.yml
@@ -29,8 +29,8 @@
 - name: Mount extra and default directories
   become: true
   ansible.posix.mount:
-    name: "{{ item.name }}"
-    src: "{{ item.path }}"
+    path: "{{ item.path }}"
+    src: "{{ item.src | default('none') }}"
     fstype: "{{ item.fstype }}"
     opts: "{{ item.opts }}"
     state: mounted


### PR DESCRIPTION
hugepages shoudn't have mounted path, only name

Conflicts:
    roles/edpm_extra_mounts/defaults/main.yml
    roles/edpm_extra_mounts/molecule/default/converge.yml

conflcits were resolved by accpeting the incoming version

Closes: [OSPRH-10215](https://issues.redhat.com//browse/OSPRH-10215)
(cherry picked from commit ca0fe3ced6ebb837ad0d0b0994857d986c2c9cd4)
