### PR TITLE
node_exporter should not be mounting dbus

### DIFF
--- a/roles/edpm_telemetry/templates/node_exporter.json.j2
+++ b/roles/edpm_telemetry/templates/node_exporter.json.j2
@@ -8,8 +8,6 @@
 {% if tls_cert_exists|bool %}
         "--web.config.file=/etc/node_exporter/node_exporter.yaml",
 {% endif %}
-        "--collector.systemd",
-        "--collector.systemd.unit-include=(edpm_.*|ovs.*|openvswitch|virt.*|rsyslog)\\.service",
         "--web.disable-exporter-metrics",
         "--no-collector.dmi",
         "--no-collector.entropy",

--- a/roles/edpm_telemetry/templates/node_exporter.json.j2
+++ b/roles/edpm_telemetry/templates/node_exporter.json.j2
@@ -39,8 +39,7 @@
     "volumes": [
 {% if tls_cert_exists|bool %}
         "{{ edpm_telemetry_config_dest }}/node_exporter.yaml:/etc/node_exporter/node_exporter.yaml:z",
-        "{{ edpm_telemetry_certs }}:/etc/node_exporter/tls:z",
+        "{{ edpm_telemetry_certs }}:/etc/node_exporter/tls:z"
 {% endif %}
-        "/var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw,z"
     ]
 }


### PR DESCRIPTION
The dbus exclusive mount is preventing everything else to restart or to use it.

This solves the route cause for not being able to deploy an edpm twice.