### PR TITLE
Apply updates for edpm_nova role instead of config

### DIFF
--- a/roles/edpm_libvirt/molecule/default/prepare.yml
+++ b/roles/edpm_libvirt/molecule/default/prepare.yml
@@ -41,7 +41,7 @@
         pushd repo-setup-main
         python3 -m venv ./venv
         PBR_VERSION=0.0.0 ./venv/bin/pip install ./
-        ./venv/bin/repo-setup current-podified -b antelope
+        ./venv/bin/repo-setup -d centos9 current-podified -b antelope
         popd
         rm -rf repo-setup-main
 

--- a/roles/edpm_nova/molecule/default/prepare.yml
+++ b/roles/edpm_nova/molecule/default/prepare.yml
@@ -144,6 +144,11 @@
         csr_content: "{{ csr.csr }}"
         provider: selfsigned
 
+    - name: Set permissions for certificate authority public key
+      ansible.builtin.file:
+        path: "{{ edpm_nova_tls_ca_src_dir }}/tls-ca-bundle.pem"
+        mode: 0644
+
     - name: Gather required facts
       ansible.builtin.setup:
         gather_subset:

--- a/roles/edpm_nova/molecule/default/prepare.yml
+++ b/roles/edpm_nova/molecule/default/prepare.yml
@@ -46,7 +46,7 @@
         pushd repo-setup-main
         python3 -m venv ./venv
         PBR_VERSION=0.0.0 ./venv/bin/pip install ./
-        ./venv/bin/repo-setup current-podified -b antelope
+        ./venv/bin/repo-setup -d centos9 current-podified -b antelope
         popd
         rm -rf repo-setup-main
     # NOTE(gibi): this is done by the boostrap role in a real deployment

--- a/roles/edpm_nova/tasks/update.yml
+++ b/roles/edpm_nova/tasks/update.yml
@@ -1,0 +1,12 @@
+---
+- name: Render newly introduced nova config files
+  tags:
+    - update
+    - nova
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ edpm_nova_config_dest }}/{{ item.dest }}"
+    setype: "container_file_t"
+    mode: "0644"
+  loop:
+    - {"src": "nova_statedir_ownership.py", "dest": "nova_statedir_ownership.py"}

--- a/roles/edpm_ovs/molecule/common/prepare_base.yml
+++ b/roles/edpm_ovs/molecule/common/prepare_base.yml
@@ -7,7 +7,7 @@
     pushd repo-setup-main
     python3 -m venv ./venv
     PBR_VERSION=0.0.0 ./venv/bin/pip install ./
-    ./venv/bin/repo-setup current-podified -b antelope
+    ./venv/bin/repo-setup -d centos9 current-podified -b antelope
     popd
     rm -rf repo-setup-main
 - name: set /etc/localtime

--- a/roles/edpm_update/tasks/containers.yml
+++ b/roles/edpm_update/tasks/containers.yml
@@ -89,21 +89,21 @@
   # multipathd is part of the "nova" EDPM service
   when: '"nova" in edpm_update_running_services'
 
+- name: Apply updates for edpm_nova role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_nova
+    tasks_from: update.yml
+  tags:
+    - edpm_nova
+    - edpm_update
+  when: '"nova" in edpm_update_running_services'
+
 - name: Updates containers for edpm_nova role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_nova
     tasks_from: install.yml
     apply:
       become: true
-  tags:
-    - edpm_nova
-    - edpm_update
-  when: '"nova" in edpm_update_running_services'
-
-- name: Updates configs for edpm_nova role
-  ansible.builtin.include_role:
-    name: osp.edpm.edpm_nova
-    tasks_from: configure.yml
   tags:
     - edpm_nova
     - edpm_update


### PR DESCRIPTION
Inlcuding configure tasks for nova role during updates doesn't work as there are no required data sources attached to osdpd calling the update service.

Introduce the update tasks which contents would be changing from release to release and include only tasks required to "migrate" the configuration and initialization logic of the nova EDPM service from A to B, then from B to C and so on.

When reproducing d/s, repo-setup fails on rhel during molecule
prepare because there is no RDO for rhel.
    
Specify centos9 distro for repo-setup explicitly.

Fix permissions to molecule CA public cert

Nova compute cannot start with the CA file created as 0600 and owned by
ansible user.

Change it to become world readable, so that nova stops failing to
access it in molecule tests. 

Related: [OSPRH-13415](https://issues.redhat.com//browse/OSPRH-13415)
Closes: [OSPRH-14533](https://issues.redhat.com//browse/OSPRH-14533)