### PR TITLE
Use PAM for sshd Motd

### DIFF
--- a/roles/edpm_sshd/tasks/configure.yml
+++ b/roles/edpm_sshd/tasks/configure.yml
@@ -74,10 +74,15 @@
          {% if edpm_sshd_banner_enabled %}
          {% set _ = edpm_sshd_server_options.__setitem__('Banner', '/etc/issue') %}
          {% endif %}
-         {% if edpm_sshd_motd_enabled %}
-         {% set _ = edpm_sshd_server_options.__setitem__('PrintMotd', 'yes') %}
-         {% endif %}
          {{ edpm_sshd_server_options }}
+
+    - name: Set sshd motd when enabled
+      ansible.builtin.lineinfile:
+        path: /etc/pam.d/sshd
+        regexp: "^session.*optional.*pam_motd.so"
+        line: "session    optional     pam_motd.so motd=/etc/motd"
+        state: present
+      when: edpm_sshd_motd_enabled
 
     - name: Adjust ssh server configuration
       become: true


### PR DESCRIPTION
This change switches the method we use to display the motd. Previously, we used PrintMotd in the sshd config. RHEL9 configures mod_motd.so in PAM, and as such the motd will be duplicated when using PrintMotd. To avoid this, we can configure the motd via PAM.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2329414