### PR TITLE
Gather local facts for configure_ovs_dpdk playbook

### DIFF
--- a/playbooks/configure_ovs_dpdk.yml
+++ b/playbooks/configure_ovs_dpdk.yml
@@ -5,11 +5,16 @@
   strategy: linear
   gather_facts: "{{ gather_facts | default(false) }}"
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Install openvswitch package
       become: true
       ansible.builtin.dnf:
         name: openvswitch
         state: present
+      when: not ansible_local.bootc
 
     - name: Configure OvS DPDK configs
       ansible.builtin.import_role:


### PR DESCRIPTION
Also skip openvswitch package install when bootc. The package is already
installed in the base bootc image.

Jira: [OSPRH-11558](https://issues.redhat.com//browse/OSPRH-11558)
Signed-off-by: James Slagle <jslagle@redhat.com>
