### PR TITLE
Do not store power monitoring config files with telemetry

### DIFF
--- a/roles/edpm_telemetry_power_monitoring/defaults/main.yml
+++ b/roles/edpm_telemetry_power_monitoring/defaults/main.yml
@@ -17,9 +17,9 @@
 
 # All variables intended for modification should be placed in this file.
 # Service name this role manages
-edpm_telemetry_service_name: telemetry
+edpm_telemetry_service_name: telemetry_power_monitoring
 # Directory in the ansibleEE container
-edpm_telemetry_config_src: "/var/lib/openstack/configs/{{ edpm_telemetry_service_name }}-power-monitoring"
+edpm_telemetry_config_src: "/var/lib/openstack/configs/telemetry-power-monitoring"
 # Directory in the compute node
 edpm_telemetry_config_dest: "/var/lib/openstack/config/{{ edpm_telemetry_service_name }}"
 # Image to use for Ceilometer Ipmi

--- a/roles/edpm_telemetry_power_monitoring/meta/argument_specs.yml
+++ b/roles/edpm_telemetry_power_monitoring/meta/argument_specs.yml
@@ -47,3 +47,10 @@ argument_specs:
         type: str
         required: true
         description: "Kepler image url"
+      edpm_telemetry_power_monitoring_healthcheck_sources:
+        type: dict
+        required: true
+        description: >
+          Contains information about distribution of container health check scripts.
+          Keys state for container names and value is name of a script directory
+          from module's files directory.

--- a/roles/edpm_telemetry_power_monitoring/templates/kepler.json.j2
+++ b/roles/edpm_telemetry_power_monitoring/templates/kepler.json.j2
@@ -4,6 +4,7 @@
     "restart": "always",
     "ports": ["8888:8888"],
     "command": "-v 2",
+    "recreate": true,
     "environment": {
         "ENABLE_GPU": "true",
         "ENABLE_MSR": "true",


### PR DESCRIPTION
Since, ipmi agent is deployed by power monitoring role it's configuration should not be stored with telemetry services. This is necessary since both require different polling.yaml files.