### PR TITLE
Do not change FIPS status for bootc and warn if requested

### DIFF
--- a/roles/edpm_bootstrap/tasks/fips.yml
+++ b/roles/edpm_bootstrap/tasks/fips.yml
@@ -21,9 +21,17 @@
   changed_when: false
   failed_when: false
 
+- name: Warn for changing FIPS status for bootc
+  debug:
+    msg: FIPS status can not be changed for bootc
+  when:
+    - edpm_bootstrap_fips_mode != 'check'
+    - ansible_local.bootc
+
 - name: Change FIPS status
   when:
     - edpm_bootstrap_fips_mode != 'check'
+    - not ansible_local.bootc
     - >
       edpm_bootstrap_fips_mode !=
       edpm_bootstrap_fips_fms_status |


### PR DESCRIPTION
FIPS status can't be changed on a running bootc system. Add a warning if
a change is requesetd.

Jira: [OSPRH-11433](https://issues.redhat.com//browse/OSPRH-11433)
Signed-off-by: James Slagle <jslagle@redhat.com>
