### PR TITLE
Iscsid use edpm container quadlets

### DIFF
--- a/roles/edpm_container_quadlet/tasks/cleanup.yml
+++ b/roles/edpm_container_quadlet/tasks/cleanup.yml
@@ -1,7 +1,7 @@
 ---
 - name: Stop and disable old standalone container for {{ edpm_container_quadlet_service }}
   ansible.builtin.systemd_service:
-    name: "{{ edpm_container_quadlet_service }}"
+    name: "edpm_{{ edpm_container_quadlet_service }}"
     state: stopped
     enabled: false
   become: true

--- a/roles/edpm_container_quadlet/tasks/main.yml
+++ b/roles/edpm_container_quadlet/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Starting quadlet {{ edpm_container_quadlet_service }}
   ansible.builtin.systemd_service:
-    name: edpm-compute@{{ edpm_container_quadlet_service }}
+    name: edpm@{{ edpm_container_quadlet_service }}
     state: restarted
     enabled: true
     daemon_reload: true

--- a/roles/edpm_iscsid/defaults/main.yml
+++ b/roles/edpm_iscsid/defaults/main.yml
@@ -29,14 +29,38 @@ edpm_iscsid_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 
 edpm_iscsid_image: "quay.io/podified-antelope-centos9/openstack-iscsid:current-podified"
 edpm_iscsid_volumes:
-  - /var/lib/kolla/config_files/iscsid.json:/var/lib/kolla/config_files/config.json:ro
-  - /dev:/dev
-  - /run:/run
-  - /sys:/sys
-  - /lib/modules:/lib/modules:ro
-  - /etc/iscsi:/etc/iscsi:z
-  - /etc/target:/etc/target:z
-  - /var/lib/iscsi:/var/lib/iscsi:z
+  - path: /var/lib/kolla/config_files/iscsid.json
+    mountPath: /var/lib/kolla/config_files/config.json
+    readOnly: true
+    name: iscsid-kolla-config
+  - path: /dev
+    mountPath: /dev
+    readOnly: false
+    name: dev
+  - path: /run
+    mountPath: /run
+    readOnly: false
+    name: run
+  - path: /sys
+    mountPath: /sys
+    readOnly: false
+    name: sys
+  - path: /lib/modules
+    mountPath: /lib/modules
+    readOnly: true
+    name: modules
+  - path: /etc/iscsi
+    mountPath: /etc/iscsi
+    readOnly: false
+    name: etc-iscsi
+  - path: /etc/target
+    mountPath: /etc/target
+    readOnly: false
+    name: etc-target
+  - path: /var/lib/iscsi
+    mountPath: /var/lib/iscsi
+    readOnly: false
+    name: var-lib-iscsi
 
 edpm_iscsid_chap_algs: >-
   {{
@@ -47,3 +71,4 @@ edpm_iscsid_chap_algs: >-
   }}
 # if container health check should be enabled
 edpm_iscsid_healthcheck: true
+edpm_container_quadlet_service: ""

--- a/roles/edpm_iscsid/tasks/run.yml
+++ b/roles/edpm_iscsid/tasks/run.yml
@@ -14,25 +14,27 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Ensure /usr/libexec/edpm-start-podman-container exists
-  ansible.builtin.import_role:
-    name: edpm_container_manage
-    tasks_from: shutdown.yml
-
 - name: Update iscsi health check script
   ansible.builtin.include_tasks:
     file: healthchecks.yml
 
-- name: Manage iscsid containers
-  ansible.builtin.include_role:
-    name: edpm_container_standalone
+- name: Cleanup existing standalone conatiner
+  ansible.builtin.import_role:
+    name: edpm_container_quadlet
+    tasks_from: cleanup.yml
   vars:
-    edpm_container_standalone_service: iscsid
-    edpm_container_standalone_container_defs:
-      iscsid: "{{ lookup('template', 'iscsid.yaml.j2') | from_yaml }}"
-    edpm_container_standalone_kolla_config_files:
+    edpm_container_quadlet_service: iscsid
+
+- name: Configure and start iscsid quadlet
+  ansible.builtin.import_role:
+    name: edpm_container_quadlet
+  vars:
+    edpm_container_quadlet_service: iscsid
+    edpm_container_quadlet_service_use_host_network: true
+    edpm_container_quadlet_service_volumes: "{{ edpm_iscsid_volumes }}"
+    edpm_container_quadlet_service_image: "{{ edpm_iscsid_image }}"
+    edpm_container_quadlet_kolla_config_files:
       iscsid: "{{ lookup('file', 'files/iscsid.yaml') | from_yaml }}"
-  register: manage_iscsid_stat
 
 - name: Check if the iscsid container restart is required
   ansible.builtin.stat:
@@ -49,10 +51,9 @@
 - name: Restart iscsid container to refresh /etcd/iscsid.conf
   become: true
   when:
-    - not manage_iscsid_stat.changed|bool
     - iscsi_restart_stat.stat.exists|bool
   ansible.builtin.systemd:
-    name: edpm_iscsid
+    name: edpm@iscsid
     state: restarted
 
 - name: Remove iscsid container restart sentinel file

--- a/roles/edpm_iscsid/templates/iscsid.yaml.j2
+++ b/roles/edpm_iscsid/templates/iscsid.yaml.j2
@@ -1,13 +1,37 @@
-image: {{ edpm_iscsid_image }}
-net: host
-privileged: true
-restart: always
-{% if edpm_iscsid_healthcheck %}
-healthcheck:
-  test: /openstack/healthcheck
-  mount: /var/lib/openstack/healthchecks/iscsid
-{% endif %}
-volumes:
-  {{ edpm_container_standalone_common_volumes | default([]) + edpm_iscsid_volumes }}
-environment:
-  KOLLA_CONFIG_STRATEGY: COPY_ALWAYS
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /etc/iscsi:z
+  creationTimestamp: "2024-12-09T02:00:14Z"
+  labels:
+    app: iscsid
+  name: iscsid
+spec:
+  hostNetwork: true
+  volumes:
+  {% set vols = edpm_container_quadlet_common_volumes | default([]) + edpm_iscsid_volumes %}
+  {%- for vol in vols -%}
+  - hostPath: 
+      path: {{ vol.path }}
+    name: {{ vol.name }}
+  {% endfor -%}
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    image: {{ edpm_iscsid_image }}
+    name: iscsid
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    {% set vols = edpm_container_quadlet_common_volumes | default([]) + edpm_iscsid_volumes %}
+    {%- for vol in vols -%}
+    - mountPath: {{ vol.mountPath }}
+      name: {{ vol.name }}
+      readOnly: {{ vol.readOnly }}
+    {% endfor -%}


### PR DESCRIPTION
Iscsid use edpm_container_quadlets role

 This change moves the iscsid configuration from using
 edpm_container_standalone, to the new edpm_container_quadlets role.

Jira: https://issues.redhat.com/browse/OSPRH-15121
Signed-off-by: Brendan Shephard <bshephar@redhat.com>