### PR TITLE
Flip the default for edpm_network_config_nonconfigured_cleanup

### DIFF
--- a/docs/source/roles/role-edpm_network_config.rst
+++ b/docs/source/roles/role-edpm_network_config.rst
@@ -19,6 +19,11 @@ This Ansible role does the following tasks:
   - Checks for the presence of required RPMS
   - Uses "provider" ifcfg/nmstate based on flag "edpm_network_config_nmstate"
 
+Note: By default this role will cleanup devices/interfaces not in
+"edpm_network_config_template". If there is requirement to keep them
+for pre-provisioned nodes, "edpm_network_config_nonconfigured_cleanup"
+ansible var can be set to "false".
+
 Here is an example playbook to run os-net-config tool:
 
 .. code-block:: YAML

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -54,4 +54,4 @@ edpm_network_config_safe_defaults: true
 edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"
 edpm_dns_search_domains: []
-edpm_network_config_nonconfigured_cleanup: false
+edpm_network_config_nonconfigured_cleanup: true

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -82,4 +82,4 @@ argument_specs:
       edpm_network_config_nonconfigured_cleanup:
         type: bool
         description: "Cleanup network interfaces not in network config"
-        default: false
+        default: true


### PR DESCRIPTION
We will switch this to cleanup the configurations not in `edpm_network_config_template` by default. This is required for provisioned nodes using vlan tagged ctlplane network. The ansible var could be set to false for cases where we want to keep the existing configuration.

This would also be useful when we want to change the initial configuration using `edpm_network_config_update` to cleanup whatever redundant interfaces created earlier.

Depends-On: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/828
jira: https://issues.redhat.com/browse/OSPRH-13433
