### PR TITLE
Improvements to download retries in roles

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -19,7 +19,7 @@
 
 
 # seconds between retries for download tasks
-edpm_bootstrap_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_bootstrap_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_bootstrap_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -19,10 +19,10 @@
 
 
 # seconds between retries for download tasks
-edpm_bootstrap_download_delay: 5
+edpm_bootstrap_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_bootstrap_download_retries: 5
+edpm_bootstrap_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 # List of packages that are requred to bootstrap EDPM.
 edpm_bootstrap_packages_bootstrap:

--- a/roles/edpm_frr/defaults/main.yml
+++ b/roles/edpm_frr/defaults/main.yml
@@ -86,7 +86,7 @@ edpm_frr_volumes:
   - /run/frr:/run/frr:shared,z
 
 # seconds between retries for download tasks
-edpm_frr_images_download_delay: 5
+edpm_frr_images_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_frr_images_download_retries: 5
+edpm_frr_images_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_frr/defaults/main.yml
+++ b/roles/edpm_frr/defaults/main.yml
@@ -86,7 +86,7 @@ edpm_frr_volumes:
   - /run/frr:/run/frr:shared,z
 
 # seconds between retries for download tasks
-edpm_frr_images_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_frr_images_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_frr_images_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_iscsid/defaults/main.yml
+++ b/roles/edpm_iscsid/defaults/main.yml
@@ -20,10 +20,10 @@
 # All variables within this role should have a prefix of "edpm_iscsid"
 
 # seconds between retries for download tasks
-edpm_iscsid_image_download_delay: 5
+edpm_iscsid_image_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_iscsid_image_download_retries: 5
+edpm_iscsid_image_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_iscsid_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 

--- a/roles/edpm_iscsid/defaults/main.yml
+++ b/roles/edpm_iscsid/defaults/main.yml
@@ -20,7 +20,7 @@
 # All variables within this role should have a prefix of "edpm_iscsid"
 
 # seconds between retries for download tasks
-edpm_iscsid_image_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_iscsid_image_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_iscsid_image_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_kernel/defaults/main.yml
+++ b/roles/edpm_kernel/defaults/main.yml
@@ -18,7 +18,7 @@
 # All variables intended for modification should be placed in this file.
 
 # seconds between retries for download tasks
-edpm_kernel_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_kernel_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_kernel_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_kernel/defaults/main.yml
+++ b/roles/edpm_kernel/defaults/main.yml
@@ -18,10 +18,10 @@
 # All variables intended for modification should be placed in this file.
 
 # seconds between retries for download tasks
-edpm_kernel_download_delay: 5
+edpm_kernel_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_kernel_download_retries: 5
+edpm_kernel_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_kernel_extra_modules: {}
 edpm_kernel_extra_packages: []

--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -22,9 +22,9 @@
 # service name this role manages
 edpm_libvirt_service_name: libvirt
 # seconds between retries for download tasks
-edpm_libvirt_download_delay: 5
+edpm_libvirt_download_delay: "{{ edpm_download_delay | default(5) }}"
 # number of retries for download tasks
-edpm_libvirt_download_retries: 5
+edpm_libvirt_download_retries: "{{ edpm_download_retries | default(5) }}"
 # this sould map to the libvirt
 edpm_libvirt_services:
   - virtlogd

--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -22,7 +22,7 @@
 # service name this role manages
 edpm_libvirt_service_name: libvirt
 # seconds between retries for download tasks
-edpm_libvirt_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_libvirt_download_delay: "{{ edpm_download_delay | default(60) }}"
 # number of retries for download tasks
 edpm_libvirt_download_retries: "{{ edpm_download_retries | default(5) }}"
 # this sould map to the libvirt

--- a/roles/edpm_logrotate_crond/defaults/main.yml
+++ b/roles/edpm_logrotate_crond/defaults/main.yml
@@ -20,10 +20,10 @@
 # All variables within this role should have a prefix of "edpm_logrotate_crond"
 
 # seconds between retries for download tasks
