### PR TITLE
Add roles for separate update of services vs operating system

### DIFF
--- a/playbooks/update_services.yml
+++ b/playbooks/update_services.yml
@@ -1,0 +1,14 @@
+---
+
+- name: EDPM update services
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  gather_facts: "{{ gather_facts | default(false) }}"
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Import edpm_update_services
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_update_services
+      tags:
+        - edpm_update_services

--- a/playbooks/update_system.yml
+++ b/playbooks/update_system.yml
@@ -1,0 +1,14 @@
+---
+
+- name: EDPM update system
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  gather_facts: "{{ gather_facts | default(false) }}"
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  tasks:
+    - name: Import edpm_update_system
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_update_system
+      tags:
+        - edpm_update_system

--- a/roles/edpm_update_services/defaults/main.yml
+++ b/roles/edpm_update_services/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# Toggle to enable/disable packages update
+edpm_update_services_enable_packages_update: true
+
+# Toggle to enable/disable containers update
+edpm_update_services_enable_containers_update: true
+
+# List of packages to exclude from the update
+edpm_update_services_exclude_packages: []
+
+edpm_update_services_running_services: "{{ edpm_service_types }}"

--- a/roles/edpm_update_services/meta/argument_specs.yml
+++ b/roles/edpm_update_services/meta/argument_specs.yml
@@ -1,0 +1,24 @@
+---
+argument_specs:
+  # ./roles/edpm_update_services/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_update role.
+    options:
+      edpm_update_services_enable_packages_update:
+        type: bool
+        default: true
+        description: Toggle to enable/disable packages update
+      edpm_update_services_enable_containers_update:
+        type: bool
+        default: true
+        description: Toggle to enable/disable containers update
+      edpm_update_services_exclude_packages:
+        type: list
+        default: []
+        description: List of packages to exclude from the update
+      edpm_update_services_running_services:
+        type: list
+        default: edpm_services
+        description: >
+          Used to select which list of services are running
+          on the machine. The list is provided by openstack-operator.

--- a/roles/edpm_update_services/meta/main.yml
+++ b/roles/edpm_update_services/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_update_services
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_update_services/molecule/default/converge.yml
+++ b/roles/edpm_update_services/molecule/default/converge.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Call edpm_update role"
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_update_services
+      vars:
+        edpm_update_services_enable_containers_update: false
+        edpm_service_types: []
+
+    # We have to run the verifications in this play to
+    # ensure we have access to the internally changed
+    # facts.
+    - name: Conduct some verifications
+      block:
+        - name: Ensure kernel and ovs packages are excluded
+          ansible.builtin.assert:
+            that:
+              - _exclude_packages is defined
+              - "'kernel' in _exclude_packages"
+              - "'kernel-core' in _exclude_packages"
+              - "'openvswitch' in _exclude_packages"

--- a/roles/edpm_update_services/molecule/default/molecule.yml
+++ b/roles/edpm_update_services/molecule/default/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+platforms:
+  - name: edpm-0.localdomain
+    groups:
+      - compute
+provisioner:
+  log: true
+  name: ansible
+
+scenario:
+  test_sequence:
+    - prepare
+    - converge
+    - cleanup
+    - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_update_services/molecule/default/prepare.yml
+++ b/roles/edpm_update_services/molecule/default/prepare.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Prepare test_deps
+  hosts: all
+  gather_facts: false
+  roles:
+    - role: ../../../../molecule/common/test_deps
+      test_deps_setup_edpm: true
+      test_deps_setup_stream: true
+
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  roles:
+    - role: osp.edpm.env_data

