### PR TITLE
Run molecule workflow against molecule dir

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -12,6 +12,7 @@ on:
     - 'plugins/**'
     - 'molecule-requirements.txt'
     - 'requirements.yml'
+    - 'molecule/**'
   workflow_dispatch:
 jobs:
   run_molecule:


### PR DESCRIPTION
The top level molecule directory should trigger the molecule workflow
that runs molecule tests.

Signed-off-by: James Slagle <jslagle@redhat.com>
