### PR TITLE
Add noop job to projects

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -5,6 +5,7 @@
       - podified-multinode-edpm-baremetal-pipeline
     github-check:
       jobs:
+        - noop
         - edpm-ansible-tempest-multinode
         - edpm-ansible-molecule-edpm_bootstrap
         - edpm-ansible-molecule-edpm_podman


### PR DESCRIPTION
In order to get proper feedback from the rdoproject.org/github-check, the noop job is added. This job should be kicked even if other jobs are not started as irrelevant-files are detected in change. Without noop job rdoproject.org/github-check is hanging with waiting for status to be reported message.