### PR TITLE
Don't use rescue with any_errors_fatal: true

### DIFF
--- a/roles/edpm_frr/tasks/configure.yml
+++ b/roles/edpm_frr/tasks/configure.yml
@@ -31,12 +31,15 @@
     - name: Construct FRR uplink interfaces from os-net-config mappings
       ansible.builtin.set_fact:
         edpm_frr_bgp_uplinks_mapped: "{{ edpm_frr_bgp_uplinks | map('extract', iface_map) | list }}"
-  rescue:
+      register: check_edpm_frr_bgp_uplinks_mapped
+      ignore_errors: true
+
     - name: Failed to construct FRR uplink interfaces
       ansible.builtin.fail:
         msg: |
           Failed to map at least one interface from {{ edpm_frr_bgp_uplinks }} to {{ iface_map }}.
           Please check value of Ansible variable edpm_frr_bgp_uplinks.
+      when: check_edpm_frr_bgp_uplinks_mapped is failed
 
 - name: Gather facts if they don't exist
   when: "'system' not in ansible_facts"

--- a/roles/edpm_users/tasks/create_users_and_groups.yml
+++ b/roles/edpm_users/tasks/create_users_and_groups.yml
@@ -23,14 +23,20 @@
       ansible.builtin.getent:
         database: passwd
         key: "{{ item.name }}"
-  rescue:
+      register: user_check
+      ignore_errors: true
+
     - name: Ensure group is present on the host [ {{ item.name }} ]
       ansible.builtin.group:
         name: "{{ item.name }}"
         gid: "{{ item.gid }}"
         state: present
+      when: user_check is failed
+
     - name: Ensure user is present on the host [ {{ item.name }} ]
-      when: not (item.group_only | default(false))
+      when:
+        - not (item.group_only | default(false))
+        - user_check is failed
       ansible.builtin.user:
         name: "{{ item.name }}"
         uid: "{{ item.uid }}"


### PR DESCRIPTION
This seems broken with ansible 2.17.x. Also the current logic of running certain tasks for failed hosts won't work with `any_errors_fatal: true` as it would run them for all nodes.

Jira: https://issues.redhat.com/browse/OSPRH-11264