### PR TITLE
Fix regression in check remote connections play

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -2,7 +2,7 @@
 - name: Check remote connections
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
-  gather_facts: "{{ gather_facts | default(false) }}"
+  gather_facts: false
   tasks:
     - name: Wait for connection
       ansible.builtin.wait_for_connection:


### PR DESCRIPTION
When using `ansible.builtin.wait_for_connection`  `gather_facts` can't be true for the play.