### PR TITLE
Add nw connectivity task to all playbooks

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -1,13 +1,6 @@
 ---
 - name: Check remote connections
-  hosts: "{{ edpm_override_hosts | default('all', true) }}"
-  strategy: linear
-  gather_facts: "{{ gather_facts | default(false) }}"
-  tasks:
-    - name: Wait for connection
-      ansible.builtin.wait_for_connection:
-        delay: "{{ edpm_wait_for_connection_delay | default(10) }}"
-        timeout: "{{ edpm_wait_for_connection_timeout | default(600) }}"
+  ansible.builtin.import_playbook: connection.yml
 - name: Bootstrap node
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/ceph_client.yml
+++ b/playbooks/ceph_client.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Configure EDPM as client of Ceph
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/ceph_hci_pre.yml
+++ b/playbooks/ceph_hci_pre.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Prepare EDPM to Host Ceph
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/configure_network.yml
+++ b/playbooks/configure_network.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM Network
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/configure_os.yml
+++ b/playbooks/configure_os.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM Operating System Configure
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/configure_ovs_dpdk.yml
+++ b/playbooks/configure_ovs_dpdk.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Configure OvS DPDK
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/connection.yml
+++ b/playbooks/connection.yml
@@ -1,0 +1,9 @@
+---
+- name: Check remote connections
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  gather_facts: false
+  tasks:
+    - name: Check remote connections
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_nodes_validation
+        tasks_from: connection.yml

--- a/playbooks/download_cache.yml
+++ b/playbooks/download_cache.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: EDPM Download cache
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/fips_status.yml
+++ b/playbooks/fips_status.yml
@@ -1,4 +1,6 @@
 ---
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: FIPS status
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/frr.yml
+++ b/playbooks/frr.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM FRR
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/install_certs.yml
+++ b/playbooks/install_certs.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: EDPM Install Certs
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: free

--- a/playbooks/install_os.yml
+++ b/playbooks/install_os.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM Operating System Install
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/libvirt.yml
+++ b/playbooks/libvirt.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM libvirt
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/neutron_dhcp.yml
+++ b/playbooks/neutron_dhcp.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM Neutron DHCP agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/neutron_metadata.yml
+++ b/playbooks/neutron_metadata.yml
@@ -1,4 +1,6 @@
 ---
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM Neutron OVN Metadata agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/neutron_ovn.yaml
+++ b/playbooks/neutron_ovn.yaml
@@ -1,4 +1,6 @@
 ---
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM Neutron OVN agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/neutron_sriov.yml
+++ b/playbooks/neutron_sriov.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM Neutron SR-IOV agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/nova.yml
+++ b/playbooks/nova.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Deploy EDPM Nova storage infrastructure
   ansible.builtin.import_playbook: nova_storage.yml
 - name: Deploy EDPM Nova

--- a/playbooks/nova_storage.yml
+++ b/playbooks/nova_storage.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy Nova storage infrastructure
   hosts: all
   strategy: linear

--- a/playbooks/ovn.yml
+++ b/playbooks/ovn.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM OVN
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/ovn_bgp_agent.yml
+++ b/playbooks/ovn_bgp_agent.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM OVN BGP Agent
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/pre_adoption_validation.yml
+++ b/playbooks/pre_adoption_validation.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Validate adoption configuration
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/reboot.yml
+++ b/playbooks/reboot.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Reboot nodes if reboot is required
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/run_os.yml
+++ b/playbooks/run_os.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM Operating System Run
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/select_kernel_ddp_package.yml
+++ b/playbooks/select_kernel_ddp_package.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Select Kernel DDP Package
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/sriov_derive_device_spec.yml
+++ b/playbooks/sriov_derive_device_spec.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Derive sriov device_spec
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/ssh_known_hosts.yml
+++ b/playbooks/ssh_known_hosts.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM SSH Known Hosts
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/swift.yml
+++ b/playbooks/swift.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM Swift
   hosts: all
   strategy: linear

--- a/playbooks/telemetry.yml
+++ b/playbooks/telemetry.yml
@@ -14,7 +14,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM telemetry metrics
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/telemetry_logging.yml
+++ b/playbooks/telemetry_logging.yml
@@ -14,7 +14,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Configure EDPM telemetry logging
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/telemetry_power_monitoring.yml
+++ b/playbooks/telemetry_power_monitoring.yml
@@ -14,7 +14,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: Deploy EDPM telemetry power monitoring services
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: EDPM Update
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/playbooks/validate_network.yml
+++ b/playbooks/validate_network.yml
@@ -1,5 +1,6 @@
 ---
-
+- name: Check remote connections
+  ansible.builtin.import_playbook: connection.yml
 - name: EDPM Node validation
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear

--- a/roles/edpm_nodes_validation/tasks/connection.yml
+++ b/roles/edpm_nodes_validation/tasks/connection.yml
@@ -14,15 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Check remote connections
-  ansible.builtin.import_playbook: connection.yml
-- name: Cleanup Tripleo services
-  hosts: "{{ edpm_override_hosts | default('all', true) }}"
-  strategy: linear
-  gather_facts: "{{ gather_facts | default(false) }}"
-  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
-  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
-  tasks:
-    - name: Stop and disable Tripleo services
-      ansible.builtin.import_role:
-        name: osp.edpm.edpm_tripleo_cleanup
+- name: Wait for connection
+  ansible.builtin.wait_for_connection:
+    delay: "{{ edpm_wait_for_connection_delay | default(10) }}"
+    timeout: "{{ edpm_wait_for_connection_timeout | default(600) }}"


### PR DESCRIPTION
When using bgp where pods using a network-attachment-definition it takes some seconds to advertise it on the fabric. As a result roles which don't have a the connectivity task check will fail.

A rerun of the ansible jobs will not fix this because every time the deployment job pod gets created it will receive a new ip from the ctlplane pool.

There were discussions on a more generic way on slack, for now lets just add the check to all the playbooks which is already there on the bootstrap playbook:
https://github.com/openstack-k8s-operators/edpm-ansible/blob/6615889c5d708df2accb7dafec5aa099946292b8/playbooks/bootstrap.yml#L8

Jira: https://issues.redhat.com/browse/OSPRH-8680