### PR TITLE
[BGP] Fix TLS options for local OVN DB creation

### DIFF
--- a/roles/edpm_ovn_bgp_agent/templates/kolla_config/nb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/kolla_config/nb_db_server.yaml.j2
@@ -1,1 +1,12 @@
-command: "/usr/share/ovn/scripts/ovn-ctl --no-monitor run_nb_ovsdb {% if edpm_ovn_bgp_agent_internal_tls_enable | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% else %} --db-nb-create-insecure-remote=yes {% endif %}"
+command: >-
+  /usr/share/ovn/scripts/ovn-ctl --no-monitor run_nb_ovsdb
+  {% if edpm_ovn_bgp_agent_internal_tls_enable | bool %}
+  --ovn-nb-db-ssl-key=/etc/pki/tls/private/ovndb.key
+  --ovn-nb-db-ssl-cert=/etc/pki/tls/certs/ovndb.crt
+  --ovn-nb-db-ssl-ca-cert=/etc/pki/tls/certs/ovndbca.crt
+  --db-nb-cluster-local-proto=ssl
+  --db-nb-cluster-remote-proto=ssl
+  --db-nb-create-insecure-remote=no
+  {% else %}
+  --db-nb-create-insecure-remote=yes
+  {% endif %}

--- a/roles/edpm_ovn_bgp_agent/templates/kolla_config/sb_db_server.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/kolla_config/sb_db_server.yaml.j2
@@ -1,1 +1,12 @@
-command: "/usr/share/ovn/scripts/ovn-ctl --no-monitor run_sb_ovsdb {% if edpm_ovn_bgp_agent_internal_tls_enable | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% else %} --db-sb-create-insecure-remote=yes  {% endif %}"
+command: >-
+  /usr/share/ovn/scripts/ovn-ctl --no-monitor run_sb_ovsdb
+  {% if edpm_ovn_bgp_agent_internal_tls_enable | bool %}
+  --ovn-sb-db-ssl-key=/etc/pki/tls/private/ovndb.key
+  --ovn-sb-db-ssl-cert=/etc/pki/tls/certs/ovndb.crt
+  --ovn-sb-db-ssl-ca-cert=/etc/pki/tls/certs/ovndbca.crt
+  --db-sb-cluster-local-proto=ssl
+  --db-sb-cluster-remote-proto=ssl
+  --db-sb-create-insecure-remote=no
+  {% else %}
+  --db-sb-create-insecure-remote=yes
+  {% endif %}


### PR DESCRIPTION
The options added to the ovn-ctl commands used to create local OVN NB and SB DBs when TLS was enabled were wrong.
With this PR, the correct options are used instead.

Jira: [OSPRH-11428](https://issues.redhat.com//browse/OSPRH-11428)