### PR TITLE
Stop and disable iscsi-starter.service

### DIFF
--- a/roles/edpm_iscsid/tasks/install.yml
+++ b/roles/edpm_iscsid/tasks/install.yml
@@ -46,12 +46,15 @@
     - name: Gather services facts
       ansible.builtin.service_facts:
 
-    - name: Stop iscsi.service
+    - name: Stop and disable iscsi.service and iscsi-starter.service
       ansible.builtin.systemd:
-        name: iscsi.service
+        name: "{{ item }}"
         state: stopped
         enabled: false
       when:
-        - ansible_facts.services["iscsi.service"] is defined
-        - ansible_facts.services["iscsi.service"]["status"] != "not-found"
-        - ansible_facts.services["iscsi.service"]["status"] == "enabled"
+        - ansible_facts.services[item] is defined
+        - ansible_facts.services[item]["status"] != "not-found"
+        - ansible_facts.services[item]["status"] == "enabled"
+      loop:
+        - iscsi.service
+        - iscsi-starter.service


### PR DESCRIPTION
When an EDPM node rebooted which runs a VM with iscsi-backed volume, 
it leaves node records under /var/lib/iscsi/nodes. 
While the records exist, iscsi-starter.service runs iscsi.service. 
Then it starts iscsid.service also.

To prevent this issue, we need to stop and disable iscsi-starter.service.

JIRA:[OSPRH-12372](https://issues.redhat.com/browse/OSPRH-12372)