### PR TITLE
Rebase bootc branch onto main

### DIFF
--- a/molecule/common/test_deps/defaults/main.yml
+++ b/molecule/common/test_deps/defaults/main.yml
@@ -20,3 +20,5 @@ test_deps_setup_edpm: false
 test_deps_mirrors_file_path: /etc/ci/mirror_info.sh
 test_deps_setup_stream: true
 test_deps_setup_ceph: false
+# Value to use for the bootc fact
+test_deps_bootc_fact: false

--- a/molecule/common/test_deps/tasks/main.yml
+++ b/molecule/common/test_deps/tasks/main.yml
@@ -152,3 +152,29 @@
         releasever: "{{ ansible_facts['distribution_major_version'] }}"
       when:
         - (test_deps_extra_packages | length) > 0
+
+- name: Bootc block
+  become: true
+  block:
+    - name: Check for /etc/ansible/facts.d/bootc.fact
+      stat:
+        path: /etc/ansible/facts.d/bootc.fact
+      register: bootc_fact_stat
+
+    - name: Create /etc/ansible/facts.d
+      file:
+        state: directory
+        path: /etc/ansible/facts.d
+
+    - name: Create /etc/ansible/facts.d/bootc.fact
+      copy:
+        dest: /etc/ansible/facts.d/bootc.fact
+        content: |
+          #!/bin/bash
+          echo "{{ test_deps_bootc_fact | lower }}"
+        mode: 0755
+
+    - name: Gather local facts
+      ansible.builtin.setup:
+        gather_subset:
+          - "local"

--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -42,6 +42,7 @@
         name: osp.edpm.edpm_kernel
       tags:
         - edpm_kernel
+      when: not ansible_local.bootc
     - name: Import edpm_tuned
       ansible.builtin.import_role:
         name: osp.edpm.edpm_tuned
@@ -53,9 +54,11 @@
         tasks_from: kernelargs.yml
       tags:
         - edpm_kernel
+      when: not ansible_local.bootc
     - name: Configure KSM for kernel
       ansible.builtin.import_role:
         name: osp.edpm.edpm_kernel
         tasks_from: ksm.yml
       tags:
         - edpm_kernel
+      when: not ansible_local.bootc

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -60,8 +60,9 @@
 - name: Execute bootstrap command
   ansible.builtin.import_tasks: bootstrap_command.yml
 
-- name: Import packages tasks
-  ansible.builtin.import_tasks: packages.yml
+- name: Include packages tasks
+  ansible.builtin.include_tasks: packages.yml
+  when: not ansible_local.bootc
 
 - name: Set selinux state
   ansible.posix.selinux:
@@ -107,8 +108,9 @@
       #!/bin/sh
       make_resolv_conf() { : ; }
 
-- name: Configure swap
-  ansible.builtin.import_tasks: swap.yml
+- name: Include swap tasks
+  ansible.builtin.include_tasks: swap.yml
+  when: not ansible_local.bootc
 
 - name: FIPS tasks
   ansible.builtin.import_tasks: fips.yml

--- a/roles/edpm_bootstrap/tasks/packages.yml
+++ b/roles/edpm_bootstrap/tasks/packages.yml
@@ -65,6 +65,7 @@
 - name: Install and enable network service
   when:
     - (edpm_bootstrap_legacy_network_packages | length) > 0
+    - not ansible_local.bootc
   become: true
   block:
     - name: Deploy network-scripts required for deprecated network service

--- a/roles/edpm_bootstrap/tasks/swap.yml
+++ b/roles/edpm_bootstrap/tasks/swap.yml
@@ -16,6 +16,7 @@
 
 - name: Configure swap file
   when:
+    - not ansible_local.bootc
     - not edpm_bootstrap_swap_partition_enabled|bool
     - edpm_bootstrap_swap_size_megabytes|int > 0
   become: true

--- a/roles/edpm_container_manage/files/edpm-container-shutdown-service
+++ b/roles/edpm_container_manage/files/edpm-container-shutdown-service
@@ -11,7 +11,7 @@ RefuseManualStop=yes
 Type=oneshot
 ExecStart=/bin/true
 RemainAfterExit=yes
-ExecStop=/usr/libexec/edpm-container-shutdown
+ExecStop=/var/local/libexec/edpm-container-shutdown
 # Wait at most 900 seconds for all containers to shutdown
 TimeoutStopSec=900
 

