### PR TITLE
Partial Revert "Use PAM for sshd Motd"

### DIFF
--- a/roles/edpm_sshd/tasks/configure.yml
+++ b/roles/edpm_sshd/tasks/configure.yml
@@ -76,14 +76,6 @@
          {% endif %}
          {{ edpm_sshd_server_options }}
 
-    - name: Set sshd motd when enabled
-      ansible.builtin.lineinfile:
-        path: /etc/pam.d/sshd
-        regexp: "^session.*optional.*pam_motd.so"
-        line: "session    optional     pam_motd.so motd=/etc/motd"
-        state: present
-      when: edpm_sshd_motd_enabled
-
     - name: Adjust ssh server configuration
       become: true
       ansible.builtin.template:


### PR DESCRIPTION
This partially reverts commit e032cf239ff7cf74912ec6308527846b69de4621. RHEL9 and greater will use PAM by default. We only need to ensure PrintMotd is set to "no" to avoid duplication of the motd message.

We changed the default for PrintMotd in:
https://github.com/openstack-k8s-operators/edpm-ansible/pull/838

This change ensures that we don't override the PrintMotd value and instead we allow users to be explicit about this, otherwise, we default to no.