### PR TITLE
Change edpm_network_config_safe_defaults to false

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -50,7 +50,7 @@ edpm_network_config_interface_name: nic1
 edpm_network_config_manage_service: true
 edpm_network_config_nmstate: false
 edpm_network_config_os_net_config_mappings: {}
-edpm_network_config_safe_defaults: true
+edpm_network_config_safe_defaults: false
 edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"
 edpm_dns_search_domains: []

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -62,7 +62,7 @@ argument_specs:
         description: >
           If enabled, safe defaults (DHCP for all interfaces) will be applied in
           case of failing while applying the provided net config.
-        default: true
+        default: false
       edpm_network_config_template:
         type: str
         description: "Which settings template should be rendered."


### PR DESCRIPTION
While edpm_network_config_safe_defaults is true, os-net-config tries to configure DHCP to all physical interfaces and update resolv.conf. This behavior should not be default because a user cannot detect the failure by this.

To prevent the uninteded configuration, change the default to false.

Resolve: [OSPRH-14370](https://issues.redhat.com//browse/OSPRH-14370)