### PR TITLE
Allow traffic for ceilometer-ipmi-prom-exporter

### DIFF
--- a/roles/edpm_telemetry/templates/firewall.yaml.j2
+++ b/roles/edpm_telemetry/templates/firewall.yaml.j2
@@ -5,11 +5,16 @@
     proto: tcp
     dport:
      - "9100"
-- rule_name: 000 Allow ceilometer_prom_exporter traffic
+- rule_name: 000 Allow ceilometer_compute_prom_exporter traffic
   rule:
     proto: tcp
     dport:
      - "9101"
+- rule_name: 000 Allow ceilometer_ipmi_prom_exporter traffic
+  rule:
+    proto: tcp
+    dport:
+     - "9102"
 - rule_name: 000 Allow podman_exporter traffic
   rule:
     proto: tcp


### PR DESCRIPTION
This is required to enable Prom-Exporter in Ceilometer-IPMI 
https://github.com/openstack-k8s-operators/telemetry-operator/pull/678
