### PR TITLE
Always load custom nftables rules

### DIFF
--- a/roles/edpm_nftables/tasks/configure.yml
+++ b/roles/edpm_nftables/tasks/configure.yml
@@ -145,18 +145,6 @@
         group: root
         mode: "0600"
 
-    - name: Create a sentinel file when nft rules are changed
-      ansible.builtin.file:
-        path: /etc/nftables/edpm-rules.nft.changed
-        state: touch
-        owner: root
-        group: root
-        mode: "0600"
-      when:
-        - nft_ruleset is defined
-        - nft_ruleset is changed
-
-
 # We cannot use the "validate" parameter from the "template" module, since
 # we don't load the chains before. So let's validate now, with all the things.
 # Remember, the "iptables" compat layout is already loaded at this point.

--- a/roles/edpm_nftables/tasks/run.yml
+++ b/roles/edpm_nftables/tasks/run.yml
@@ -26,22 +26,12 @@
 - name: Reload custom nftables ruleset files
   become: true
   block:
-    - name: Check if rules are changed
-      ansible.builtin.stat:
-        path: /etc/nftables/edpm-rules.nft.changed
-      register: nft_ruleset_changed
     - name: Reload ruleset
       ansible.builtin.shell: >-
         set -o pipefail;
         cat /etc/nftables/edpm-flushes.nft
         /etc/nftables/edpm-rules.nft
         /etc/nftables/edpm-update-jumps.nft | nft -f -
-      when: nft_ruleset_changed.stat.exists
       register: nft_reload_ruleset
       changed_when: nft_reload_ruleset.rc == 0
       failed_when: nft_reload_ruleset.rc != 0
-  always:
-    - name: Delete nft_ruleset_changed file
-      ansible.builtin.file:
-        path: /etc/nftables/edpm-rules.nft.changed
-        state: absent


### PR DESCRIPTION
This change ensures the custom nftables rules are always loaded by removing the conditional check and associated sential file. This is necessary since we're always loading the iptables compatibility rules and this sets the policy of the INPUT chain to accept. After our custom rules are configured, this policy should be reset to drop to ensure we're only allowing defined traffic and dropping anything that doesn't match a rule in the chain.

Jira: [OSPRH-14250](https://issues.redhat.com//browse/OSPRH-14250)