### PR TITLE
Consolidate "redhat" service conditions

### DIFF
--- a/playbooks/redhat.yml
+++ b/playbooks/redhat.yml
@@ -19,6 +19,8 @@
         name: "{{ lookup('ansible.builtin.env', 'EDPM_SYSTEMROLES', default='redhat.rhel_system_roles') + '.rhc' }}"
         apply:
           become: true
-      when: ansible_facts['distribution'] | lower == 'redhat'
+      when:
+        - ansible_facts['distribution'] | lower == 'redhat'
+        - rhc_auth | length > 0
       tags:
         - edpm_bootstrap


### PR DESCRIPTION
A node can be running RHEL, but doesn't necessarly need to
register/subscribe.

This PR ensures the node is running RHEL (as before), but also checks we
have at least `rhc_auth` parameter defined, and not empty.
This should provide enough security to re-add the "redhat" service in
the default list.

Related-Issue: [OSPRH-15644](https://issues.redhat.com//browse/OSPRH-15644)
