### PR TITLE
Add ansible var to cleanup non configured interfaces

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -54,3 +54,4 @@ edpm_network_config_safe_defaults: true
 edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"
 edpm_dns_search_domains: []
+edpm_network_config_nonconfigured_cleanup: false

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -79,3 +79,7 @@ argument_specs:
         type: str
         description: "Name of the public network interface"
         default: nic1
+      edpm_network_config_nonconfigured_cleanup:
+        type: bool
+        description: "Cleanup network interfaces not in network config"
+        default: false

--- a/roles/edpm_network_config/tasks/os_net_config.yml
+++ b/roles/edpm_network_config/tasks/os_net_config.yml
@@ -42,6 +42,7 @@
             msg: "{{ os_net_config_config['content'] | b64decode | trim }}"
     - name: Run edpm_os_net_config_module with network_config
       edpm_os_net_config:
+        cleanup: "{{ edpm_network_config_nonconfigured_cleanup }}"
         config_file: "{{ nic_config_file }}"
         debug: "{{ edpm_network_config_debug | bool }}"
         detailed_exit_codes: true


### PR DESCRIPTION
This would allow to remove interfaces that exist but aren't specified in the provided nic config, if required.

jira: https://issues.redhat.com/browse/OSPRH-13433