### PR TITLE
Add prometheus-podman-exporter deployment

### DIFF
--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -24,6 +24,8 @@ edpm_telemetry_config_src: "/var/lib/openstack/configs/{{ edpm_telemetry_service
 edpm_telemetry_config_dest: "/var/lib/openstack/config/{{ edpm_telemetry_service_name }}"
 # Image to use for node_exporter
 edpm_telemetry_node_exporter_image: quay.io/prometheus/node-exporter:v1.5.0
+# Image to use for podman_exporter
+edpm_telemetry_podman_exporter_image: quay.io/navidys/prometheus-podman-exporter:v1.10.1
 # Image to use for Ceilometer
 edpm_telemetry_ceilometer_compute_image: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
 # Certificates location for tls encryption
@@ -43,6 +45,7 @@ edpm_telemetry_old_tripleo_compute_sevices:
 edpm_telemetry_healthcheck_sources:
   ceilometer_agent_compute: ceilometer_agent
   node_exporter: exporter
+  podman_exporter: exporter
 #  kepler: exporter
 # If telemetry services should have health checks enabled
 edpm_telemetry_healthcheck: true

--- a/roles/edpm_telemetry/meta/argument_specs.yml
+++ b/roles/edpm_telemetry/meta/argument_specs.yml
@@ -23,6 +23,10 @@ argument_specs:
         type: "str"
         required: true
         description: "The name of the node_exporter podman image"
+      edpm_telemetry_podman_exporter_image:
+        type: "str"
+        required: true
+        description: "The name of the podman_exporter podman image"
       edpm_telemetry_ceilometer_compute_image:
         type: "str"
         required: true

--- a/roles/edpm_telemetry/tasks/install.yml
+++ b/roles/edpm_telemetry/tasks/install.yml
@@ -53,11 +53,34 @@
     edpm_container_manage_config_patterns: "node_exporter.json"
     edpm_container_manage_clean_orphans: false
 
+- name: Deploy podman_exporter container
+  block:
+    - name: Start podman.socket service
+      ansible.builtin.systemd_service:
+        name: podman.socket
+        state: started
+        enabled: true
+      become: true
+    - name: Start podman_exporter container
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_container_manage
+      vars:
+        edpm_container_manage_config: "{{ edpm_telemetry_config_dest }}"
+        edpm_container_manage_healthcheck_disabled: true
+        edpm_container_manage_config_patterns: "podman_exporter.json"
+        edpm_container_manage_clean_orphans: false
+
 - name: Restart node_exporter
   become: true
   ansible.builtin.systemd:
     state: restarted
     name: edpm_node_exporter.service
+
+- name: Restart podman_exporter
+  become: true
+  ansible.builtin.systemd:
+    state: restarted
+    name: edpm_podman_exporter.service
 
 - name: Restart ceilometer compute
   become: true

--- a/roles/edpm_telemetry/templates/podman_exporter.json.j2
+++ b/roles/edpm_telemetry/templates/podman_exporter.json.j2
@@ -1,0 +1,22 @@
+{
+    "image": "{{ edpm_telemetry_podman_exporter_image }}",
+    "restart": "always",
+    "recreate": true,
+    "user": "root",
+    "privileged": true,
+    "ports": ["9882:9882"],
+    "net": "host",
+    "environment": {
+        "OS_ENDPOINT_TYPE": "internal",
+        "CONTAINER_HOST": "unix:///run/podman/podman.sock"
+    },
+{% if edpm_telemetry_healthcheck %}
+    "healthcheck": {
+        "test": "/openstack/healthcheck podman_exporter",
+        "mount": "/var/lib/openstack/healthchecks/podman_exporter"
+    },
+{% endif %}
+    "volumes": [
+       "/run/podman/podman.sock:/run/podman/podman.sock:rw,z"
+    ]
+}


### PR DESCRIPTION
This PR adds prometheus-podman-exporter container deployment
which serves for reporting health of containerized services.

Related: [OBSDA-574](https://issues.redhat.com/browse/OBSDA-574)
Related: [OSPRH-1052](https://issues.redhat.com/browse/OSPRH-1052)
Closes: [OSPRH-5007](https://issues.redhat.com/browse/OSPRH-5007)