### PR TITLE
[OSPRH-13840]use download role for powermonitoring

### DIFF
--- a/roles/edpm_download_cache/tasks/container_images.yml
+++ b/roles/edpm_download_cache/tasks/container_images.yml
@@ -100,6 +100,12 @@
     name: osp.edpm.edpm_telemetry
     tasks_from: download_cache.yml
 
+- name: Download images for edpm_telemetry_power_monitoring role
+  when: '"telemetry-power-monitoring" in edpm_download_cache_running_services'
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_telemetry_power_monitoring
+    tasks_from: download_cache.yml
+
 - name: Download images for edpm_swift role
   when: '"swift" in edpm_download_cache_running_services'
   ansible.builtin.include_role:


### PR DESCRIPTION
Use the edpm_download_cache role for downloading the container images for the telemetry-power-monitoring service. This will fix container registry credential issues when running the edmp_telemetry_power_monitoring role.