### PR TITLE
Gather ansible_local facts at the start of each service

### DIFF
--- a/playbooks/configure_network.yml
+++ b/playbooks/configure_network.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Import edpm_ovs to install ovs packages
       ansible.builtin.import_role:
         name: osp.edpm.edpm_ovs

--- a/playbooks/configure_os.yml
+++ b/playbooks/configure_os.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Configure edpm_podman
       ansible.builtin.import_role:
         name: osp.edpm.edpm_podman

--- a/playbooks/download_cache.yml
+++ b/playbooks/download_cache.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Import edpm_download_cache
       ansible.builtin.import_role:
         name: osp.edpm.edpm_download_cache

--- a/playbooks/install_certs.yml
+++ b/playbooks/install_certs.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Install EDPM Certs
       ansible.builtin.import_role:
         name: osp.edpm.edpm_install_certs

--- a/playbooks/install_os.yml
+++ b/playbooks/install_os.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Install edpm_podman
       ansible.builtin.import_role:
         name: osp.edpm.edpm_podman

--- a/playbooks/libvirt.yml
+++ b/playbooks/libvirt.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Deploy EDPM libvirt
       ansible.builtin.import_role:
         name: osp.edpm.edpm_libvirt

--- a/playbooks/neutron_metadata.yml
+++ b/playbooks/neutron_metadata.yml
@@ -6,6 +6,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Neutron OVN Metadata agent
       ansible.builtin.import_role:
         name: osp.edpm.edpm_neutron_metadata

--- a/playbooks/neutron_ovn.yaml
+++ b/playbooks/neutron_ovn.yaml
@@ -6,6 +6,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Neutron OVN agent
       ansible.builtin.import_role:
         name: osp.edpm.edpm_neutron_ovn

--- a/playbooks/nova.yml
+++ b/playbooks/nova.yml
@@ -9,6 +9,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Deploy EDPM Nova
       ansible.builtin.import_role:
         name: osp.edpm.edpm_nova

--- a/playbooks/ovn.yml
+++ b/playbooks/ovn.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Deploy EDPM OVN
       ansible.builtin.import_role:
         name: osp.edpm.edpm_ovn

--- a/playbooks/run_os.yml
+++ b/playbooks/run_os.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Run edpm_sshd
       ansible.builtin.import_role:
         name: osp.edpm.edpm_sshd

--- a/playbooks/telemetry.yml
+++ b/playbooks/telemetry.yml
@@ -23,6 +23,10 @@
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   # Doesn't handle rsyslog
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Deploy telemetry metrics
       ansible.builtin.import_role:
         name: osp.edpm.edpm_telemetry

--- a/playbooks/validate_network.yml
+++ b/playbooks/validate_network.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     # Pings only IPv4
     - name: Import edpm_nodes_validation
       ansible.builtin.import_role:


### PR DESCRIPTION
We depend on a custom fact for bootc deployments. This change ensures we gather at least ansible_local facts at the beginning of each service.