--- a/roles/edpm_container_manage/tasks/shutdown.yml
+++ b/roles/edpm_container_manage/tasks/shutdown.yml
@@ -17,17 +17,24 @@
 - name: Create EDPM Container systemd service
   become: true
   block:
+    - name: "Create /var/local/libexec dir"
+      file:
+        state: directory
+        path: /var/local/libexec
+        recurse: true
+        setype: container_file_t
+
     - name: "Deploy edpm-container-shutdown and edpm-start-podman-container"
       ansible.builtin.copy:
         src: "{{ role_path }}/files/{{ item }}"
-        dest: "/usr/libexec/{{ item }}"
+        dest: "/var/local/libexec/{{ item }}"
         mode: '0700'
         owner: root
         group: root
+        setype: container_file_t
       loop:
         - 'edpm-container-shutdown'
         - 'edpm-start-podman-container'
-      when: not edpm_use_bootc
 
     - name: "Create systemd preset dir"
       ansible.builtin.file:

--- a/roles/edpm_container_manage/tasks/shutdown.yml
+++ b/roles/edpm_container_manage/tasks/shutdown.yml
@@ -27,17 +27,25 @@
       loop:
         - 'edpm-container-shutdown'
         - 'edpm-start-podman-container'
-    - name: "Create /usr/lib/systemd/system/edpm-container-shutdown.service"
+      when: not edpm_use_bootc
+
+    - name: "Create systemd preset dir"
+      ansible.builtin.file:
+        state: "directory"
+        path: "/etc/systemd/system-preset"
+        mode: 0644
+
+    - name: "Create /etc/systemd/system/edpm-container-shutdown.service"
       ansible.builtin.copy:
         src: "{{ role_path }}/files/edpm-container-shutdown-service"
-        dest: "/usr/lib/systemd/system/edpm-container-shutdown.service"
+        dest: "/etc/systemd/system/edpm-container-shutdown.service"
         mode: '0644'
         owner: root
         group: root
-    - name: "Create /usr/lib/systemd/system-preset/91-edpm-container-shutdown.preset"
+    - name: "Create /etc/systemd/system-preset/91-edpm-container-shutdown.preset"
       ansible.builtin.copy:
         src: "{{ role_path }}/files/91-edpm-container-shutdown-preset"
-        dest: "/usr/lib/systemd/system-preset/91-edpm-container-shutdown.preset"
+        dest: "/etc/systemd/system-preset/91-edpm-container-shutdown.preset"
         mode: '0644'
         owner: root
         group: root
@@ -47,17 +55,17 @@
         state: started
         enabled: true
         daemon_reload: true
-    - name: "Create /usr/lib/systemd/system/netns-placeholder.service"
+    - name: "Create /etc/systemd/system/netns-placeholder.service"
       ansible.builtin.copy:
         src: "{{ role_path }}/files/netns-placeholder-service"
-        dest: "/usr/lib/systemd/system/netns-placeholder.service"
+        dest: "/etc/systemd/system/netns-placeholder.service"
         mode: '0644'
         owner: root
         group: root
-    - name: "Create /usr/lib/systemd/system-preset/91-netns-placeholder.preset"
+    - name: "Create /etc/systemd/system-preset/91-netns-placeholder.preset"
       ansible.builtin.copy:
         src: "{{ role_path }}/files/91-netns-placeholder-preset"
-        dest: "/usr/lib/systemd/system-preset/91-netns-placeholder.preset"
+        dest: "/etc/systemd/system-preset/91-netns-placeholder.preset"
         mode: '0644'
         owner: root
         group: root

