### PR TITLE
Noqa on container volume formatting

### DIFF
--- a/plugins/modules/edpm_container_manage.py
+++ b/plugins/modules/edpm_container_manage.py
@@ -301,7 +301,7 @@ class EdpmContainerManage:
             # add healthcheck script to the list of volume mounts
             mnt = opts['healthcheck'].get('mount', None)
             if mnt is not None:
-                opts['volume'].append(f'{mnt}:{os.path.dirname(tst)}:ro,z')
+                opts['volume'].append(f'{mnt}:{os.path.dirname(tst)}:ro,z')  # noqa
             opts['healthcheck'] = tst
         if 'check_interval' in opts:
             opts['healthcheck_interval'] = opts.pop('check_interval')


### PR DESCRIPTION
Flake8 complains about how we're formatting the container volume string. This change ignores the following complaints:

flake8...................................................................Failed
- hook id: flake8
- exit code: 1

plugins/modules/edpm_container_manage.py:304:46: E231 missing whitespace after ':'
plugins/modules/edpm_container_manage.py:304:69: E231 missing whitespace after ':'
plugins/modules/edpm_container_manage.py:304:72: E231 missing whitespace after ','