### PR TITLE
Gather local facts for bootc

### DIFF
--- a/playbooks/nova_storage.yml
+++ b/playbooks/nova_storage.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Deploy iSCSI daemon
       ansible.builtin.import_role:
         name: osp.edpm.edpm_iscsid

--- a/playbooks/reboot.yml
+++ b/playbooks/reboot.yml
@@ -5,6 +5,9 @@
   strategy: linear
   gather_facts: "{{ gather_facts | default(false) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
     - name: Run edpm_reboot
       ansible.builtin.import_role:
         name: osp.edpm.edpm_reboot


### PR DESCRIPTION
Adds the gathering of ansible local facts to the reboot.yml playbook.

Signed-off-by: James Slagle <jslagle@redhat.com>
