### PR TITLE
Change Ceph Dashboard port to 8443

### DIFF
--- a/roles/edpm_ceph_hci_pre/defaults/main.yml
+++ b/roles/edpm_ceph_hci_pre/defaults/main.yml
@@ -108,7 +108,7 @@ edpm_ceph_hci_pre_firewall_services:
   - name: ceph_dashboard
     num: 100
     dport:
-      - 8444
+      - 8443
     ranges: "{{ edpm_ceph_hci_pre_storage_ranges | list }}"
   - name: ceph_grafana_frontend
     num: 100


### PR DESCRIPTION
Update edpm_ceph_hci_pre role since the default port for the dashboard was wrong as per the ceph docs.

https://docs.ceph.com/en/latest/mgr/dashboard/#host-name-and-port

Jira: https://issues.redhat.com/browse/OSPRH-14300