--- a/roles/edpm_update_services/tasks/containers.yml
+++ b/roles/edpm_update_services/tasks/containers.yml
@@ -1,0 +1,162 @@
+---
+
+- name: Login to container registries if needed
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_podman
+    tasks_from: login.yml
+    apply:
+      become: true
+  tags:
+    - edpm_podman
+    - edpm_update_services
+
+- name: Updates containers for edpm_iscsid role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_iscsid
+    tasks_from: run.yml
+    apply:
+      become: true
+  tags:
+    - edpm_iscsid
+    - edpm_update_services
+  # iscsid is part of the "nova" EDPM service
+  when: '"nova" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_ovn role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_ovn
+    tasks_from: run.yml
+    apply:
+      become: true
+  tags:
+    - edpm_ovn
+    - edpm_update_services
+  when: '"ovn" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_frr role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_frr
+    tasks_from: run.yml
+    apply:
+      become: true
+  tags:
+    - edpm_frr
+    - edpm_update_services
+  when: '"frr" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_ovn_bgp_agent role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_ovn_bgp_agent
+    tasks_from: run.yml
+    apply:
+      become: true
+  tags:
+    - edpm_ovn_bgp_agent
+    - edpm_update_services
+  when: '"ovn-bgp-agent" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_neutron_metadata role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_metadata
+    tasks_from: run.yml
+    apply:
+      become: true
+  tags:
+    - edpm_neutron_metadata
+    - edpm_update_services
+  when: '"neutron-metadata" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_neutron_ovn role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_ovn
+    tasks_from: run.yml
+    apply:
+      become: true
+  tags:
+    - edpm_neutron_ovn
+    - edpm_update_services
+  when: '"neutron-ovn" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_multipathd role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_multipathd
+    tasks_from: run.yml
+    apply:
+      become: true
+  tags:
+    - edpm_multipathd
+    - edpm_update_services
+  # multipathd is part of the "nova" EDPM service
+  when: '"nova" in edpm_update_services_running_services'
+
+- name: Apply updates for edpm_nova role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_nova
+    tasks_from: update.yml
+  tags:
+    - edpm_nova
+    - edpm_update_services
+  when: '"nova" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_nova role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_nova
+    tasks_from: install.yml
+    apply:
+      become: true
+  tags:
+    - edpm_nova
+    - edpm_update_services
+  when: '"nova" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_neutron_sriov role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_sriov
+    tasks_from: run.yml
+    apply:
+      become: true
+  tags:
+    - edpm_neutron_sriov
+    - edpm_update_services
+  when: '"neutron-sriov" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_neutron_dhcp role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_neutron_dhcp
+    tasks_from: run.yml
+    apply:
+      become: true
+  when: '"neutron-dhcp" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_logrotate_crond role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_logrotate_crond
+    tasks_from: run.yml
+    apply:
+      become: true
+  tags:
+    - edpm_logrotate_crond
+    - edpm_update_services
+  when: '"run-os" in edpm_update_services_running_services'
+
+- name: Updates configs for edpm_telemetry role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_telemetry
+    tasks_from: update.yml
+    apply:
+      become: true
+  tags:
+    - edpm_telemetry
+    - edpm_update_services
+  when: '"telemetry" in edpm_update_services_running_services'
+
+- name: Updates containers for edpm_telemetry role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_telemetry
+    tasks_from: install.yml
+    apply:
+      become: true
+  tags:
+    - edpm_telemetry
+    - edpm_update_services
+  when: '"telemetry" in edpm_update_services_running_services'

--- a/roles/edpm_update_services/tasks/main.yml
+++ b/roles/edpm_update_services/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Update packages
+  ansible.builtin.include_tasks: packages.yml
+  when: edpm_update_services_enable_packages_update
+
+- name: Update containers
+  ansible.builtin.include_tasks: containers.yml
+  when: edpm_update_services_enable_containers_update

--- a/roles/edpm_update_services/tasks/packages.yml
+++ b/roles/edpm_update_services/tasks/packages.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Ensure package update exclusions
+  vars:
+    _exclude_packages_always:
+      - kernel
+      - kernel-core
+      - openvswitch
+  ansible.builtin.set_fact:
+    _exclude_packages: >-
+      {{
+        edpm_update_services_exclude_packages
+        + _exclude_packages_always
+        | ansible.builtin.unique
+      }}
+  tags:
+    - edpm_update_services
+
+- name: Apply package updates needed for service updates
+  become: true
+  ansible.builtin.dnf:  # noqa: package-latest
+    name:
+      - openstack-selinux
+    state: latest
+    update_cache: true
+    exclude: "{{ _exclude_packages }}"
+  tags:
+    - edpm_update_services

