### PR TITLE
edpm_kernel: bootc support

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -45,7 +45,6 @@
         name: osp.edpm.edpm_kernel
       tags:
         - edpm_kernel
-      when: not ansible_local.bootc
     - name: Import edpm_tuned
       ansible.builtin.import_role:
         name: osp.edpm.edpm_tuned
@@ -57,11 +56,9 @@
         tasks_from: kernelargs.yml
       tags:
         - edpm_kernel
-      when: not ansible_local.bootc
     - name: Configure KSM for kernel
       ansible.builtin.import_role:
         name: osp.edpm.edpm_kernel
         tasks_from: ksm.yml
       tags:
         - edpm_kernel
-      when: not ansible_local.bootc

--- a/roles/edpm_kernel/molecule/kernelargs-update-bootc/converge.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-bootc/converge.yml
@@ -1,0 +1,69 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  pre_tasks:
+  tasks:
+
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        filter: ansible_local
+
+    - name: Create BLS entry dir
+      file:
+        dest: /boot/loader/entries/
+        state: directory
+        recurse: true
+
+    - name: Create BLS entry files
+      ansible.builtin.copy:
+        dest: /boot/loader/entries/{{ item }}
+        content: |
+          title CentOS Stream 9 (ostree:1)
+          version {{ item_index }}
+          options root=UUID=root-uuid rw boot=UUID=boot-uuid rw console=tty0 console=ttyS0 ostree=/ostree/boot.0/default/ostree-uuid/0
+          linux /boot/ostree/default-ostree-uuid/vmlinuz-5.14.0-570.el9.x86_64
+          initrd /boot/ostree/default-ostree-uuid/initramfs-5.14.0-570.el9.x86_64.img
+          aboot /ostree/deploy/default/deploy/deploy-uuid.0/usr/lib/ostree-boot/aboot.img
+          abootcfg /ostree/deploy/default/deploy/deploy-uuid.0/usr/lib/ostree-boot/aboot.cfg
+      loop:
+        - ostree-1.conf
+        - ostree-2.conf
+      loop_control:
+        index_var: item_index
+
+    - name: Set 2 new initial kernel args
+      vars:
+        test_kernelargs: "test1=1 test2=2"
+      include_tasks: test_kernelargs.yml
+
+    - name: Set 1 new additional kernel args
+      vars:
+        test_kernelargs: "test1=1 test2=2 test3=3"
+      include_tasks: test_kernelargs.yml
+
+    - name: Remove 1 kernel arg
+      vars:
+        test_kernelargs: "test1=1 test3=3"
+      include_tasks: test_kernelargs.yml
+
+    - name: Remove all kernel args
+      vars:
+        test_kernelargs: ""
+      include_tasks: test_kernelargs.yml

--- a/roles/edpm_kernel/molecule/kernelargs-update-bootc/molecule.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-bootc/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+  playbooks:
+    # cleanup: ${MOLECULE_SCENARIO_DIRECTORY}/../../resources/molecule/cleanup.yml
+    prepare: ${MOLECULE_SCENARIO_DIRECTORY}/../../resources/molecule/prepare-bootc.yml
+scenario:
+  name: kernelargs-update-bootc
+  test_sequence:
+  - prepare
+  - converge
+  - check
+  - cleanup
+verifier:
+  name: testinfra

--- a/roles/edpm_kernel/molecule/kernelargs-update-bootc/test_kernelargs.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-bootc/test_kernelargs.yml
@@ -1,0 +1,43 @@
+- name: Test kernelargs
+  become: true
+  block:
+    - name: set kernelargs
+      vars:
+        edpm_kernel_args: "{{ test_kernelargs }}"
+      include_role:
+        name: osp.edpm.edpm_kernel
+        tasks_from: kernelargs.yml
+
+    - name: check kernelargs
+      ansible.builtin.lineinfile:
+        dest: /boot/loader/entries/{{ item }}
+        line:
+          options root=UUID=root-uuid rw boot=UUID=boot-uuid rw console=tty0 console=ttyS0 ostree=/ostree/boot.0/default/ostree-uuid/0 {{ test_kernelargs }}
+      loop:
+        - ostree-1.conf
+        - ostree-2.conf
+      check_mode: true
+      register: check_kernelargs
+        
+    - name: check kernelargs EDPM_KERNEL_ARGS
+      ansible.builtin.lineinfile:
+        dest: /boot/loader/entries/{{ item }}
+        line: |-
+          # EDPM_KERNEL_ARGS={{ test_kernelargs }}
+      loop:
+        - ostree-1.conf
+        - ostree-2.conf
+      check_mode: true
+      register: check_kernelargs_edpm_kernel_args
+
+    - name: assert kernelargs
+      ansible.builtin.assert:
+        that:
+          - "{{ not item.changed }}"
+      loop: "{{ check_kernelargs.results }}"
+
+    - name: assert kernelargs EDPM_KERNEL_ARGS
+      ansible.builtin.assert:
+        that:
+          - "{{ not item.changed }}"
+      loop: "{{ check_kernelargs_edpm_kernel_args.results }}"

