### PR TITLE
Inject user provided nft rules

### DIFF
--- a/roles/edpm_nftables/defaults/main.yml
+++ b/roles/edpm_nftables/defaults/main.yml
@@ -21,3 +21,4 @@
 edpm_nftables_src: /var/lib/edpm-config/firewall
 edpm_nftables_default_chains_prefix: EDPM
 edpm_nftables_debug: false
+edpm_nftables_user_rules: []

--- a/roles/edpm_nftables/molecule/action/converge.yml
+++ b/roles/edpm_nftables/molecule/action/converge.yml
@@ -21,16 +21,35 @@
   become: true
   vars:
     edpm_nftables_src: /opt/edpm-firewall
+    edpm_nftables_user_rules: |
+          - rule_name: '011 testing user action'
+            rule:
+              proto: udp
+              dport: 1211
+              action: accept
+          - rule_name: '021 user string port-range check'
+            rule:
+              proto: udp
+              dport: 5555-5558
+              action: drop
   tasks:
     - name: Run role
       ansible.builtin.import_role:
         name: osp.edpm.edpm_nftables
         tasks_from: configure.yml
+
     - name: "Ensure we drop connections on TCP/1211"
       lineinfile:
         path: /etc/nftables/edpm-rules.nft
         line: 'add rule inet filter EDPM_INPUT tcp dport { 1211 } ct state new counter drop comment "010 testing action"'
       register: line_in_file
+
+    - name: "Ensure we accept connections on UDP/1211"
+      lineinfile:
+        path: /etc/nftables/edpm-rules.nft
+        line: 'add rule inet filter EDPM_INPUT udp dport { 1211 } ct state new counter accept comment "011 testing user action"'
+      register: udp_line_in_file
+      failed_when: udp_line_in_file.changed
 
     - name: Clean everything nftables related
       import_role:

--- a/roles/edpm_nftables/tasks/configure.yml
+++ b/roles/edpm_nftables/tasks/configure.yml
@@ -31,6 +31,12 @@
         src: base-rules.yaml.j2
         mode: "0644"
 
+    - name: Write user rules snippet
+      ansible.builtin.copy:
+        dest: "{{ edpm_nftables_src }}/edpm-nftables-user-rules.yaml"
+        content: "{{ edpm_nftables_user_rules }}"
+        mode: "0644"
+
 - name: IPtables compatibility layout
   become: true
   block:


### PR DESCRIPTION
This change ensures that user provided rules are injected into the edpm_nftables_src directory and loaded during rule generation.

The change adds a new variable to facilitate a user interface for rule injection edpm_nftables_user_rules.

Jira: https://issues.redhat.com/browse/OSPRH-11347