### PR TITLE
Fix ceilometer ipmi agent volume mounts

### DIFF
--- a/roles/edpm_telemetry_power_monitoring/defaults/main.yml
+++ b/roles/edpm_telemetry_power_monitoring/defaults/main.yml
@@ -19,7 +19,7 @@
 # Service name this role manages
 edpm_telemetry_service_name: telemetry
 # Directory in the ansibleEE container
-edpm_telemetry_config_src: "/var/lib/openstack/configs/{{ edpm_telemetry_service_name }}"
+edpm_telemetry_config_src: "/var/lib/openstack/configs/{{ edpm_telemetry_service_name }}-power-monitoring"
 # Directory in the compute node
 edpm_telemetry_config_dest: "/var/lib/openstack/config/{{ edpm_telemetry_service_name }}"
 # Image to use for Ceilometer Ipmi


### PR DESCRIPTION
The configurations for ipmi agent service in ansibleee pod would be stored under "/var/lib/openstack/configs/telemetry-power-monitoring" and not "/var/lib/openstack/configs/telemetry".