### PR TITLE
Don't mask old tripleo services in systemd during the cleanup

### DIFF
--- a/roles/edpm_tripleo_cleanup/tasks/main.yml
+++ b/roles/edpm_tripleo_cleanup/tasks/main.yml
@@ -73,26 +73,6 @@
     loop_var: path
   when: edpm_remove_tripleo_unit_files
 
-- name: Mask tripleo services to make them unusable
-  tags:
-    - adoption
-  become: true
-  ansible.builtin.systemd_service:
-    name: "{{ item }}"
-    masked: true
-  register: result_mask
-  loop: "{{ tripleo_services }}"
-  failed_when: false
-
-- name: Check for errors
-  ansible.builtin.fail:
-    msg: "Attempt to mask service {{ item.item }} failed with {{ item.msg }}"
-  loop: "{{ result_mask.results }}"
-  when: >
-    ('msg' in item) and
-    (item.msg != '') and
-    ("Could not find the requested service" not in item.msg)
-
 - name: Adopt (stop tracking) certs from tripleo
   tags:
     - adoption


### PR DESCRIPTION
This patch removes masking old Tripleo services in systemd (makes them to be
symlinks to /dev/null). All those unit files are removed by the same
role so there should be no need to mask them before.

Closes-issue: #[OSPRH-11323](https://issues.redhat.com//browse/OSPRH-11323)