### PR TITLE
Openvswitch package install required

### DIFF
--- a/playbooks/configure_ovs_dpdk.yml
+++ b/playbooks/configure_ovs_dpdk.yml
@@ -5,6 +5,12 @@
   strategy: linear
   gather_facts: "{{ gather_facts | default(false) }}"
   tasks:
+    - name: Install openvswitch package
+      become: true
+      ansible.builtin.dnf:
+        name: openvswitch
+        state: present
+
     - name: Configure OvS DPDK configs
       ansible.builtin.import_role:
         name: osp.edpm.edpm_ovs_dpdk

--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -21,7 +21,6 @@ argument_specs:
           - jq
           - nftables
           - openstack-selinux
-          - os-net-config
           - python3-libselinux
           - python3-pyyaml
           - rsync


### PR DESCRIPTION
This change is to fix the openvswitch package missing
issue during configure ovs dpdk for pre provisioned
EDPM nodes.

We already have ovs packages installation, ovs services
are enabled and running part in configure-network which
is common for all deployment.

To avoid issue in configure ovs dpdk, we are adding only
openvswitch package installation part and not using
existing edpm_ovs install.yml task to avoid complete
redundat like ovs services configuration, enable
and running part.