### PR TITLE
Reintroduce systemd collector

### DIFF
--- a/roles/edpm_telemetry/templates/node_exporter.json.j2
+++ b/roles/edpm_telemetry/templates/node_exporter.json.j2
@@ -2,6 +2,7 @@
     "image": "{{ edpm_telemetry_node_exporter_image }}",
     "restart": "always",
     "recreate": true,
+    "user": "root",
     "privileged": true,
     "ports": ["9100:9100"],
     "command": [
@@ -9,6 +10,8 @@
         "--web.config.file=/etc/node_exporter/node_exporter.yaml",
 {% endif %}
         "--web.disable-exporter-metrics",
+        "--collector.systemd",
+        "--collector.systemd.unit-include=(edpm_.*|ovs.*|openvswitch|virt.*|rsyslog)\\.service",
         "--no-collector.dmi",
         "--no-collector.entropy",
         "--no-collector.thermal_zone",
@@ -39,6 +42,6 @@
         "{{ edpm_telemetry_config_dest }}/node_exporter.yaml:/etc/node_exporter/node_exporter.yaml:z",
         "{{ edpm_telemetry_certs }}:/etc/node_exporter/tls:z",
 {% endif %}
-        "/var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw,z"
+        "/var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw"
     ]
 }

--- a/roles/edpm_telemetry/templates/node_exporter.json.j2
+++ b/roles/edpm_telemetry/templates/node_exporter.json.j2
@@ -37,7 +37,8 @@
     "volumes": [
 {% if tls_cert_exists|bool %}
         "{{ edpm_telemetry_config_dest }}/node_exporter.yaml:/etc/node_exporter/node_exporter.yaml:z",
-        "{{ edpm_telemetry_certs }}:/etc/node_exporter/tls:z"
+        "{{ edpm_telemetry_certs }}:/etc/node_exporter/tls:z",
 {% endif %}
+        "/var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw,z"
     ]
 }


### PR DESCRIPTION
Relabeling dbus socket introduced issues with systemd in the past. This patch reintroduces systemd collector for node_exporter without messing with selinux, but using root user instead.