### PR TITLE
Add missing mount required to capture GPU metrics

### DIFF
--- a/roles/edpm_telemetry_power_monitoring/templates/kepler.json.j2
+++ b/roles/edpm_telemetry_power_monitoring/templates/kepler.json.j2
@@ -19,6 +19,7 @@
     },
 {% endif %}
     "volumes": [
+        "/lib/modules:/lib/modules:ro",
         "/run/libvirt:/run/libvirt:shared,ro",
         "/sys/:/sys/",
         "/proc:/proc"


### PR DESCRIPTION
Closes: [OSPRH-11890](https://issues.redhat.com/browse/OSPRH-11890)