### PR TITLE
Escalate privs for NetworkManager-ovs install

### DIFF
--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -16,6 +16,7 @@
 
 - name: Configure network with network role from system roles [nmstate]
   when: edpm_network_config_tool == 'nmstate'
+  become: true
   block:
     - name: Install OVS NetworkManager plugin [nmstate]
       ansible.builtin.dnf:


### PR DESCRIPTION
When installing packages, we need to escalate privileges. This change adds become: true to the block that is installing NetworkManager-ovs for use with nmstate.

Jira: https://issues.redhat.com/browse/OSPRH-11663