### PR TITLE
Update task name to clarify disconnected env

### DIFF
--- a/roles/edpm_podman/tasks/install.yml
+++ b/roles/edpm_podman/tasks/install.yml
@@ -106,7 +106,7 @@
         mode: "0644"
       when: not edpm_podman_disconnected_ocp
 
-    - name: Write containers registries.conf
+    - name: Write containers registries.conf for disconnected ocp
       ansible.builtin.copy:
         content: "{{ edpm_podman_registries_conf }}"
         dest: /etc/containers/registries.conf


### PR DESCRIPTION
Before this fix, the task name of writing registries.conf is the same between connected env and disconnected env. 
It requires to check the rendered registries.conf for identifying which is used.

To make it clear, this fix updates the name for disconnected ocp.