### PR TITLE
Ignore no-handler lint errors

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,3 +22,4 @@ profile: production
 skip_list:
   - command-instead-of-shell
   - galaxy[version-incorrect]
+  - no-handler


### PR DESCRIPTION
We have decided as a project not to enforce handler usage, therefor we should add the no-handler filter to the ignore list, rather than having to noqa: no-handler throughout the codebase.