### PR TITLE
avoid rw permissions on system files for exporters

### DIFF
--- a/roles/edpm_telemetry/templates/openstack_network_exporter.json.j2
+++ b/roles/edpm_telemetry/templates/openstack_network_exporter.json.j2
@@ -22,8 +22,8 @@
         "{{ edpm_telemetry_certs }}:/etc/openstack_network_exporter/tls:z",
 {% endif %}
 {% if telemetry_test is not defined or not telemetry_test | bool %}
-        "/var/run/openvswitch:/run/openvswitch:rw,z",
-        "/var/lib/openvswitch/ovn:/run/ovn:rw,z",
+        "/var/run/openvswitch:/run/openvswitch:ro",
+        "/var/lib/openvswitch/ovn:/run/ovn:ro",
 {% endif %}
         "/proc:/host/proc:ro"
     ]

--- a/roles/edpm_telemetry/templates/podman_exporter.json.j2
+++ b/roles/edpm_telemetry/templates/podman_exporter.json.j2
@@ -26,6 +26,6 @@
         "{{ edpm_telemetry_config_dest }}/podman_exporter.yaml:/etc/podman_exporter/podman_exporter.yaml:z",
         "{{ edpm_telemetry_certs }}:/etc/podman_exporter/tls:z",
 {% endif %}
-       "/run/podman/podman.sock:/run/podman/podman.sock:rw,z"
+       "/run/podman/podman.sock:/run/podman/podman.sock:ro"
     ]
 }


### PR DESCRIPTION
exporters shouldn't have rw permissions on system files. This is a security risk.
this also creates issues with other services causing failures in deployment.