### PR TITLE
Explicitly set PrintMotd to no

### DIFF
--- a/roles/edpm_sshd/defaults/main.yml
+++ b/roles/edpm_sshd/defaults/main.yml
@@ -56,6 +56,7 @@ edpm_sshd_server_options:
     - 'LC_IDENTIFICATION LC_ALL LANGUAGE'
     - 'XMODIFIERS'
   Subsystem: 'sftp /usr/libexec/openssh/sftp-server'
+  PrintMotd: 'no'
 
 # Firewall configuration part
 edpm_sshd_configure_firewall: true

--- a/roles/edpm_sshd/meta/argument_specs.yml
+++ b/roles/edpm_sshd/meta/argument_specs.yml
@@ -58,6 +58,7 @@ argument_specs:
             - 'LC_IDENTIFICATION LC_ALL LANGUAGE'
             - 'XMODIFIERS'
           Subsystem: 'sftp /usr/libexec/openssh/sftp-server'
+          PrintMotd: 'no'
       edpm_sshd_configure_firewall:
         type: bool
         default: false


### PR DESCRIPTION
This change explicitly sets PrintMotd to no in the sshd_config. PrintMotd defaults to yes, and we're now using PAM to manage our motd requirements in RHEL9:

https://www.man7.org/linux/man-pages/man8/pam_motd.8.html 
https://www.man7.org/linux/man-pages/man5/sshd_config.5.html