### PR TITLE
Prevent NM from automatic (DHCP) configuration on ethernet devices

### DIFF
--- a/playbooks/configure_network.yml
+++ b/playbooks/configure_network.yml
@@ -12,7 +12,7 @@
         name: osp.edpm.edpm_ovs
       tags:
         - edpm_ovs
-    # Sets up network using OVS
+    # Sets up EDPM network using os-net-config
     - name: Import edpm_network_config
       ansible.builtin.import_role:
         name: osp.edpm.edpm_network_config

--- a/roles/edpm_network_config/molecule/default/converge.yml
+++ b/roles/edpm_network_config/molecule/default/converge.yml
@@ -33,5 +33,6 @@
               next_hop: 192.168.180.1
     edpm_network_config_manage_service: false
     edpm_network_config_hide_sensitive_logs: false
+    edpm_network_config_nmstate: false
   roles:
     - role: "osp.edpm.edpm_network_config"

--- a/roles/edpm_network_config/molecule/default/prepare.yml
+++ b/roles/edpm_network_config/molecule/default/prepare.yml
@@ -22,6 +22,7 @@
       test_deps_setup_edpm: true
       test_deps_extra_packages:
         - iproute
+        - NetworkManager
 - name: Prepare
   hosts: all
   gather_facts: false
@@ -34,7 +35,7 @@
         name: network-scripts
         state: present
       when:
-        - ansible_facts['distribution_major_version'] is version('8', '==')
+        - ansible_facts['distribution_major_version'] is version('8', '>=')
     - name: Create a dummy network interface
       ansible.builtin.command: "ip link add dummy0 type dummy"
       register: ip_command_output

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -46,7 +46,25 @@
     - name: Load system-roles.network tasks [nmstate]
       ansible.builtin.include_role:
         name: "{{ lookup('ansible.builtin.env', 'EDPM_SYSTEMROLES', default='fedora.linux_system_roles') + '.network' }}"
-- name: Load edpm_network_config tasks [os-net-config]
-  ansible.builtin.include_tasks:
-    file: network_config.yml
+
+- name: Disable auto-configuration of all interfaces by NetworkManager
   when: edpm_network_config_tool == 'os-net-config'
+  become: true
+  block:
+    - name: Set 'no-auto-default' in /etc/NetworkManager/NetworkManager.conf
+      community.general.ini_file:
+        path: /etc/NetworkManager/NetworkManager.conf
+        state: present
+        mode: "0644"
+        no_extra_spaces: true
+        section: main
+        option: no-auto-default
+        value: "*"
+        backup: true
+    - name: Restart NetworkManager
+      ansible.builtin.systemd:
+        name: NetworkManager
+        state: restarted
+    - name: Load edpm_network_config tasks for os-net-config tool
+      ansible.builtin.include_tasks:
+        file: network_config.yml


### PR DESCRIPTION
When edpm_network_config role uses os-net-config to perform host network configuration, duplicate DHCP requests from NM are causing connectivity issue. Eg.

https://issues.redhat.com/browse/OSPRH-9142

This fix prevents NM from configure DHCP by default

This PR replaces an older [PR](https://github.com/openstack-k8s-operators/edpm-ansible/pull/720)