### PR TITLE
Use either edpm_frr_bgp_peers or edpm_frr_bgp_uplinks in frr.conf

### DIFF
--- a/roles/edpm_frr/defaults/main.yml
+++ b/roles/edpm_frr/defaults/main.yml
@@ -52,7 +52,7 @@ edpm_frr_bgp_neighbor_ttl_security_hops: 1
 edpm_frr_bgp_peers: []
 # List of interfaces frr should use to set up peering
 edpm_frr_bgp_asn: 64999
-edpm_frr_bgp_uplinks: ['nic1']
+edpm_frr_bgp_uplinks: []
 edpm_frr_bgp_uplinks_scope: internal
 edpm_frr_config_basedir: "/var/lib/config-data/ansible-generated/frr"
 edpm_frr_defaults: traditional

--- a/roles/edpm_frr/molecule/default/converge.yml
+++ b/roles/edpm_frr/molecule/default/converge.yml
@@ -20,6 +20,9 @@
   gather_facts: false
   vars:
     edpm_download_cache_podman_auth_file: "" # Override since the file doesn't exist
+    edpm_frr_bgp_peers:
+      - 10.64.0.1
+      - 10.65.0.1
   pre_tasks:
     - name: set basic user fact
       set_fact:

--- a/roles/edpm_frr/tasks/configure.yml
+++ b/roles/edpm_frr/tasks/configure.yml
@@ -25,8 +25,17 @@
   ansible.builtin.set_fact:
     iface_map: "{{ os_net_config_result.stdout }}"
 
+
+- name: Assert either edpm_frr_bgp_peers or edpm_frr_bgp_uplinks configured
+  ansible.builtin.assert:
+    that:
+      - "edpm_frr_bgp_uplinks or edpm_frr_bgp_peers"
+
 - name: FRR uplink interfaces
-  when: edpm_frr_bgp_uplinks
+  # if edpm_frr_bgp_peers are defined, edpm_frr_bgp_uplinks are not used to create frr.conf.j2
+  when:
+    - edpm_frr_bgp_uplinks
+    - not edpm_frr_bgp_peers
   block:
     - name: Construct FRR uplink interfaces from os-net-config mappings
       ansible.builtin.set_fact:


### PR DESCRIPTION
This PR sets edpm_frr_bgp_uplinks default to empty list, sync'ing with
corresponding tripleo default value.

It also ensures that either edpm_frr_bgp_peers or edpm_frr_bgp_uplinks
have been configured.

If both are configured, only edpm_frr_bgp_peers is applied.

[OSPRH-14173](https://issues.redhat.com//browse/OSPRH-14173)