### PR TITLE
Preliminary bootc update handling

### DIFF
--- a/roles/edpm_update/defaults/main.yml
+++ b/roles/edpm_update/defaults/main.yml
@@ -31,3 +31,7 @@ edpm_update_exclude_packages:
   - openvswitch
 
 edpm_update_running_services: "{{ edpm_service_types }}"
+
+# The bootc container image is provided by the OpenStackVersion
+# CR using the bootcOsContainerImage parameter
+edpm_bootc_os_container_image: ""

--- a/roles/edpm_update/tasks/bootc.yml
+++ b/roles/edpm_update/tasks/bootc.yml
@@ -15,26 +15,7 @@
 # under the License.
 
 
-# "edpm_update" will search for and load any operating system variable file
-
-- name: Apply kernel patch via kpatch
-  ansible.builtin.include_tasks: kpatch.yml
-  when:
-  - edpm_update_enable_kpatch
-  - not ansible_local.bootc
-
-- name: Update packages
-  ansible.builtin.include_tasks: packages.yml
-  when:
-  - edpm_update_enable_packages_update
-  - not ansible_local.bootc
-
-- name: Update OS (bootc)
-  ansible.builtin.include_tasks: bootc.yml
-  when: ansible_local.bootc
-
-- name: Update containers
-  ansible.builtin.include_tasks: containers.yml
-  when:
-  - edpm_update_enable_containers_update
-
+- name: Update bootc image
+  ansible.builtin.shell: bootc switch "{{ edpm_bootc_os_container_image }}"
+  become: true
+  register: bootc_result


### PR DESCRIPTION
This PR adds the basic, preliminary handling for a bootc container upgrade. We simply perform a bootc switch to the image provided via the edpm_bootc_os_container_image variable. It's also necessary to skip other plays responsible for updating packages and kernels params.

Jira: https://issues.redhat.com/browse/OSPRH-14327