### PR TITLE
[edpm_ovn_bgp_agent] Fix molecule after PR#883

### DIFF
--- a/roles/edpm_ovn_bgp_agent/molecule/default/prepare.yml
+++ b/roles/edpm_ovn_bgp_agent/molecule/default/prepare.yml
@@ -63,6 +63,10 @@
         tasks_from: "download_cache.yml"
 
     - name: "Running FRR"
+      vars:
+        edpm_frr_bgp_peers:
+          - 10.64.0.1
+          - 10.65.0.1
       ansible.builtin.include_role:
         name: "osp.edpm.edpm_frr"
         apply:


### PR DESCRIPTION
The following PR added an assertion to the edpm_frr role that makes it fail when default values are used:
https://github.com/openstack-k8s-operators/edpm-ansible/pull/883

This is correct, but edpm_ovn_bgp_agent molecule calls edpm_frr and it needs to configure either edpm_frr_bgp_peers or edpm_frr_bgp_uplinks to avoid the assertion error.