### PR TITLE
exporters: add dataplane_node_exporter installation

### DIFF
--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -28,6 +28,8 @@ edpm_telemetry_node_exporter_image: quay.io/prometheus/node-exporter:v1.5.0
 edpm_telemetry_podman_exporter_image: quay.io/navidys/prometheus-podman-exporter:v1.10.1
 # Image to use for Ceilometer
 edpm_telemetry_ceilometer_compute_image: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
+# Image to use for dataplane_node_exporter
+edpm_telemetry_dataplane_node_exporter_image: quay.io/openstack-k8s-operators/dataplane-node-exporter:latest
 # Certificates location for tls encryption
 edpm_telemetry_certs: "/var/lib/openstack/certs/{{ edpm_telemetry_service_name }}/default"
 # CA certs location for tls encryption
@@ -46,6 +48,7 @@ edpm_telemetry_healthcheck_sources:
   ceilometer_agent_compute: ceilometer_agent
   node_exporter: exporter
   podman_exporter: exporter
+  dataplane_node_exporter: exporter
 #  kepler: exporter
 # If telemetry services should have health checks enabled
 edpm_telemetry_healthcheck: true
@@ -54,3 +57,4 @@ edpm_telemetry_enabled_exporters:
   - ceilometer_agent_compute
   - node_exporter
   - podman_exporter
+  - dataplane_node_exporter

--- a/roles/edpm_telemetry/meta/argument_specs.yml
+++ b/roles/edpm_telemetry/meta/argument_specs.yml
@@ -31,6 +31,10 @@ argument_specs:
         type: "str"
         required: true
         description: "The name of the ceilometer compute podman image"
+      edpm_telemetry_dataplane_node_exporter_image:
+         type: "str"
+         required: true
+         description: "The name of the dataplane_node_exporter podman image"
       edpm_telemetry_config_src:
         type: "str"
         required: true

--- a/roles/edpm_telemetry/tasks/download_cache.yml
+++ b/roles/edpm_telemetry/tasks/download_cache.yml
@@ -21,6 +21,7 @@
   loop:
     - "{{ edpm_telemetry_ceilometer_compute_image }}"
     - "{{ edpm_telemetry_node_exporter_image }}"
+    - "{{ edpm_telemetry_dataplane_node_exporter_image }}"
   become: true
   register: edpm_telemetry_images_download
   until: edpm_telemetry_images_download.failed == false

--- a/roles/edpm_telemetry/templates/dataplane_node_exporter.json.j2
+++ b/roles/edpm_telemetry/templates/dataplane_node_exporter.json.j2
@@ -1,0 +1,28 @@
+{
+    "image": "{{ edpm_telemetry_dataplane_node_exporter_image }}",
+    "restart": "always",
+    "recreate": true,
+    "privileged": true,
+    "ports": ["9101:9101"],
+    "command": [],
+    "net": "host",
+    "environment": {
+        "OS_ENDPOINT_TYPE":"internal",
+        "DATAPLANE_NODE_EXPORTER_YAML":"/etc/dataplane_node_exporter/dataplane_node_exporter.yaml"
+    },
+{% if edpm_telemetry_healthcheck %}
+    "healthcheck": {
+        "test": "/openstack/healthcheck dataplane-no",
+        "mount": "/var/lib/openstack/healthchecks/dataplane_node_exporter"
+    },
+{% endif %}
+    "volumes": [
+        "{{ edpm_telemetry_config_dest }}/dataplane_node_exporter.yaml:/etc/dataplane_node_exporter/dataplane_node_exporter.yaml:z",
+{% if tls_cert_exists|bool %}
+        "{{ edpm_telemetry_certs }}:/etc/dataplane_node_exporter/tls:z",
+{% endif %}
+        "/var/run/openvswitch:/run/openvswitch:rw,z",
+        "/var/lib/openvswitch/ovn:/run/ovn:rw,z",
+        "/proc:/host/proc:ro"
+    ]
+}

