### PR TITLE
Trim newline from end of swap path

### DIFF
--- a/roles/edpm_bootstrap/tasks/swap.yml
+++ b/roles/edpm_bootstrap/tasks/swap.yml
@@ -22,7 +22,7 @@
   block:
     - name: Set swap path
       set_fact:
-        edpm_bootstrap_swap_path_value: |
+        edpm_bootstrap_swap_path_value: |-
           {% if ansible_local.bootc | bool %}{{ edpm_bootstrap_swap_path_bootc }}{% else %}{{ edpm_bootstrap_swap_path }}{% endif %}
     - name: Create swapfile if needed
       ansible.builtin.command:


### PR DESCRIPTION
There was an extra newline at the end of the swap path value, causing
the path to be /var/swap\n instead of just /var/swap. Trim the newline
using |-.

Signed-off-by: James Slagle <jslagle@redhat.com>
