### PR TITLE
Apply configuration tasks for Nova on updates

### DIFF
--- a/roles/edpm_update/tasks/containers.yml
+++ b/roles/edpm_update/tasks/containers.yml
@@ -100,6 +100,15 @@
     - edpm_update
   when: '"nova" in edpm_update_running_services'
 
+- name: Updates configs for edpm_nova role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_nova
+    tasks_from: configure.yml
+  tags:
+    - edpm_nova
+    - edpm_update
+  when: '"nova" in edpm_update_running_services'
+
 - name: Updates containers for edpm_neutron_sriov role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_neutron_sriov


### PR DESCRIPTION
When 'updates' service runs, it only calls install.yml from Nova service role, which is not sufficient to provide required configuration updates. Inlcude configure.yml as well to cover that for Nova service.

To properly address this for *all services* we should add migration/update tasks there, which can be called individually from the update playbook.

Jira: #[OSPRH-13415](https://issues.redhat.com/browse/OSPRH-13415)