--- a/roles/edpm_telemetry/templates/dataplane_node_exporter.yaml.j2
+++ b/roles/edpm_telemetry/templates/dataplane_node_exporter.yaml.j2
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 Robin Jarry
+#
+# This is the configuration file for OpenStack dataplane-node-exporter. It is
+# written in the YAML format. The exporter will lookup the configuration file
+# at /etc/dataplane-node-exporter.yaml by default. The path can be changed via
+# the DATAPLANE_NODE_EXPORTER_YAML environment variable.
+#
+# All settings have default values and some of them can be overriden via
+# environment variables as indicated in their description.
+
+---
+# Local addess and port to listen to for scraping HTTP requests. Can be
+# "127.0.0.1:<port>" or "[::1]:<port>" to limit to localhost. If address is
+# omited, listen on all addresses.
+#
+# Env: DATAPLANE_NODE_EXPORTER_HTTP_LISTEN
+# Default: ":1981"
+#
+http-listen: ":9101"
+
+# The HTTP path where to serve responses to prometheus scrapers.
+#
+# Env: DATAPLANE_NODE_EXPORTER_HTTP_PATH
+# Default: /metrics
+#
+#http-path: /metrics
+
+# The path to a TLS certificate to enable HTTPS support.
+#
+# Env: DATAPLANE_NODE_EXPORTER_TLS_CERT
+# Default: ""
+#
+{% if tls_cert_exists|bool %}
+tls-cert: "/etc/dataplane_node_exporter/tls/tls.crt"
+{% endif %}
+
+# The path to a TLS certificate secret key to enable HTTPS support.
+#
+# Env: DATAPLANE_NODE_EXPORTER_TLS_KEY
+# Default: ""
+#
+{% if tls_cert_exists|bool %}
+tls-key: "/etc/dataplane_node_exporter/tls/tls.key"
+{% endif %}
+
+# Space separated list of valid users and passwords. Leave empty to disable
+# authentication. Authentication will only be enforced when TLS is enabled.
+#
+# Example:
+#
+#   auth-users:
+#     - name: admin
+#       password: admin
+#     - name: foobar
+#       password: s3cr3t
+#     - name: johndoe
+#       password: p4ssw0rd
+#
+# Default: []
+#
+#auth-users: []
+
+# Overall log verbosity of the exporter.
+#
+# Supported levels are: debug info notice warning error critical
+#
+# Env: DATAPLANE_NODE_EXPORTER_LOG_LEVEL
+# Default: notice
+#
+log-level: info
+
+# The absolute path to the runtime directory of ovn-controller. This folder is
+# expected to contain the the ovn-controller pid file "ovn-controller.pid" and
+# its unixctl socket "ovn-controller.$pid.ctl".
+#
+# Env: DATAPLANE_NODE_EXPORTER_OVN_RUNDIR
+# Default: /run/ovn
+#
+
+# The absolute path to the runtime directory of openvswitch. This folder is
+# expected to contain the ovsdb-server socket endpoint "db.sock", the
+# "ovs-vswitchd.pid" file and each bridge openflow management sockets
+# "$bridge_name.mgmt".
+#
+# Env: DATAPLANE_NODE_EXPORTER_OVS_RUNDIR
+# Default: /run/openvswitch
+#
+#ovs-rundir: /run/openvswitch
+
+# The mount path of the procfs directory to search for the PID found in
+# ovs-vswitchd.pid. When running the exporter in a different PID namespace than
+# OVS, this will need to be changed to another folder.
+#
+# Env: DATAPLANE_NODE_EXPORTER_OVS_PROCDIR
+# Default: /proc
+#
+ovs-procdir: /host/proc
+
+# List of metric collectors to scrape and export. To list the available
+# collectors and the metrics they export, use "dataplane-node-exporter -l". If
+# the list is empty (default) all collectors will be enabled.
+#
+# Default: []
+#
+#collectors: []
+#collectors:
+#  - bridge
+#  - counters
+# List of metric sets to export. This is cumulative with the collectors option.
+# The "dataplane-node-exporter -l" flag will list all supported metrics along
+# with their set name. If the list is empty (default) all metrics from enabled
+# collectors will be exported.
+#
+# Supported sets are: base errors perf counters debug
+#
+# Default: [base, errors, perf, counters]
+#
+metric-sets:
+  - base
+  - errors
+  - perf
+  - counters
+  - debug

--- a/roles/edpm_telemetry/templates/firewall.yaml.j2
+++ b/roles/edpm_telemetry/templates/firewall.yaml.j2
@@ -5,3 +5,9 @@
     proto: tcp
     dport:
      - "9100"
+
+- rule_name: 001 Allow dataplane_node_exporter traffic
+  rule:
+    proto: tcp
+    dport:
+     - "9101"


### PR DESCRIPTION
The dataplane_node_exporter is a Prometheus exporter that collects networking metrics from OVN, DPDK, and OVS.

[Depends-upon](https://issues.redhat.com/browse/OSPRH-11765)

**DNM** until image is available on quay.io.

