### PR TITLE
OVS NetworkManager Plugin installation issue

### DIFF
--- a/roles/edpm_network_config/tasks/download_cache.yml
+++ b/roles/edpm_network_config/tasks/download_cache.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Download packages needed by linux-system-role - nmstate
-  when: edpm_network_config_tool == 'nmstate'
+- name: Download packages needed by linux-system-role - nmstate and nmsate provider
+  when: edpm_network_config_tool == 'nmstate' or edpm_network_config_nmstate | bool
   ansible.builtin.dnf:
     name: "{{ edpm_network_config_systemrole_nmstate_dependencies }}"
     download_only: true

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -23,8 +23,8 @@
     - edpm_network_config_tool == 'nmstate'
     - not edpm_network_config_tool_nmstate_override|bool
 
-- name: Configure network with network role from system roles [nmstate]
-  when: edpm_network_config_tool == 'nmstate'
+- name: Install OVS NetworkManager plugin [nmstate and nmstate provider]
+  when: edpm_network_config_tool == 'nmstate' or edpm_network_config_nmstate | bool
   become: true
   block:
     - name: Install OVS NetworkManager plugin [nmstate]
@@ -40,6 +40,11 @@
         name: NetworkManager
         state: restarted
       when: nm_ovs_status.changed  # noqa: no-handler
+
+- name: Configure network with network role from system roles [nmstate]
+  when: edpm_network_config_tool == 'nmstate'
+  become: true
+  block:
     - name: Render network_state variable
       ansible.builtin.set_fact:
         network_state: "{{ edpm_network_config_template | from_yaml }}"


### PR DESCRIPTION
This change is to fix the OVS NetworkManager plugin installation for os-net-config wnmstate provider.