### PR TITLE
Allow traffic for the ceilometer_ipmi_prom_exporter in power_monitoring module

### DIFF
--- a/roles/edpm_telemetry/templates/firewall.yaml.j2
+++ b/roles/edpm_telemetry/templates/firewall.yaml.j2
@@ -10,11 +10,6 @@
     proto: tcp
     dport:
      - "9101"
-- rule_name: 000 Allow ceilometer_ipmi_prom_exporter traffic
-  rule:
-    proto: tcp
-    dport:
-     - "9102"
 - rule_name: 000 Allow podman_exporter traffic
   rule:
     proto: tcp

--- a/roles/edpm_telemetry_power_monitoring/templates/firewall.yaml.j2
+++ b/roles/edpm_telemetry_power_monitoring/templates/firewall.yaml.j2
@@ -5,3 +5,8 @@
     proto: tcp
     dport:
      - "8888"
+- rule_name: 000 Allow ceilometer_ipmi_prom_exporter traffic
+  rule:
+    proto: tcp
+    dport:
+     - "9102"


### PR DESCRIPTION
This configuration should go into the edpm_telemetry_power_monitoring role, since that's what deploys the ipmi agent.
