### PR TITLE
Use copy instead of template for disconnected registries.conf

### DIFF
--- a/roles/edpm_podman/tasks/install.yml
+++ b/roles/edpm_podman/tasks/install.yml
@@ -107,8 +107,8 @@
       when: not edpm_podman_disconnected_ocp
 
     - name: Write containers registries.conf
-      ansible.builtin.template:
-        src: "{{ edpm_podman_registries_conf }}"
+      ansible.builtin.copy:
+        content: "{{ edpm_podman_registries_conf }}"
         dest: /etc/containers/registries.conf
         owner: root
         group: root


### PR DESCRIPTION
This change switches the Ansible module from template to copy for writing the disconnected registries.conf file. Since trying to use `src` in the `template` module looks for a path and not content.

Jira: https://issues.redhat.com/browse/OSPRH-11475