### PR TITLE
[tripleo_cleanup] Add daemon-reload and reset-failed as last step

### DIFF
--- a/roles/edpm_tripleo_cleanup/tasks/main.yml
+++ b/roles/edpm_tripleo_cleanup/tasks/main.yml
@@ -99,3 +99,18 @@
   ansible.builtin.include_role:
     name: edpm_install_certs
     tasks_from: adoption
+
+- name: Cleanup tripleo services from the systemd
+  become: true
+  tags:
+    - adoption
+  when: edpm_remove_tripleo_unit_files
+  block:
+    - name: Reload units
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+    - name: Reset state of failed systemd units
+      ansible.builtin.command:
+        cmd: /usr/bin/systemctl reset-failed {{ item }}  # noqa: command-instead-of-module no-changed-when
+      loop: "{{ tripleo_services }}"
+      failed_when: false


### PR DESCRIPTION
In the role which cleans up old tripleo related systemd services this patch adds call for "systemctl daemon-reload" and "systemctl reset-failed <service_name>" for each tripleo service which was removed. This is done to make sure that those services aren't visible in the systemctl output with e.g. failure that unit file don't exists.

Closes: #[OSPRH-11323](https://issues.redhat.com//browse/OSPRH-11323)