### PR TITLE
Nftables reload

### DIFF
--- a/roles/edpm_nftables/tasks/configure.yml
+++ b/roles/edpm_nftables/tasks/configure.yml
@@ -147,6 +147,18 @@
         group: root
         mode: "0600"
 
+    - name: Create a sentinel file when nft rules are changed
+      ansible.builtin.file:
+        path: /etc/nftables/edpm-rules.nft.changed
+        state: touch
+        owner: root
+        group: root
+        mode: "0600"
+      when:
+        - nft_ruleset is defined
+        - nft_ruleset is changed
+
+
 # We cannot use the "validate" parameter from the "template" module, since
 # we don't load the chains before. So let's validate now, with all the things.
 # Remember, the "iptables" compat layout is already loaded at this point.

--- a/roles/edpm_nftables/tasks/configure.yml
+++ b/roles/edpm_nftables/tasks/configure.yml
@@ -47,12 +47,14 @@
         owner: root
         group: root
         mode: "0600"
+      register: iptables_nft_ruleset
 
     - name: Load empty ruleset
       ansible.builtin.command: nft -f /etc/nftables/iptables.nft
       register: nft_iptables
       changed_when: nft_iptables.rc == 0
       failed_when: nft_iptables.rc != 0
+      when: iptables_nft_ruleset.changed  # noqa: no-handler
 
 # Get current nft rules in JSON format, with our iptables compat content.
 - name: Get current nftables content

--- a/roles/edpm_nftables/tasks/run.yml
+++ b/roles/edpm_nftables/tasks/run.yml
@@ -26,12 +26,22 @@
 - name: Reload custom nftables ruleset files
   become: true
   block:
+    - name: Check if rules are changed
+      ansible.builtin.stat:
+        path: /etc/nftables/edpm-rules.nft.changed
+      register: nft_ruleset_changed
     - name: Reload ruleset
       ansible.builtin.shell: >-
         set -o pipefail;
         cat /etc/nftables/edpm-flushes.nft
         /etc/nftables/edpm-rules.nft
         /etc/nftables/edpm-update-jumps.nft | nft -f -
+      when: nft_ruleset_changed.stat.exists
       register: nft_reload_ruleset
       changed_when: nft_reload_ruleset.rc == 0
       failed_when: nft_reload_ruleset.rc != 0
+  always:
+    - name: Delete nft_ruleset_changed file
+      ansible.builtin.file:
+        path: /etc/nftables/edpm-rules.nft.changed
+        state: absent


### PR DESCRIPTION
In cases where the iptables compatibility ruleset has already been added,
we can skip applying it again which will allow us to avoid reloading nftables
each deployment.

Jira: https://issues.redhat.com/browse/OSPRH-15473
Signed-off-by: Brendan Shephard <bshephar@redhat.com>