### PR TITLE
Pin antsibul-docs to fix html_docs

### DIFF
--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -6,7 +6,7 @@ doc8>=0.8.1 # Apache-2.0
 bashate>=0.6.0 # Apache-2.0
 jsonschema  # MIT
 ruamel.yaml
-antsibull-docs >= 2.0.0, < 3.0.0
+antsibull-docs >= 2.0.0, < 2.15.0
 ansible-pygments >= 0.1.1
 sphinx-ansible-theme >= 0.9.0
 pyyaml!=5.4.0,!=5.4.1 # https://github.com/yaml/pyyaml/issues/601


### PR DESCRIPTION
Latest antsibull-docs 2.15.0 uses pydantic v2 which has broken the way we use it to override documentation argspec parsing.