--- a/roles/edpm_update_system/defaults/main.yml
+++ b/roles/edpm_update_system/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# Toggle to enable/disable kpatch usage
+edpm_update_system_enable_kpatch: false
+
+# Toggle to enable/disable packages update
+edpm_update_system_enable_packages_update: true
+
+# List of packages to exclude from the update
+edpm_update_system_exclude_packages: []

--- a/roles/edpm_update_system/meta/argument_specs.yml
+++ b/roles/edpm_update_system/meta/argument_specs.yml
@@ -1,0 +1,18 @@
+---
+argument_specs:
+  # ./roles/edpm_update_system/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_update role.
+    options:
+      edpm_update_system_enable_kpatch:
+        type: bool
+        default: false
+        description: Toggle to enable/disable kpatch usage
+      edpm_update_system_enable_packages_update:
+        type: bool
+        default: true
+        description: Toggle to enable/disable packages update
+      edpm_update_system_exclude_packages:
+        type: list
+        default: []
+        description: List of packages to exclude from the update

--- a/roles/edpm_update_system/meta/main.yml
+++ b/roles/edpm_update_system/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_update_system
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.14'
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/edpm_update_system/molecule/default/converge.yml
+++ b/roles/edpm_update_system/molecule/default/converge.yml
@@ -1,0 +1,38 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Call edpm_update_system role"
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_update_system
+      vars:
+        edpm_service_types: []
+
+    # We have to run the verifications in this play to
+    # ensure we have access to the internally changed
+    # facts.
+    - name: Conduct some verifications
+      block:
+        - name: Ensure ovs packages are excluded but kernel is not
+          ansible.builtin.assert:
+            that:
+              - _exclude_packages is defined
+              - "'kernel' not in _exclude_packages"
+              - "'kernel-core' not in _exclude_packages"
+              - "'openvswitch' in _exclude_packages"

--- a/roles/edpm_update_system/molecule/default/molecule.yml
+++ b/roles/edpm_update_system/molecule/default/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+platforms:
+  - name: edpm-0.localdomain
+    groups:
+      - compute
+provisioner:
+  log: true
+  name: ansible
+
+scenario:
+  test_sequence:
+    - prepare
+    - converge
+    - cleanup
+    - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_update_system/molecule/default/prepare.yml
+++ b/roles/edpm_update_system/molecule/default/prepare.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Prepare test_deps
+  hosts: all
+  gather_facts: false
+  roles:
+    - role: ../../../../molecule/common/test_deps
+      test_deps_setup_edpm: true
+      test_deps_setup_stream: true
+
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  roles:
+    - role: osp.edpm.env_data

--- a/roles/edpm_update_system/molecule/kpatch/converge.yml
+++ b/roles/edpm_update_system/molecule/kpatch/converge.yml
@@ -1,0 +1,56 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: "Call edpm_update_system role"
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_update_system
+      vars:
+        edpm_service_types: []
+        edpm_update_system_enable_kpatch: true
+
+    # We have to run the verifications in this play to
+    # ensure we have access to the internally changed
+    # facts.
+    - name: Conduct some verifications
+      block:
+        - name: Ensure kernel related packages are excluded
+          ansible.builtin.assert:
+            that:
+              - _exclude_packages is defined
+              - "'kernel' in _exclude_packages"
+              - "'kernel-core' in _exclude_packages"
+
+        - name: Gather all installed packages
+          ansible.builtin.package_facts:
+
+        - name: Check service status if we have kpatch-patch installed
+          when:
+            - ansible_facts.packages["kpatch-patch"] is defined
+          block:
+            - name: Gather services
+              ansible.builtin.service_facts:
+
+            - name: Ensure kpatch.service is running
+              ansible.builtin.assert:
+                that:
+                  - ansible_facts.services['kpatch.service'] is defined
+                  - ansible_facts.services['kpatch.service'].state == 'running'
+                  - ansible_facts.services['kpatch.service'].status == 'enabled'

