### PR TITLE
Replace creator-ee with ansible-dev-tools image

### DIFF
--- a/openstack_ansibleee/Dockerfile
+++ b/openstack_ansibleee/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/creator-ee:v0.21.0 as builder
+FROM ghcr.io/ansible/community-ansible-dev-tools:v24.10.0 as builder
 
 ARG REMOTE_SOURCE=.
 ARG REMOTE_SOURCE_DIR=/var/tmp/edpm-ansible
@@ -8,20 +8,16 @@ RUN cd $REMOTE_SOURCE_DIR && \
     ansible-galaxy collection install -U --timeout 120 -r requirements.yml --collections-path "/usr/share/ansible/collections" && \
     ansible-galaxy collection install -U $REMOTE_SOURCE_DIR --collections-path "/usr/share/ansible/collections"
 
-FROM quay.io/ansible/creator-ee:v0.21.0 as runner
+FROM ghcr.io/ansible/community-ansible-dev-tools:v24.10.0 as runner
 
-RUN \
-microdnf install -y \
-# we are installing ansible.posix with rsync, but we aren't installing rsync itself
-rsync
 COPY --from=builder /usr/share/ansible /usr/share/ansible
-
 COPY $REMOTE_SOURCE/openstack_ansibleee/settings /runner/env/settings
-RUN chmod 775 /runner/env/settings
-COPY $REMOTE_SOURCE/openstack_ansibleee/edpm_entrypoint.sh /bin/edpm_entrypoint
-RUN sed -i '1d' /bin/entrypoint
-RUN cat /bin/entrypoint >> /bin/edpm_entrypoint
-RUN chmod +x /bin/edpm_entrypoint
+COPY $REMOTE_SOURCE/openstack_ansibleee/edpm_entrypoint.sh /opt/builder/bin/edpm_entrypoint
+
+RUN sed '1d' /opt/builder/bin/entrypoint >> /opt/builder/bin/edpm_entrypoint
+RUN chmod 775 /runner/env/settings && chmod +x /opt/builder/bin/edpm_entrypoint && chmod ug+rw /etc/passwd
+
 ENV EDPM_SYSTEMROLES='fedora.linux_system_roles'
 WORKDIR /runner
-ENTRYPOINT ["edpm_entrypoint"]
+LABEL ansible-execution-environment=true
+ENTRYPOINT ["/opt/builder/bin/edpm_entrypoint", "dumb-init"]

--- a/plugins/filter/helpers.py
+++ b/plugins/filter/helpers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright 2019 Red Hat, Inc.
 # All Rights Reserved.
 #

--- a/plugins/modules/edpm_nftables_from_files.py
+++ b/plugins/modules/edpm_nftables_from_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # Copyright 2021 Red Hat, Inc.
 # All Rights Reserved.
 #

--- a/plugins/modules/edpm_nftables_snippet.py
+++ b/plugins/modules/edpm_nftables_snippet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # Copyright 2021 Red Hat, Inc.
 # All Rights Reserved.
 #


### PR DESCRIPTION
As [quay.io/ansible/creator-ee](https://quay.io/repository/ansible/creator-ee?tab=tags&tag=latest)  is no longer maintained: https://github.com/ansible/creator-ee

closes [OSPRH-10743](https://issues.redhat.com//browse/OSPRH-10743)