### PR TITLE
Add bootc fact tasks

### DIFF
--- a/roles/edpm_bootstrap/facts/bootc.fact
+++ b/roles/edpm_bootstrap/facts/bootc.fact
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+BOOTC_SYSTEM="false"
+BOOTC_PACKAGE=$(rpm -qa | grep bootc)
+
+# If the system isn't using bootc, we can exit early here since the
+# RPM wont be installed.
+if [[ $BOOTC_PACKAGE == "" ]]; then
+  echo ${BOOTC_SYSTEM}
+  exit
+fi
+
+is_bootc() {
+  BOOTC_STATUS=$(sudo bootc status --json | jq .status.type)
+  if [[ "$BOOTC_STATUS" == \"bootcHost\" ]]; then
+    BOOTC_SYSTEM="true"
+  fi
+}
+
+is_bootc
+
+echo ${BOOTC_SYSTEM}

--- a/roles/edpm_bootstrap/tasks/bootc.yml
+++ b/roles/edpm_bootstrap/tasks/bootc.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check if /etc/ansible/facts.d/bootc.fact exists
+  ansible.builtin.stat:
+    path: /etc/ansible/facts.d/bootc.fact
+  register: stat_bootc_fact
+
+- name: Ensure bootc fact
+  when: not stat_bootc_fact.stat.exists
+  become: true
+  block:
+
+    - name: Ensure /etc/ansible/facts.d exists
+      ansible.builtin.file:
+        state: directory
+        path: /etc/ansible/facts.d
+        recurse: true
+
+    - name: Ensure /etc/ansible/facts.d/bootc.fact exists
+      ansible.builtin.copy:
+        src: facts/bootc.fact
+        dest: /etc/ansible/facts.d/bootc.fact
+        mode: '755'
+
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -14,6 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+
+- name: Include bootc tasks
+  ansible.builtin.include_tasks: bootc.yml
+
 - name: Ensure /var/log/journal exists
   ansible.builtin.file:
     path: /var/log/journal


### PR DESCRIPTION
Add tasks to ensure the bootc custom fact exists. If it doesn't exist,
copy it in place on the node. This ensures all nodes have the fact in
place, which is needed for pre-provisioned nodes.

Signed-off-by: James Slagle <jslagle@redhat.com>