--- a/roles/edpm_update_system/molecule/kpatch/molecule.yml
+++ b/roles/edpm_update_system/molecule/kpatch/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+platforms:
+  - name: edpm-0.localdomain
+    groups:
+      - compute
+provisioner:
+  log: true
+  name: ansible
+
+scenario:
+  test_sequence:
+    - prepare
+    - converge
+    - cleanup
+    - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_update_system/molecule/kpatch/prepare.yml
+++ b/roles/edpm_update_system/molecule/kpatch/prepare.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Run prepare playbook
+  ansible.builtin.import_playbook: ../default/prepare.yml

--- a/roles/edpm_update_system/tasks/kpatch.yml
+++ b/roles/edpm_update_system/tasks/kpatch.yml
@@ -1,0 +1,38 @@
+---
+- name: Ensure we know about kernel version
+  when:
+    - ansible_facts['kernel'] is undefined
+  ansible.builtin.setup:
+    gather_subset:
+      - '!all,!min'
+      - 'kernel'
+  tags:
+    - edpm_update_system
+
+- name: Ensure kpatch package is installed
+  become: true
+  ansible.builtin.package:
+    name: kpatch
+    state: present
+  tags:
+    - edpm_update_system
+
+- name: Install kpatch-patch if available  # noqa: package-latest
+  failed_when: false
+  become: true
+  ansible.builtin.package:
+    name: "kpatch-patch = {{ ansible_facts['kernel'] }}"
+    state: latest
+  tags:
+    - edpm_update_system
+
+- name: Ensure further update stages will not update kernel
+  vars:
+    _kernel_packages:
+      - kernel
+      - kernel-core
+  ansible.builtin.set_fact:
+    _exclude_packages: >-
+      {{ _exclude_packages + _kernel_packages | ansible.builtin.unique }}
+  tags:
+    - edpm_update_system

--- a/roles/edpm_update_system/tasks/main.yml
+++ b/roles/edpm_update_system/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Set up package exclusions
+  ansible.builtin.set_fact:
+    _exclude_packages: "{{ edpm_update_system_exclude_packages }}"
+  tags:
+    - edpm_update_system
+
+- name: Apply kernel patch via kpatch
+  ansible.builtin.include_tasks: kpatch.yml
+  when: edpm_update_system_enable_kpatch
+
+- name: Update packages
+  ansible.builtin.include_tasks: packages.yml
+  when: edpm_update_system_enable_packages_update

--- a/roles/edpm_update_system/tasks/packages.yml
+++ b/roles/edpm_update_system/tasks/packages.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Import edpm_ovs role for independent openvswitch update
+  ansible.builtin.import_role:
+    name: osp.edpm.edpm_ovs
+    tasks_from: update
+  tags:
+    - edpm_update_system
+
+- name: Ensure openvswitch is excluded from bulk update
+  ansible.builtin.set_fact:
+    _exclude_packages: >-
+      {{ _exclude_packages + ['openvswitch'] | ansible.builtin.unique }}
+  tags:
+    - edpm_update_system
+
+- name: Apply package updates
+  become: true
+  ansible.builtin.dnf:  # noqa: package-latest
+    name: "*"
+    state: latest
+    update_cache: true
+    exclude: "{{ _exclude_packages }}"
+  tags:
+    - edpm_update_system


### PR DESCRIPTION
This splits edpm_update role into edpm_update_system and edpm_update_services.

The plan is that original edpm_update role and its dataplane service CRs will remain as-is for the time being to allow gradual rollout of the new procedure, and when we're happy with the new procedure, we'll drop the old one.

Resolves: https://issues.redhat.com/browse/OSPRH-16546 