### PR TITLE
Stop and disable iscsi-starter.service

### DIFF
--- a/roles/edpm_iscsid/tasks/install.yml
+++ b/roles/edpm_iscsid/tasks/install.yml
@@ -46,22 +46,15 @@
     - name: Gather services facts
       ansible.builtin.service_facts:
 
-    - name: Stop and disable iscsi.service
+    - name: Stop and disable iscsi.service and iscsi-starter.service 
       ansible.builtin.systemd:
-        name: iscsi.service
+        name: "{{ item }}"
         state: stopped
         enabled: false
       when:
-        - ansible_facts.services["iscsi.service"] is defined
-        - ansible_facts.services["iscsi.service"]["status"] != "not-found"
-        - ansible_facts.services["iscsi.service"]["status"] == "enabled"
-
-    - name: Stop and disable iscsi-starter.service
-      ansible.builtin.systemd:
-        name: iscsi-starter.service
-        state: stopped
-        enabled: false
-      when:
-        - ansible_facts.services["iscsi-starter.service"] is defined
-        - ansible_facts.services["iscsi-starter.service"]["status"] != "not-found"
-        - ansible_facts.services["iscsi-starter.service"]["status"] == "enabled"
+        - ansible_facts.services["item"] is defined
+        - ansible_facts.services["item"]["status"] != "not-found"
+        - ansible_facts.services["item"]["status"] == "enabled"
+      loop:
+        - iscsi.service
+        - iscsi-starter.service

--- a/roles/edpm_iscsid/tasks/install.yml
+++ b/roles/edpm_iscsid/tasks/install.yml
@@ -46,7 +46,7 @@
     - name: Gather services facts
       ansible.builtin.service_facts:
 
-    - name: Stop iscsi.service
+    - name: Stop and disable iscsi.service
       ansible.builtin.systemd:
         name: iscsi.service
         state: stopped
@@ -55,3 +55,13 @@
         - ansible_facts.services["iscsi.service"] is defined
         - ansible_facts.services["iscsi.service"]["status"] != "not-found"
         - ansible_facts.services["iscsi.service"]["status"] == "enabled"
+
+    - name: Stop and disable iscsi-starter.service
+      ansible.builtin.systemd:
+        name: iscsi-starter.service
+        state: stopped
+        enabled: false
+      when:
+        - ansible_facts.services["iscsi-starter.service"] is defined
+        - ansible_facts.services["iscsi-starter.service"]["status"] != "not-found"
+        - ansible_facts.services["iscsi-starter.service"]["status"] == "enabled"


### PR DESCRIPTION
When an EDPM node is rebooted  which runs a VM with iscsi-backed volume, iscsi-starter.service is started on the node then iscsid.service is started via running systemctl start iscsi.service in iscsi-starter.service.

To prevent the issue, we need to stop/disable iscsi-starter.service.

JIRA: [OSPRH-12372](https://issues.redhat.com/browse/OSPRH-12372)