-edpm_logrotate_crond_download_delay: 5
+edpm_logrotate_crond_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_logrotate_crond_download_retries: 5
+edpm_logrotate_crond_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_logrotate_crond_cronie_package: cronie
 

--- a/roles/edpm_logrotate_crond/defaults/main.yml
+++ b/roles/edpm_logrotate_crond/defaults/main.yml
@@ -20,7 +20,7 @@
 # All variables within this role should have a prefix of "edpm_logrotate_crond"
 
 # seconds between retries for download tasks
-edpm_logrotate_crond_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_logrotate_crond_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_logrotate_crond_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_multipathd/defaults/main.yml
+++ b/roles/edpm_multipathd/defaults/main.yml
@@ -19,7 +19,7 @@ edpm_container_cli: "{{ container_cli | default('podman') }}"
 # All variables intended for modification should be placed in this file.
 
 edpm_multipathd_image: "quay.io/podified-antelope-centos9/openstack-multipathd:current-podified"
-edpm_multipathd_image_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_multipathd_image_download_delay: "{{ edpm_download_delay | default(60) }}"
 edpm_multipathd_image_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_multipathd_command: "/usr/sbin/multipathd -d"

--- a/roles/edpm_multipathd/defaults/main.yml
+++ b/roles/edpm_multipathd/defaults/main.yml
@@ -19,8 +19,8 @@ edpm_container_cli: "{{ container_cli | default('podman') }}"
 # All variables intended for modification should be placed in this file.
 
 edpm_multipathd_image: "quay.io/podified-antelope-centos9/openstack-multipathd:current-podified"
-edpm_multipathd_image_download_delay: 5
-edpm_multipathd_image_download_retries: 5
+edpm_multipathd_image_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_multipathd_image_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_multipathd_command: "/usr/sbin/multipathd -d"
 edpm_multipathd_volumes:

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -35,7 +35,7 @@ edpm_network_config_systemrole_nmstate_dependencies:
   - NetworkManager-ovs
 
 # seconds between retries for download tasks
-edpm_network_config_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_network_config_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_network_config_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -35,10 +35,10 @@ edpm_network_config_systemrole_nmstate_dependencies:
   - NetworkManager-ovs
 
 # seconds between retries for download tasks
-edpm_network_config_download_delay: 5
+edpm_network_config_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_network_config_download_retries: 5
+edpm_network_config_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_network_config_update: false
 edpm_network_config_async_poll: 3

--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -22,10 +22,10 @@
 edpm_neutron_dhcp_service_name: neutron-dhcp
 
 # seconds between retries for download tasks
-edpm_neutron_dhcp_images_download_delay: 5
+edpm_neutron_dhcp_images_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_neutron_dhcp_images_download_retries: 5
+edpm_neutron_dhcp_images_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_neutron_dhcp_agent_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_dhcp_service_name }}"
 edpm_neutron_dhcp_agent_config_dir: "/var/lib/config-data/ansible-generated/neutron-dhcp-agent"

--- a/roles/edpm_neutron_dhcp/defaults/main.yml
+++ b/roles/edpm_neutron_dhcp/defaults/main.yml
@@ -22,7 +22,7 @@
 edpm_neutron_dhcp_service_name: neutron-dhcp
 
 # seconds between retries for download tasks
-edpm_neutron_dhcp_images_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_neutron_dhcp_images_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_neutron_dhcp_images_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -5,10 +5,10 @@
 edpm_neutron_metadata_service_name: neutron-metadata
 
 # seconds between retries for download tasks
-edpm_neutron_metadata_images_download_delay: 5
+edpm_neutron_metadata_images_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_neutron_metadata_images_download_retries: 5
+edpm_neutron_metadata_images_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_neutron_metadata_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_metadata_service_name }}"
 edpm_neutron_metadata_agent_config_dir: /var/lib/config-data/ansible-generated/neutron-ovn-metadata-agent

--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -5,7 +5,7 @@
 edpm_neutron_metadata_service_name: neutron-metadata
 
 # seconds between retries for download tasks
