### PR TITLE
Force rhc_organization variable to be interger

### DIFF
--- a/playbooks/redhat.yml
+++ b/playbooks/redhat.yml
@@ -24,3 +24,5 @@
         - rhc_auth | length > 0
       tags:
         - edpm_bootstrap
+      vars:
+        rhc_organization: "{{ rhc_organization | int | default(omit) }}"  # noqa: jinja[invalid]


### PR DESCRIPTION
In situations where we're unmarshaling data from json to form variables, it's possible that those values can be unmarshalled as floating point numbers. Which would be incompatible with the current org ID's. This change asserts that the type of number for rhc_organization should be an integer.

Jira: https://issues.redhat.com/browse/OSPRH-15097