### PR TITLE
Gather local facts for playbooks/telemetry_logging.yml

### DIFF
--- a/playbooks/telemetry_logging.yml
+++ b/playbooks/telemetry_logging.yml
@@ -22,6 +22,10 @@
   any_errors_fatal: true
   # Only enables rsyslog
   tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
     - name: Deploy logging
       ansible.builtin.import_role:
         name: osp.edpm.edpm_telemetry_logging

--- a/roles/edpm_telemetry_logging/tasks/configure.yml
+++ b/roles/edpm_telemetry_logging/tasks/configure.yml
@@ -31,7 +31,9 @@
       ansible.builtin.dnf:
         name: rsyslog-openssl
         state: present
-      when: telemetry_test is undefined or not telemetry_test
+      when:
+        - telemetry_test is undefined or not telemetry_test
+        - not ansible_local.bootc
 
     - name: Copy Openshift CA to the node
       ansible.builtin.copy:


### PR DESCRIPTION
Also skip package install of rsyslog-openssl when bootc. The package is
installed in the bootc image in
https://github.com/openstack-k8s-operators/edpm-image-builder/pull/70.

Jira: [OSPRH-11580](https://issues.redhat.com//browse/OSPRH-11580)
Jira: [OSPRH-11545](https://issues.redhat.com//browse/OSPRH-11545)
Signed-off-by: James Slagle <jslagle@redhat.com>
