### PR TITLE
Add CA cert to bootstrap service

### DIFF
--- a/roles/edpm_bootstrap/handlers/main.yml
+++ b/roles/edpm_bootstrap/handlers/main.yml
@@ -15,3 +15,11 @@
   changed_when: _swapon_command.rc == 0
   failed_when: _swapon_command.rc != 0
   listen: "create and activate swap"
+
+- name: Run update-ca-trust
+  become: true
+  ansible.builtin.command: /usr/bin/update-ca-trust
+  register: _trust_cmd
+  changed_when: _trust_cmd.rc == 0
+  failed_when: _trust_cmd.rc != 0
+  listen: "update-ca-trust"

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -110,6 +110,34 @@
 - name: Configure swap
   ansible.builtin.import_tasks: swap.yml
 
+- name: Check if CA cert file exists
+  delegate_to: localhost
+  ansible.builtin.stat:
+    path: /var/lib/openstack/cacerts/bootstrap/tls-ca-bundle.pem
+  register: ca_file
+
+- name: Copy CA cert file if present
+  when: ca_file.stat.exists
+  become: true
+  block:
+    - name: Ensure that the CA destination directory exists
+      ansible.builtin.file:
+        path: "/etc/pki/ca-trust/source/anchors"
+        state: "directory"
+        setype: "cert_t"
+        owner: "root"
+        group: "root"
+        mode: "0755"
+
+    - name: Copy CA certs to the standard location on the compute node
+      ansible.builtin.copy:
+        src: "/var/lib/openstack/cacerts/bootstrap/tls-ca-bundle.pem"
+        dest: "/etc/pki/ca-trust/source/anchors/tls-ca-bundle.pem"
+        mode: '0644'
+        owner: root
+        group: root
+      notify: "update-ca-trust"
+
 - name: FIPS tasks
   ansible.builtin.import_tasks: fips.yml
   when: edpm_bootstrap_fips_mode != 'check'


### PR DESCRIPTION
    Add CA cert to bootstrap service
    
    We want to copy the combined-ca-cert-bundle to the compute nodes to
    ensure that any third party certs are trusted.  Lets use the bootstrap
    service to do this.  This change is paired with - but does not depend on
    a change in openstack-operator that will ensure that the bootstrap service has the
    cert bundle mounted to /var/lib/openstack/cacerts/bootstrap.
    
    The relevant change is https://github.com/openstack-k8s-operators/openstack-operator/pull/1374
    
    Jira: OSPRH-14205