-edpm_neutron_metadata_images_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_neutron_metadata_images_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_neutron_metadata_images_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -5,10 +5,10 @@
 edpm_neutron_ovn_service_name: neutron-ovn
 
 # seconds between retries for download tasks
-edpm_neutron_ovn_images_download_delay: 5
+edpm_neutron_ovn_images_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_neutron_ovn_images_download_retries: 5
+edpm_neutron_ovn_images_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_neutron_ovn_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_ovn_service_name }}"
 edpm_neutron_ovn_agent_config_dir: /var/lib/config-data/ansible-generated/neutron-ovn-agent

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -5,7 +5,7 @@
 edpm_neutron_ovn_service_name: neutron-ovn
 
 # seconds between retries for download tasks
-edpm_neutron_ovn_images_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_neutron_ovn_images_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_neutron_ovn_images_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -21,7 +21,7 @@
 edpm_neutron_sriov_service_name: neutron-sriov
 
 # seconds between retries for download tasks
-edpm_neutron_sriov_images_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_neutron_sriov_images_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_neutron_sriov_images_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_neutron_sriov/defaults/main.yml
+++ b/roles/edpm_neutron_sriov/defaults/main.yml
@@ -21,10 +21,10 @@
 edpm_neutron_sriov_service_name: neutron-sriov
 
 # seconds between retries for download tasks
-edpm_neutron_sriov_images_download_delay: 5
+edpm_neutron_sriov_images_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_neutron_sriov_images_download_retries: 5
+edpm_neutron_sriov_images_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 # All variables within this role should have a prefix of "edpm_neutron_sriov_agent"
 edpm_neutron_sriov_agent_config_src: "/var/lib/openstack/configs/{{ edpm_neutron_sriov_service_name }}"

--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -21,7 +21,7 @@
 edpm_nova_service_name: nova
 
 # seconds between retries for download tasks
-edpm_nova_image_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_nova_image_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_nova_image_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_nova/defaults/main.yml
+++ b/roles/edpm_nova/defaults/main.yml
@@ -21,10 +21,10 @@
 edpm_nova_service_name: nova
 
 # seconds between retries for download tasks
-edpm_nova_image_download_delay: 5
+edpm_nova_image_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_nova_image_download_retries: 5
+edpm_nova_image_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 # Note that the src dir is in the AEE container but the
 # dest dir is on the target host

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -5,10 +5,10 @@
 edpm_ovn_service_name: "ovn"
 
 # seconds between retries for download tasks
-edpm_ovn_images_download_delay: 5
+edpm_ovn_images_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_ovn_images_download_retries: 5
+edpm_ovn_images_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_ovn_config_src: "/var/lib/openstack/configs/{{ edpm_ovn_service_name }}"
 edpm_ovn_bridge: br-int

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -5,7 +5,7 @@
 edpm_ovn_service_name: "ovn"
 
 # seconds between retries for download tasks
-edpm_ovn_images_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_ovn_images_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_ovn_images_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -76,7 +76,7 @@ edpm_ovn_bgp_agent_tls_volumes:
 # we need to add the InternalTLSCAFile and do a if/then/else in case tls-e
 
 # seconds between retries for download tasks
-edpm_ovn_bgp_agent_images_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_ovn_bgp_agent_images_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_ovn_bgp_agent_images_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -76,10 +76,10 @@ edpm_ovn_bgp_agent_tls_volumes:
 # we need to add the InternalTLSCAFile and do a if/then/else in case tls-e
 
 # seconds between retries for download tasks
-edpm_ovn_bgp_agent_images_download_delay: 5
+edpm_ovn_bgp_agent_images_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_ovn_bgp_agent_images_download_retries: 5
+edpm_ovn_bgp_agent_images_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 # ovn cluster per node parameters
 # Enable or disable OVN routing for Datapath acceleration

--- a/roles/edpm_ovs/defaults/main.yml
+++ b/roles/edpm_ovs/defaults/main.yml
@@ -20,9 +20,9 @@
 # All variables within this role should have a prefix of "edpm_ovs"
 
 # seconds between retries for download tasks
