### PR TITLE
Fix validate systemd-container package task

### DIFF
--- a/roles/edpm_pre_adoption_validation/molecule/machined-check/converge.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/machined-check/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Converge
+      block:
+        - name: "Include role"
+          ansible.builtin.include_role:
+            name: osp.edpm.edpm_pre_adoption_validation

--- a/roles/edpm_pre_adoption_validation/molecule/machined-check/molecule.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/machined-check/molecule.yml
@@ -1,0 +1,33 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+- name: edpm-0
+  command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        vars:
+          edpm_pre_adoption_validation_hostname_enabled: false
+          edpm_pre_adoption_validation_kernel_args_enabled: false
+          edpm_pre_adoption_validation_tuned_enabled: false
+          edpm_pre_adoption_validation_machined_enabled: true
+
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+     - destroy
+     - create
+     - prepare
+     - converge

--- a/roles/edpm_pre_adoption_validation/molecule/machined-check/prepare.yml
+++ b/roles/edpm_pre_adoption_validation/molecule/machined-check/prepare.yml
@@ -14,19 +14,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
-- name: Validate hostname
-  when: edpm_pre_adoption_validation_hostname_enabled
-  ansible.builtin.include_tasks: hostname.yml
-
-- name: Validate kernel_args
-  when: edpm_pre_adoption_validation_kernel_args_enabled
-  ansible.builtin.include_tasks: kernel_args.yml
-
-- name: Validate tuned profile
-  when: edpm_pre_adoption_validation_tuned_enabled
-  ansible.builtin.include_tasks: tuned.yml
-
-- name: Validate systemd-container package
-  when: edpm_pre_adoption_validation_machined_enabled
-  ansible.builtin.include_tasks: machined.yml
+- name: Prepare
+  hosts: all
+  roles:
+    - role: ../../../../molecule/common/test_deps  # noqa: role-name[path]
+      vars:
+        test_deps_setup_edpm: true
+        test_deps_setup_cifmw: true
+        test_deps_edpm_packages: []
+    - role: osp.edpm.env_data
+- name: Setup machined
+  hosts: all
+  pre_tasks:
+    - name: Install systemd-container
+      become: true
+      ansible.builtin.package:
+        name: systemd-container
+        state: present
+  tasks: []

--- a/roles/edpm_pre_adoption_validation/tasks/machined.yml
+++ b/roles/edpm_pre_adoption_validation/tasks/machined.yml
@@ -23,11 +23,13 @@
     state: present
   check_mode: true
   register: is_systemd_container_package
+  failed_when: false
 
 - name: Fail when systemd-container package is missing
   ansible.builtin.assert:
     that:
-      - is_systemd_container_package.changed
+      - not is_systemd_container_package.changed
+      - ("No package systemd-container available." not in is_systemd_container_package.failures | default([]))
     success_msg: Found installed systemd-container package
     fail_msg: |
       You must have the systemd-container package installed.


### PR DESCRIPTION
Fix validate systemd-container package task
Add postitive check test case
Include machined task instead of tuned

JIRA: #[OSPRH-10318](https://issues.redhat.com/browse/OSPRH-10318)