### PR TITLE
Document nmstate as experimental and require an override to use it

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -22,10 +22,13 @@
 # This variable let the use choose which tool will be used to configure networking on hosts
 # Accepted values are:
 # * os-net-config (default) -> the os-net-config will be used
-# * nmstate -> the network role from linux-system-roles/rhel-system-roles will be used to
+# * nmstate (experimental, unsupported) -> the network role from linux-system-roles/rhel-system-roles will be used to
 #   configure networking on hosts. In particular, the nmstate tool should cover all the
 #   supported scenario. Refer to nmstate.io for configuration snippets.
 edpm_network_config_tool: os-net-config
+
+# Must be set to true to allow usage of nmstate as edpm_network_config_tool
+edpm_network_config_tool_nmstate_override: false
 
 # Packages needed by nmstate (via system-role)
 edpm_network_config_systemrole_nmstate_dependencies:

--- a/roles/edpm_network_config/molecule/nmstate/converge.yml
+++ b/roles/edpm_network_config/molecule/nmstate/converge.yml
@@ -21,6 +21,7 @@
   vars:
     # edpm_network_config - nmstate
     edpm_network_config_tool: 'nmstate'
+    edpm_network_config_tool_nmstate_override: true
     edpm_network_config_template: |
       ---
       interfaces:

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -14,6 +14,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Fail when edpm_network_config_tool=nmstate unless edpm_network_config_tool_nmstate_override=true
+  ansible.builtin.fail:
+    msg: |
+      edpm_network_config_tool=nmstate is experimental and not supported.
+      Set edpm_network_config_tool_nmstate_override=true to continue anyway.
+  when:
+    - edpm_network_config_tool == 'nmstate'
+    - not edpm_network_config_tool_nmstate_override|bool
+
 - name: Configure network with network role from system roles [nmstate]
   when: edpm_network_config_tool == 'nmstate'
   become: true


### PR DESCRIPTION
"edpm_network_config_tool: nmstate" is experimental and officially
unsupported. This change will require users to explicitly opt-in to
using nmstate directly instead of using os-net-config+nmstate. It adds a
task that will fail unless edpm_network_config_tool_nmstate_override is
set to true (defaults to false).

Signed-off-by: James Slagle <jslagle@redhat.com>
Jira: https://issues.redhat.com/browse/OSPRH-12316
