### PR TITLE
[frr] Send logs to container's stdout

### DIFF
--- a/roles/edpm_frr/templates/frr.conf.j2
+++ b/roles/edpm_frr/templates/frr.conf.j2
@@ -3,7 +3,7 @@
 frr version {{ edpm_frr_version }}
 frr defaults {{ edpm_frr_defaults }}
 hostname {{ edpm_frr_hostname }}
-log syslog {{ edpm_frr_log_level }}
+log stdout {{ edpm_frr_log_level }}
 log timestamp precision {{ edpm_frr_log_timestamp_precision }}
 service integrated-vtysh-config
 line vty


### PR DESCRIPTION
The frr version we use doesn't work well with "log syslog" configuration from a container.
However, when frr logs are sent to the frr container's stdout, they are written to the server's /var/log/messages and shown with journalctl.

This depends on an frr bug: [RHEL-83966](https://issues.redhat.com//browse/RHEL-83966)

[OSPRH-10204](https://issues.redhat.com//browse/OSPRH-10204)