-edpm_ovs_download_delay: 5
+edpm_ovs_download_delay: "{{ edpm_download_delay | default(5) }}"
 # number of retries for download tasks
-edpm_ovs_download_retries: 5
+edpm_ovs_download_retries: "{{ edpm_download_retries | default(5) }}"
 # this sould map to the ovs
 edpm_ovs_services:
   - openvswitch

--- a/roles/edpm_ovs/defaults/main.yml
+++ b/roles/edpm_ovs/defaults/main.yml
@@ -20,7 +20,7 @@
 # All variables within this role should have a prefix of "edpm_ovs"
 
 # seconds between retries for download tasks
-edpm_ovs_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_ovs_download_delay: "{{ edpm_download_delay | default(60) }}"
 # number of retries for download tasks
 edpm_ovs_download_retries: "{{ edpm_download_retries | default(5) }}"
 # this sould map to the ovs

--- a/roles/edpm_podman/defaults/main.yml
+++ b/roles/edpm_podman/defaults/main.yml
@@ -19,7 +19,7 @@
 
 
 # seconds between retries for download tasks
-edpm_podman_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_podman_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_podman_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_podman/defaults/main.yml
+++ b/roles/edpm_podman/defaults/main.yml
@@ -19,10 +19,10 @@
 
 
 # seconds between retries for download tasks
-edpm_podman_download_delay: 5
+edpm_podman_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_podman_download_retries: 5
+edpm_podman_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_podman_hide_sensitive_logs: "{{ hide_sensitive_logs | default(true) }}"
 

--- a/roles/edpm_sshd/defaults/main.yml
+++ b/roles/edpm_sshd/defaults/main.yml
@@ -20,10 +20,10 @@
 # All variables within this role should have a prefix of "edpm_sshd"
 # Mapping of sshd_config values
 # seconds between retries for download tasks
-edpm_sshd_download_delay: 5
+edpm_sshd_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_sshd_download_retries: 5
+edpm_sshd_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_sshd_packages:
   - openssh-server

--- a/roles/edpm_sshd/defaults/main.yml
+++ b/roles/edpm_sshd/defaults/main.yml
@@ -20,7 +20,7 @@
 # All variables within this role should have a prefix of "edpm_sshd"
 # Mapping of sshd_config values
 # seconds between retries for download tasks
-edpm_sshd_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_sshd_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_sshd_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_swift/defaults/main.yml
+++ b/roles/edpm_swift/defaults/main.yml
@@ -20,7 +20,7 @@
 # All variables within this role should have a prefix of "edpm_swift"
 
 # seconds between retries for download tasks
-edpm_swift_images_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_swift_images_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_swift_images_download_retries: "{{ edpm_download_retries | default(5) }}"

--- a/roles/edpm_swift/defaults/main.yml
+++ b/roles/edpm_swift/defaults/main.yml
@@ -20,10 +20,10 @@
 # All variables within this role should have a prefix of "edpm_swift"
 
 # seconds between retries for download tasks
-edpm_swift_images_download_delay: 5
+edpm_swift_images_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_swift_images_download_retries: 5
+edpm_swift_images_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 # Note that the src dir is in the AEE container but the
 # dest dir is on the target host

--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -37,7 +37,7 @@ edpm_telemetry_cacerts: "/var/lib/openstack/cacerts/{{ edpm_telemetry_service_na
 # If TLS should be enabled for telemetry
 edpm_telemetry_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 # seconds between retries for download tasks
-edpm_telemetry_image_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_telemetry_image_download_delay: "{{ edpm_download_delay | default(60) }}"
 # number of retries for download tasks
 edpm_telemetry_image_download_retries: "{{ edpm_download_retries | default(5) }}"
 # list of tripleo telemetry services to stop during EDPM adoption

--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -37,9 +37,9 @@ edpm_telemetry_cacerts: "/var/lib/openstack/cacerts/{{ edpm_telemetry_service_na
 # If TLS should be enabled for telemetry
 edpm_telemetry_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 # seconds between retries for download tasks
