### PR TITLE
Gather local facts for neutron_dhcp playbook

### DIFF
--- a/playbooks/neutron_dhcp.yml
+++ b/playbooks/neutron_dhcp.yml
@@ -7,6 +7,10 @@
   any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
   max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Neutron DHCP agent
       ansible.builtin.import_role:
         name: osp.edpm.edpm_neutron_dhcp


### PR DESCRIPTION
Needed to set the bootc fact so the ovs install is skipped since
edpm_ovs/tasks/install.yml gets included.

Jira: [OSPRH-11526](https://issues.redhat.com//browse/OSPRH-11526)
Jira: [OSPRH-11565](https://issues.redhat.com//browse/OSPRH-11565)
Signed-off-by: James Slagle <jslagle@redhat.com>
