### PR TITLE
update: Add update and install handling for openstack_network_exporter

### DIFF
--- a/roles/edpm_telemetry/tasks/update.yml
+++ b/roles/edpm_telemetry/tasks/update.yml
@@ -1,0 +1,36 @@
+---
+- name: Check for openstack_network_exporter config
+  ansible.builtin.stat:
+    path: "{{ edpm_telemetry_config_dest }}/openstack_network_exporter.json"
+  register: openstack_network_exporter_config_json
+
+- name: Install openstack_network_operator if not present
+  when: not openstack_network_exporter_config_json.stat.exists
+  become: true
+  block:
+    - name: Determine if cacert file exists
+      ansible.builtin.stat:
+        path: "{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem"
+      register: ca_bundle_stat_res
+
+    - name: Check that tls.crt exists
+      ansible.builtin.stat:
+        path: "{{ edpm_telemetry_certs }}/tls.crt"
+      register: tls_crt_stat
+
+    - name: Check that tls.key exists
+      ansible.builtin.stat:
+        path: "{{ edpm_telemetry_certs }}/tls.key"
+      register: tls_key_stat
+
+    - name: Render container config templates
+      ansible.builtin.template:
+        src: "{{ item }}"
+        dest: "{{ edpm_telemetry_config_dest }}/{{ item | basename | regex_replace('\\.j2$', '') }}"
+        mode: 0644
+      with_items:
+        - ../templates/openstack_network_exporter.json.j2
+        - ../templates/openstack_network_exporter.yaml.j2
+      vars:
+        ca_bundle_exists: "{{ ca_bundle_stat_res.stat.exists }}"
+        tls_cert_exists: "{{ tls_crt_stat.stat.exists and tls_key_stat.stat.exists }}"

--- a/roles/edpm_telemetry/templates/openstack_network_exporter.json.j2
+++ b/roles/edpm_telemetry/templates/openstack_network_exporter.json.j2
@@ -21,8 +21,10 @@
 {% if tls_cert_exists|bool %}
         "{{ edpm_telemetry_certs }}:/etc/openstack_network_exporter/tls:z",
 {% endif %}
+{% if telemetry_test is not defined or not telemetry_test | bool %}
         "/var/run/openvswitch:/run/openvswitch:rw,z",
         "/var/lib/openvswitch/ovn:/run/ovn:rw,z",
+{% endif %}
         "/proc:/host/proc:ro"
     ]
 }

--- a/roles/edpm_update/tasks/containers.yml
+++ b/roles/edpm_update/tasks/containers.yml
@@ -139,6 +139,17 @@
     - edpm_update
   when: '"run-os" in edpm_update_running_services'
 
+- name: Updates configs for edpm_telemetry role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_telemetry
+    tasks_from: update.yml
+    apply:
+      become: true
+  tags:
+    - edpm_telemetry
+    - edpm_update
+  when: '"telemetry" in edpm_update_running_services'
+
 - name: Updates containers for edpm_telemetry role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_telemetry


### PR DESCRIPTION
The openstack_network_exporter was not present in previous releases. Added code to check for the presence of the exporter and install if necessary before running through the update process.

[OSPRH-14841](https://issues.redhat.com//browse/OSPRH-14841)