### PR TITLE
Removing DPDK lcore list config

### DIFF
--- a/docs/source/roles/role-edpm_ovs_dpdk.rst
+++ b/docs/source/roles/role-edpm_ovs_dpdk.rst
@@ -22,7 +22,6 @@ This Ansible role allows to do the following tasks:
         name: "osp.edpm.edpm_ovs_dpdk"
       vars:
          edpm_ovs_dpdk_pmd_core_list: "1,13,3,15"
-         edpm_ovs_dpdk_lcore_list: "0,12"
          edpm_ovs_dpdk_socket_memory: "4096"
          edpm_ovs_dpdk_memory_channels: 4
          edpm_ovs_dpdk_vhost_postcopy_support: true

--- a/roles/edpm_ovs_dpdk/defaults/main.yml
+++ b/roles/edpm_ovs_dpdk/defaults/main.yml
@@ -19,7 +19,6 @@
 
 # All variables within this role should have a prefix of "edpm_ovs_dpdk"
 edpm_ovs_dpdk_pmd_core_list: ""
-edpm_ovs_dpdk_lcore_list: ""
 edpm_ovs_dpdk_memory_channels: 4
 edpm_ovs_dpdk_extra: ""
 edpm_ovs_dpdk_socket_memory: ""

--- a/roles/edpm_ovs_dpdk/meta/argument_specs.yml
+++ b/roles/edpm_ovs_dpdk/meta/argument_specs.yml
@@ -8,10 +8,6 @@ argument_specs:
         type: str
         default: ""
         description: OvS DPDK PMD Core list
-      edpm_ovs_dpdk_lcore_list:
-        type: str
-        default: ""
-        description: OvS DPDK LCore list
       edpm_ovs_dpdk_memory_channels:
         type: int
         default: 4

--- a/roles/edpm_ovs_dpdk/tasks/configure.yml
+++ b/roles/edpm_ovs_dpdk/tasks/configure.yml
@@ -31,18 +31,6 @@
       ansible.builtin.set_fact:
         edpm_ovs_other_config: "{{ {} | combine(pmd_cpu_mask) }}"
 
-- name: Set DPDK lcores config
-  when: edpm_ovs_dpdk_lcore_list|string
-  block:
-    - name: Apply DPDK lcores config
-      ansible.builtin.set_fact:
-        dpdk_lcore_mask:
-          dpdk-lcore-mask: "{{ edpm_ovs_dpdk_lcore_list | osp.edpm.cpu_mask }}"
-
-    - name: Append other_config with DPDK lcores
-      ansible.builtin.set_fact:
-        edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(dpdk_lcore_mask) }}"
-
 - name: Add memory channels to dpdk extra
   ansible.builtin.set_fact:
     edpm_ovs_dpdk_extra_internal: "{{ edpm_ovs_dpdk_extra }} -n {{ edpm_ovs_dpdk_memory_channels }}"


### PR DESCRIPTION
This edpm_ovs_dpdk_lcore_list config is not
required now to enable ovs dpdk in EDPM
nodes.