--- a/roles/edpm_kernel/molecule/kernelargs-update-bootc/verify.yml
+++ b/roles/edpm_kernel/molecule/kernelargs-update-bootc/verify.yml
@@ -1,0 +1,46 @@
+---
+# Copyright 2019 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Check if the kernel args is applied to the grub file
+      lineinfile:
+        path: /etc/default/grub
+        line: 'GRUB_EDPM_KERNEL_ARGS=" test=1 "'
+        state: present
+      check_mode: true
+      register: grub
+      failed_when: (grub is changed) or (grub is failed)
+    - name: Check if the older name entries are removed
+      lineinfile:
+        path: /etc/default/grub
+        regexp: '^EDPM_KERNEL_ARGS.*'
+        state: absent
+      check_mode: true
+      register: grub
+      failed_when: (grub is changed) or (grub is failed)
+    - name: Check if the older name entries are removed for append
+      lineinfile:
+        path: /etc/default/grub
+        regexp: '.*{EDPM_KERNEL_ARGS}.*'
+        state: absent
+      check_mode: true
+      register: grub
+      failed_when: (grub is changed) or (grub is failed)

--- a/roles/edpm_kernel/resources/molecule/prepare-bootc.yml
+++ b/roles/edpm_kernel/resources/molecule/prepare-bootc.yml
@@ -1,0 +1,19 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- ansible.builtin.import_playbook: prepare.yml
+  vars:
+    test_deps_bootc_fact: true

--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -50,15 +50,6 @@
 - name: Handle hugepages
   ansible.builtin.include_tasks: hugepages.yml
 
-- name: Check if the kernelargs entry is already present in the file
-  become: true
-  ansible.builtin.replace:
-    regexp: EDPM_KERNEL_ARGS
-    dest: /etc/default/grub
-    replace: ''
-  check_mode: true
-  register: grub_file_entry_check
-
 - name: Set set_kernel_args fact if args need to be set
   ansible.builtin.set_fact:
     set_kernel_args: true
@@ -76,7 +67,21 @@
     - set_kernel_args is true
     - not ansible_local.bootc
   block:
-    # Leapp does not recognise grun entries starting other than GRUB
+
+    - name: Check if the kernelargs entry is already present in the file
+      become: true
+      ansible.builtin.replace:
+        regexp: EDPM_KERNEL_ARGS
+        dest: /etc/default/grub
+        replace: ''
+      check_mode: true
+      register: grub_file_entry_check
+
+    - name: Set boot_file_entry_check fact
+      ansible.builtin.set_fact:
+        boot_file_entry_present: grub_file_entry_check is changed
+
+    # Leapp does not recognise grub entries starting other than GRUB
     # It results wrong formatting of entries in file /etc/default/grub
     # In order to fix it for FFU (queens to train), EDPM_KERNEL_ARGS has been renamed
     # Ensure the fresh deployment is also alinged with the same name
@@ -124,9 +129,33 @@
     - set_kernel_args is true
     - ansible_local.bootc
   block:
+
+    - name: Check if the kernelargs entry is already present in the file
+      become: true
+      ansible.builtin.shell: |
+        grep EDPM_KERNEL_ARGS /boot/loader/entries/*.conf
+      failed_when: false
+      register: grep_edpm_kernel_args
+
+    - name: Set boot_file_entry_check fact
+      ansible.builtin.set_fact:
+        boot_file_entry_present: grep_edpm_kernel_args.rc == 0
+
     - name: Add kernel args to boot entries
       ansible.builtin.shell: |
-        unshare -m /bin/bash -c "mount -o remount,rw /boot; sed \"s/$/ {{ edpm_kernel_args }}/\" /boot/loader/entries/*.conf"
+        set -eux
+        for f in /boot/loader/entries/*.conf; do
+          # Get the previously set kernel args from the commented line
+          old_edpm_kernel_args=$(grep EDPM_KERNEL_ARGS ${f} | cut -d= -f2-)
+          # Delete the commented line
+          unshare -m /bin/bash -c "mount -o remount,rw /boot; sed -i \"/EDPM_KERNEL_ARGS/d\" ${f}"
+          # Delete the previously set kernel args from the options line
+          unshare -m /bin/bash -c "mount -o remount,rw /boot; sed -i \"s/ ${old_edpm_kernel_args}$//\" ${f}"
+          # Set the new kernel args to the options line
+          unshare -m /bin/bash -c "mount -o remount,rw /boot; sed -i \"s/\(^options.*\)/\1 {{ edpm_kernel_args }}/\" ${f}"
+          # Add the commented line
+          unshare -m /bin/bash -c "mount -o remount,rw /boot; echo \"# EDPM_KERNEL_ARGS={{ edpm_kernel_args }}\" >> ${f}"
+        done
 
 - name: Kernel args post configuration
   become: true
@@ -173,10 +202,10 @@
     - name: Reboot tasks
       ansible.builtin.include_tasks: reboot.yaml
       when:
-        - grub_file_entry_check is not changed
+        - not boot_file_entry_present
 
     - name: Skipping reboot for deployed node
       ansible.builtin.debug:  # noqa: no-handler
         msg: "Reboot is skipped for kernel arg change, user has to plan the reboot with migration and downtime"
       when:
-        - grub_file_entry_check is changed
+        - boot_file_entry_present


### PR DESCRIPTION
Additional fixes for bootc support for edpm_kernel module.

Jira: [OSPRH-11503](https://issues.redhat.com//browse/OSPRH-11503)
Signed-off-by: James Slagle <jslagle@redhat.com>
