### PR TITLE
Set OVN BGP agent as PartOf frr service

### DIFF
--- a/roles/edpm_container_manage/templates/systemd-service.j2
+++ b/roles/edpm_container_manage/templates/systemd-service.j2
@@ -5,6 +5,9 @@ After=edpm-container-shutdown.service
 After={{ lookup('dict', container_data_unit).value.depends_on | default([]) | join(' ') }}
 Wants={{ lookup('dict', container_data_unit).value.depends_on | default([]) | join(' ') }}
 {% endif %}
+{% if lookup('dict', container_data_unit).value.part_of| default([]) | length > 0 %}
+PartOf={{ lookup('dict', container_data_unit).value.part_of | default([]) | join(' ') }}
+{% endif %}
 [Service]
 Restart=always
 {% if lookup('dict', container_data_unit).value.depends_on is defined and (lookup('dict', container_data_unit).value.depends_on | length > 0) and podman_drop_in | default('false') %}

--- a/roles/edpm_ovn_bgp_agent/templates/ovn_bgp_agent.yaml.j2
+++ b/roles/edpm_ovn_bgp_agent/templates/ovn_bgp_agent.yaml.j2
@@ -25,6 +25,8 @@ user: root
 restart: always
 depends_on:
   - openvswitch.service
+part_of:
+  - frr.service
 volumes: {{ edpm_ovn_bgp_agent_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS


### PR DESCRIPTION
OVN BGP agent dynamically configures FRR daemon. In case the daemon is restarted the dynamic configuration is lost until the agent runs a periodic sync.

This can be prevented on systemd level that restarts the agent to perform the sync right after frr was restarted to minimize the downtime.

Resolves: [OSPRH-12363](https://issues.redhat.com//browse/OSPRH-12363)
Signed-off-by: Jakub Libosvar <jlibosva@redhat.com>
(cherry picked from commit d66597a8804aaf6263ad7788d248563f583ff33d)