-edpm_telemetry_image_download_delay: 5
+edpm_telemetry_image_download_delay: "{{ edpm_download_delay | default(5) }}"
 # number of retries for download tasks
-edpm_telemetry_image_download_retries: 5
+edpm_telemetry_image_download_retries: "{{ edpm_download_retries | default(5) }}"
 # list of tripleo telemetry services to stop during EDPM adoption
 edpm_telemetry_old_tripleo_compute_sevices:
   - tripleo_ceilometer_agent_compute.service

--- a/roles/edpm_telemetry_power_monitoring/defaults/main.yml
+++ b/roles/edpm_telemetry_power_monitoring/defaults/main.yml
@@ -31,7 +31,7 @@ edpm_telemetry_cacerts: "/var/lib/openstack/cacerts/{{ edpm_telemetry_service_na
 # If TLS should be enabled for telemetry
 edpm_telemetry_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 # seconds between retries for download tasks
-edpm_telemetry_image_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_telemetry_image_download_delay: "{{ edpm_download_delay | default(60) }}"
 # number of retries for download tasks
 edpm_telemetry_image_download_retries: "{{ edpm_download_retries | default(5) }}"
 # list of tripleo telemetry services to stop during EDPM adoption

--- a/roles/edpm_telemetry_power_monitoring/defaults/main.yml
+++ b/roles/edpm_telemetry_power_monitoring/defaults/main.yml
@@ -31,9 +31,9 @@ edpm_telemetry_cacerts: "/var/lib/openstack/cacerts/{{ edpm_telemetry_service_na
 # If TLS should be enabled for telemetry
 edpm_telemetry_tls_certs_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 # seconds between retries for download tasks
-edpm_telemetry_image_download_delay: 5
+edpm_telemetry_image_download_delay: "{{ edpm_download_delay | default(5) }}"
 # number of retries for download tasks
-edpm_telemetry_image_download_retries: 5
+edpm_telemetry_image_download_retries: "{{ edpm_download_retries | default(5) }}"
 # list of tripleo telemetry services to stop during EDPM adoption
 edpm_telemetry_old_tripleo_compute_sevices:
   - tripleo_ceilometer_agent_ipmi.service

--- a/roles/edpm_tuned/defaults/main.yml
+++ b/roles/edpm_tuned/defaults/main.yml
@@ -18,10 +18,10 @@
 # All variables intended for modification should be placed in this file.
 
 # seconds between retries for download tasks
-edpm_tuned_download_delay: 5
+edpm_tuned_download_delay: "{{ edpm_download_delay | default(5) }}"
 
 # number of retries for download tasks
-edpm_tuned_download_retries: 5
+edpm_tuned_download_retries: "{{ edpm_download_retries | default(5) }}"
 
 edpm_tuned_profile: "throughput-performance"
 edpm_tuned_custom_profile: ""

--- a/roles/edpm_tuned/defaults/main.yml
+++ b/roles/edpm_tuned/defaults/main.yml
@@ -18,7 +18,7 @@
 # All variables intended for modification should be placed in this file.
 
 # seconds between retries for download tasks
-edpm_tuned_download_delay: "{{ edpm_download_delay | default(5) }}"
+edpm_tuned_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_tuned_download_retries: "{{ edpm_download_retries | default(5) }}"


### PR DESCRIPTION
This pull request contains two changes proposed:

**Add variable to override all download retries**

> Currently each edpm_* role defines their own set of variables
> to control the number of retries and delay between retries
> when attempting to download and install the system packages.
> 
> There is over 20 such roles that involve it already, however
> there is no way to set those variables easily for all roles
> at once – the only option for someone is to set all about
> 40 variables in worst scenario.
> 
> This commit introduces two variables that would be used
> as first choice, if provided, by all the roles to allow
> the setting the download retries much easier.

**Increase default delay between download retries**

> From my experience on our testing environments,
> e.g. when there is problem accessing REPOMD.xml file,
> the current default default of 5 seconds is not realistic.
> If repo is temporarily unavailable, it usually takes
> a few minutes before it is back online.
> 
> Hence, let's use at least a minute between retries.