### PR TITLE
Change default number of ovn-metadata-workers to 1

### DIFF
--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -47,7 +47,7 @@ edpm_neutron_metadata_agent_rootwrap_DEFAULT_rlimit_nofile: '1024'
 
 # neutron-ovn-metadata-agent.conf
 edpm_neutron_metadata_agent_DEFAULT_debug: 'True'
-edpm_neutron_metadata_agent_DEFAULT_metadata_workers: '2'
+edpm_neutron_metadata_agent_DEFAULT_metadata_workers: '1'
 edpm_neutron_metadata_agent_DEFAULT_state_path: '/var/lib/neutron'
 edpm_neutron_metadata_agent_agent_root_helper: 'sudo neutron-rootwrap /etc/neutron/rootwrap.conf'
 edpm_neutron_metadata_agent_ovs_ovsdb_connection: 'tcp:127.0.0.1:6640'

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -35,7 +35,7 @@ argument_specs:
         description: ''
         type: str
       edpm_neutron_metadata_agent_DEFAULT_metadata_workers:
-        default: '2'
+        default: '1'
         description: ''
         type: str
       edpm_neutron_metadata_agent_DEFAULT_nova_metadata_host:


### PR DESCRIPTION
This was set by default to '2' but according to the KCS article [1] it is recommended to have it set to '1'. If necessary it can be overwritten through the OpenStackDataPlaneNodeSet CR.

[1] https://access.redhat.com/solutions/6666911

Closes: #[OSPRH-10780](https://issues.redhat.com//browse/OSPRH-10780)