--- a/roles/edpm_container_manage/templates/systemd-service.j2
+++ b/roles/edpm_container_manage/templates/systemd-service.j2
@@ -8,7 +8,7 @@ Wants={{ lookup('dict', container_data_unit).value.depends_on | default([]) | jo
 [Service]
 Restart=always
 {% if lookup('dict', container_data_unit).value.depends_on is defined and (lookup('dict', container_data_unit).value.depends_on | length > 0) and podman_drop_in | default('false') %}
-ExecStart=/usr/libexec/edpm-start-podman-container {{ lookup('dict', container_data_unit).key }}
+ExecStart=/var/local/libexec/edpm-start-podman-container {{ lookup('dict', container_data_unit).key }}
 {% else %}
 ExecStart=/usr/bin/podman start {{ lookup('dict', container_data_unit).key }}
 {% endif %}

--- a/roles/edpm_frr/tasks/run.yml
+++ b/roles/edpm_frr/tasks/run.yml
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_iscsid/tasks/run.yml
+++ b/roles/edpm_iscsid/tasks/run.yml
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_kernel/tasks/main.yml
+++ b/roles/edpm_kernel/tasks/main.yml
@@ -25,7 +25,9 @@
         name: "{{ edpm_kernel_extra_packages }}"
         state: present
       register: _install_packages_result
-      when: edpm_kernel_extra_packages | length > 0
+      when: 
+        - edpm_kernel_extra_packages | length > 0
+        - not ansible_local.bootc
       until: _install_packages_result is succeeded
       retries: "{{ edpm_kernel_download_retries }}"
       delay: "{{ edpm_kernel_download_delay }}"

--- a/roles/edpm_kernel/tasks/main.yml
+++ b/roles/edpm_kernel/tasks/main.yml
@@ -36,6 +36,7 @@
       ansible.builtin.dnf:
         name: 'dracut-config-generic'
         state: absent
+      when: not ansible_local.bootc
 
     - name: Ensure the /etc/modules-load.d/ directory exists
       ansible.builtin.file:

--- a/roles/edpm_libvirt/tasks/install.yml
+++ b/roles/edpm_libvirt/tasks/install.yml
@@ -13,6 +13,7 @@
   delay: "{{ edpm_libvirt_download_delay }}"
   notify:
     - Restart libvirt
+  when: not ansible_local.bootc
 
 - name: Ensure monolithic libvirt and tcp socket activation is not enabled or running
   tags:

--- a/roles/edpm_logrotate_crond/molecule/default/converge.yml
+++ b/roles/edpm_logrotate_crond/molecule/default/converge.yml
@@ -19,6 +19,7 @@
   hosts: all
   gather_facts: false
   tasks:
+
     - name: install edpm_logrotate_crond
       include_role:
         name: "osp.edpm.edpm_logrotate_crond"

--- a/roles/edpm_logrotate_crond/molecule/default/verify.yml
+++ b/roles/edpm_logrotate_crond/molecule/default/verify.yml
@@ -23,7 +23,7 @@
 
     - name: Push script
       ansible.builtin.stat:
-        path: /usr/local/sbin/containers-tmpwatch
+        path: /var/lib/openstack/cron/containers-tmpwatch
       register: stat_result
       failed_when: not stat_result.stat.exists
 
@@ -31,7 +31,7 @@
       ansible.builtin.shell:
         crontab -l
       register: crontab
-      failed_when: "'@daily /usr/local/sbin/containers-tmpwatch' not in crontab.stdout"
+      failed_when: "'@daily /var/lib/openstack/cron/containers-tmpwatch' not in crontab.stdout"
 
     - name: Ensure config directories exist
       ansible.builtin.stat:

--- a/roles/edpm_logrotate_crond/tasks/configure.yml
+++ b/roles/edpm_logrotate_crond/tasks/configure.yml
@@ -22,8 +22,6 @@
         path: "/var/lib/openstack"
         mode: 0755
         state: directory
-        owner: "{{ ansible_user }}"
-        group: "{{ ansible_user }}"
         setype: "container_file_t"
 
     - name: Create /var/lib/openstack/cron
@@ -52,7 +50,7 @@
         name: "Remove old logs"
         special_time: "daily"
         user: "root"
-        job: "/usr/local/sbin/containers-tmpwatch"
+        job: "/var/lib/openstack/cron/containers-tmpwatch"
 
 - name: Configure logrotate_crond
   become: true

--- a/roles/edpm_logrotate_crond/tasks/configure.yml
+++ b/roles/edpm_logrotate_crond/tasks/configure.yml
@@ -17,9 +17,25 @@
 - name: Configure tmpwatch on the host
   become: true
   block:
+    - name: Create /var/lib/openstack
+      ansible.builtin.file:
+        path: "/var/lib/openstack"
+        mode: 0755
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        setype: "container_file_t"
+
+    - name: Create /var/lib/openstack/cron
+      ansible.builtin.file:
+        path: "/var/lib/openstack/cron"
+        mode: 0644
+        state: directory
+        setype: "container_file_t"
+
     - name: Push script
       ansible.builtin.copy:
-        dest: /usr/local/sbin/containers-tmpwatch
+        dest: /var/lib/openstack/cron/containers-tmpwatch
         owner: root
         group: root
         mode: "0755"

--- a/roles/edpm_logrotate_crond/tasks/install.yml
+++ b/roles/edpm_logrotate_crond/tasks/install.yml
@@ -23,6 +23,7 @@
   until: edpm_logrotate_crond_cronie_package_download is succeeded
   retries: "{{ edpm_logrotate_crond_download_retries }}"
   delay: "{{ edpm_logrotate_crond_download_delay }}"
+  when: not ansible_local.bootc
 
 - name: Gather SELinux fact if needed
   when:

--- a/roles/edpm_logrotate_crond/tasks/install.yml
+++ b/roles/edpm_logrotate_crond/tasks/install.yml
@@ -18,6 +18,8 @@
 - name: Gather local facts
   ansible.builtin.setup:
     gather_subset:
+      - "!all"
+      - "!min"
       - "local"
 
 - name: Install cronie

--- a/roles/edpm_logrotate_crond/tasks/install.yml
+++ b/roles/edpm_logrotate_crond/tasks/install.yml
@@ -14,6 +14,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+
+- name: Gather local facts
+  ansible.builtin.setup:
+    gather_subset:
+      - "local"
+
 - name: Install cronie
   become: true
   ansible.builtin.dnf:

--- a/roles/edpm_multipathd/tasks/run.yml
+++ b/roles/edpm_multipathd/tasks/run.yml
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -35,6 +35,7 @@
       until: nm_ovs_status is succeeded
       retries: "{{ edpm_network_config_download_retries }}"
       delay: "{{ edpm_network_config_download_delay }}"
+      when: not ansible_local.bootc
     - name: Restart NetworkManager after plugin installation [nmstate]
       ansible.builtin.systemd:
         name: NetworkManager

--- a/roles/edpm_network_config/tasks/network_config.yml
+++ b/roles/edpm_network_config/tasks/network_config.yml
@@ -47,6 +47,7 @@
   until: edpm_network_config_onc_download is succeeded
   retries: "{{ edpm_network_config_download_retries }}"
   delay: "{{ edpm_network_config_download_delay }}"
+  when: not ansible_local.bootc
 
 - name: Ensure /var/lib/edpm-config directory exists
   become: true

--- a/roles/edpm_neutron_dhcp/tasks/run.yml
+++ b/roles/edpm_neutron_dhcp/tasks/run.yml
@@ -27,7 +27,7 @@
           - "{{ edpm_neutron_dhcp_tls_cacert_bundle_src }}:{{ edpm_neutron_dhcp_tls_cacert_bundle_dest }}:ro,z"
       when: cacert_bundle_exists.stat.exists
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_neutron_metadata/tasks/run.yml
+++ b/roles/edpm_neutron_metadata/tasks/run.yml
@@ -27,7 +27,7 @@
           - "{{ edpm_neutron_metadata_tls_cacert_bundle_src }}:{{ edpm_neutron_metadata_tls_cacert_bundle_dest }}:ro,z"
       when: cacert_bundle_exists.stat.exists
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_neutron_ovn/tasks/run.yml
+++ b/roles/edpm_neutron_ovn/tasks/run.yml
@@ -27,7 +27,7 @@
           - "{{ edpm_neutron_ovn_tls_cacert_bundle_src }}:{{ edpm_neutron_ovn_tls_cacert_bundle_dest }}:ro,z"
       when: cacert_bundle_exists.stat.exists
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_neutron_sriov/tasks/run.yml
+++ b/roles/edpm_neutron_sriov/tasks/run.yml
@@ -27,7 +27,7 @@
           - "{{ edpm_neutron_sriov_tls_cacert_bundle_src }}:{{ edpm_neutron_sriov_tls_cacert_bundle_dest }}:ro,z"
       when: cacert_bundle_exists.stat.exists
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_nvmeof/tasks/install.yml
+++ b/roles/edpm_nvmeof/tasks/install.yml
@@ -29,3 +29,4 @@
   ansible.builtin.package:
     name: nvme-cli
     state: present
+  when: not ansible_local.bootc

--- a/roles/edpm_ovn/tasks/run.yml
+++ b/roles/edpm_ovn/tasks/run.yml
@@ -27,7 +27,7 @@
           - "{{ edpm_ovn_controller_tls_cacert_bundle_src }}:{{ edpm_ovn_controller_tls_cacert_bundle_dest }}:ro,z"
       when: cacert_bundle_exists.stat.exists
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_ovn_bgp_agent/tasks/run.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/run.yml
@@ -27,7 +27,7 @@
           - "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}:{{ edpm_ovn_bgp_agent_tls_cacert_bundle_dest }}:ro,z"
       when: cacert_bundle_exists.stat.exists
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: osp.edpm.edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_ovn_bgp_agent/tasks/run_ovn.yml
+++ b/roles/edpm_ovn_bgp_agent/tasks/run_ovn.yml
@@ -27,7 +27,7 @@
           - "{{ edpm_ovn_bgp_agent_tls_cacert_bundle_src }}:{{ edpm_ovn_bgp_agent_tls_cacert_bundle_dest }}:ro,z"
       when: cacert_bundle_exists.stat.exists
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_ovs/tasks/download_cache.yml
+++ b/roles/edpm_ovs/tasks/download_cache.yml
@@ -9,3 +9,4 @@
   until: _install_packages_result is succeeded
   retries: "{{ edpm_ovs_download_retries }}"
   delay: "{{ edpm_ovs_download_delay }}"
+  when: not ansible_local.bootc

--- a/roles/edpm_ovs/tasks/install.yml
+++ b/roles/edpm_ovs/tasks/install.yml
@@ -11,6 +11,7 @@
   until: edpm_ovs_package_install is succeeded
   retries: "{{ edpm_ovs_download_retries }}"
   delay: "{{ edpm_ovs_download_delay }}"
+  when: not ansible_local.bootc
 
 - name: Ensure ovs services are enabled and running
   tags:

--- a/roles/edpm_podman/tasks/install.yml
+++ b/roles/edpm_podman/tasks/install.yml
@@ -25,6 +25,7 @@
       until: edpm_podman_package_download is succeeded
       retries: "{{ edpm_podman_download_retries }}"
       delay: "{{ edpm_podman_download_delay }}"
+      when: not ansible_local.bootc
 
     - name: Ensure we get the ansible interfaces facts
       when:

--- a/roles/edpm_reboot/tasks/main.yaml
+++ b/roles/edpm_reboot/tasks/main.yaml
@@ -18,6 +18,7 @@
   become: true
   ansible.builtin.dnf:
     name: yum-utils
+  when: not ansible_local.bootc
 
 - name: Check if reboot is required with needs-restarting
   ansible.builtin.command: needs-restarting -r

--- a/roles/edpm_sshd/tasks/install.yml
+++ b/roles/edpm_sshd/tasks/install.yml
@@ -26,6 +26,7 @@
       until: _sshd_install_result is succeeded
       retries: "{{ edpm_sshd_download_retries }}"
       delay: "{{ edpm_sshd_download_delay }}"
+      when: not ansible_local.bootc
 
     # NOTE(mwhahaha): we need this here because in order to validate our generated
     # config, we need to ensure the host keys exist

--- a/roles/edpm_swift/tasks/run.yml
+++ b/roles/edpm_swift/tasks/run.yml
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
+- name: Ensure /var/local/libexec/edpm-start-podman-container exists
   ansible.builtin.import_role:
     name: edpm_container_manage
     tasks_from: shutdown.yml

--- a/roles/edpm_timezone/tasks/configure.yml
+++ b/roles/edpm_timezone/tasks/configure.yml
@@ -15,6 +15,23 @@
 # under the License.
 
 
+# TODO(slagle): should this be in edpm-image-builder instead?
+- name: Manage /etc/localtime
+  when: ansible_local.bootc
+  block:
+    - name: Check for /etc/localtime
+      stat:
+        path: /etc/localtime
+      register: localtime_stat
+
+    - name: Symlink /etc/localtime to timezone file if it doesn't exist
+      become: true
+      file:
+        state: link
+        path: /etc/localtime
+        src: /usr/share/zoneinfo/{{ edpm_timezone }}
+      when: not localtime_stat.stat.exists
+
 - name: Set timezone
   become: true
   community.general.timezone:

--- a/roles/edpm_tuned/tasks/main.yml
+++ b/roles/edpm_tuned/tasks/main.yml
@@ -17,6 +17,7 @@
 
 - name: Install packages
   ansible.builtin.include_tasks: install.yml
+  when: not ansible_local.bootc
 
 - name: Configure tuned
   ansible.builtin.include_tasks: configure.yml


### PR DESCRIPTION
- **edpm_container_manage support bootc**
- **Move containers-tmpwatch to /var/lib/openstack**
- **Skip swapfile creation for bootc**
- **Skip package installations for bootc**
- **Skip kernel tasks when using bootc**
- **Install edpm-container-shutdown to /var**
- **Create /etc/localtime if it doesn't exist**
- **Skip tuned package installed for bootc**
- **Add bootc fact to test_deps**
- **Gather local facts where ansible_local.bootc is used**
- **Drop owner/group from /var/lib/openstack**
