### PR TITLE
Re-enable swap for bootc

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -15,6 +15,9 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
     - name: Grow volumes
       ansible.builtin.import_role:
         name: osp.edpm.edpm_growvols

--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -72,6 +72,9 @@ edpm_bootstrap_selinux_mode: enforcing
 # Swap management
 edpm_bootstrap_swap_size_megabytes: 1024
 edpm_bootstrap_swap_path: /swap
+# swap path needs to be under /var on bootc, so a separate default value is
+# needed.
+edpm_bootstrap_swap_path_bootc: /var/swap
 edpm_bootstrap_swap_partition_enabled: false
 edpm_bootstrap_swap_partition_label: swap1
 

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -110,7 +110,6 @@
 
 - name: Include swap tasks
   ansible.builtin.include_tasks: swap.yml
-  when: not ansible_local.bootc
 
 - name: FIPS tasks
   ansible.builtin.import_tasks: fips.yml

--- a/roles/edpm_bootstrap/tasks/swap.yml
+++ b/roles/edpm_bootstrap/tasks/swap.yml
@@ -16,26 +16,29 @@
 
 - name: Configure swap file
   when:
-    - not ansible_local.bootc
     - not edpm_bootstrap_swap_partition_enabled|bool
     - edpm_bootstrap_swap_size_megabytes|int > 0
   become: true
   block:
+    - name: Set swap path
+      set_fact:
+        edpm_bootstrap_swap_path_value: |
+          {% if ansible_local.bootc | bool %}{{ edpm_bootstrap_swap_path_bootc }}{% else %}{{ edpm_bootstrap_swap_path }}{% endif %}
     - name: Create swapfile if needed
       ansible.builtin.command:
-        cmd: dd if=/dev/zero of={{ edpm_bootstrap_swap_path }} count={{ edpm_bootstrap_swap_size_megabytes }} bs=1M
-        creates: "{{ edpm_bootstrap_swap_path }}"
+        cmd: dd if=/dev/zero of={{ edpm_bootstrap_swap_path_value }} count={{ edpm_bootstrap_swap_size_megabytes }} bs=1M
+        creates: "{{ edpm_bootstrap_swap_path_value }}"
       notify: "create and activate swap"
     - name: Set permission on swapfile
       ansible.builtin.file:
-        path: "{{ edpm_bootstrap_swap_path }}"
+        path: "{{ edpm_bootstrap_swap_path_value }}"
         owner: root
         group: root
         mode: "0600"
     - name: Enable swapfile on fstab
       ansible.posix.mount:
         name: none
-        src: "{{ edpm_bootstrap_swap_path }}"
+        src: "{{ edpm_bootstrap_swap_path_value }}"
         fstype: swap
         opts: sw
         state: present


### PR DESCRIPTION
The default path for a swapfile needs to be under a writeable location
for bootc. Use /var/swap. The value of the existing variable,
edpm_bootstrap_swap_path can't just be changed since there are already
existing deployments, so a new variable, edpm_bootstrap_swap_path_bootc
is added for bootc. An ansible task will select which variable to use
based on the type of system.

Signed-off-by: James Slagle <jslagle@redhat.com>
