### PR TITLE
fips_status: 'check' must be a string

### DIFF
--- a/roles/edpm_bootstrap/tasks/fips_status.yml
+++ b/roles/edpm_bootstrap/tasks/fips_status.yml
@@ -31,7 +31,7 @@
       }}
 
 - name: Assert that we have the wanted status
-  when: edpm_bootstrap_fips_mode != check
+  when: edpm_bootstrap_fips_mode != 'check'
   ansible.builtin.assert:
     that:
       - >


### PR DESCRIPTION
Otherwise, it's considered a variable name.

Signed-off-by: James Slagle <jslagle@redhat.com>