### PR TITLE
Fix removal of old tripleo services unit files

### DIFF
--- a/roles/edpm_tripleo_cleanup/tasks/remove_unit_files.yml
+++ b/roles/edpm_tripleo_cleanup/tasks/remove_unit_files.yml
@@ -2,7 +2,7 @@
 - name: "Remove unit files from the location: {{ path }}"
   become: true
   ansible.builtin.file:
-    path: "{{ path }}/{{ service_name }}.service"
+    path: "{{ path }}/{{ service_name }}"
     state: absent
   loop: "{{ tripleo_services }}"
   loop_control:


### PR DESCRIPTION
File names which should be removed had automatically added ".service" extension to the name which ended up with names like "tripleo-service.service.service" as names of the services already have ".service" suffix in their names so adding it to the file name wasn't necessary.

Closes: #[OSPRH-11323](https://issues.redhat.com//browse/OSPRH-11323)