### PR TITLE
Update creator-ee image

### DIFF
--- a/openstack_ansibleee/Dockerfile
+++ b/openstack_ansibleee/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/creator-ee:v0.21.0 as builder
+FROM quay.io/ansible/creator-ee:v24.2.0 as builder
 
 ARG REMOTE_SOURCE=.
 ARG REMOTE_SOURCE_DIR=/var/tmp/edpm-ansible
@@ -8,7 +8,7 @@ RUN cd $REMOTE_SOURCE_DIR && \
     ansible-galaxy collection install -U --timeout 120 -r requirements.yml --collections-path "/usr/share/ansible/collections" && \
     ansible-galaxy collection install -U $REMOTE_SOURCE_DIR --collections-path "/usr/share/ansible/collections"
 
-FROM quay.io/ansible/creator-ee:v0.21.0 as runner
+FROM quay.io/ansible/creator-ee:v24.2.0 as runner
 
 RUN \
 microdnf install -y \


### PR DESCRIPTION
this is the last tag of [quay.io/ansible/creator-ee](https://quay.io/repository/ansible/creator-ee?tab=tags&tag=latest)
Alternatively, we can move to ansible-dev-tools image: https://github.com/openstack-k8s-operators/edpm-ansible/pull/788