### PR TITLE
Make ansible-lint happy with telemetry_power_monititoring

### DIFF
--- a/roles/edpm_telemetry_power_monitoring/tasks/configure.yml
+++ b/roles/edpm_telemetry_power_monitoring/tasks/configure.yml
@@ -77,7 +77,7 @@
 
 - name: Append custom.conf to config files
   ansible.builtin.set_fact:
-    configs: "{{ configs + [{'src': edpm_telemetry_config_src + '/custom.conf', 'dest': edpm_telemetry_config_dest + '/custom.conf' }] }}"
+    configs: "{{ configs + [{'src': edpm_telemetry_config_src + '/custom.conf', 'dest': edpm_telemetry_config_dest + '/custom.conf'}] }}"
   when: custom_ceilometer_conf.stat.exists
 
 - name: Copy generated ceilometer configs


### PR DESCRIPTION
Ansible lint was complaining about the jinja2 spacing used in the configure.yml playbook. This change fixes the spacing as per the suggestion from ansible-lint.