### PR TITLE
Follow-ups from split update review

### DIFF
--- a/roles/edpm_update_services/tasks/packages.yml
+++ b/roles/edpm_update_services/tasks/packages.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Apply package updates needed for service updates
+- name: Apply essential package updates required by services
   become: true
   vars:
     _exclude_packages_always:

--- a/roles/edpm_update_services/tasks/packages.yml
+++ b/roles/edpm_update_services/tasks/packages.yml
@@ -1,28 +1,22 @@
 ---
 
-- name: Ensure package update exclusions
+- name: Apply package updates needed for service updates
+  become: true
   vars:
     _exclude_packages_always:
       - kernel
       - kernel-core
       - openvswitch
-  ansible.builtin.set_fact:
-    _exclude_packages: >-
-      {{
-        edpm_update_services_exclude_packages
-        + _exclude_packages_always
-        | ansible.builtin.unique
-      }}
-  tags:
-    - edpm_update_services
-
-- name: Apply package updates needed for service updates
-  become: true
   ansible.builtin.dnf:  # noqa: package-latest
     name:
       - openstack-selinux
     state: latest
     update_cache: true
-    exclude: "{{ _exclude_packages }}"
+    exclude: >-
+      {{
+        edpm_update_services_exclude_packages
+        + _exclude_packages_always
+        | ansible.builtin.unique
+      }}
   tags:
     - edpm_update_services

--- a/roles/edpm_update_system/tasks/kpatch.yml
+++ b/roles/edpm_update_system/tasks/kpatch.yml
@@ -9,11 +9,11 @@
   tags:
     - edpm_update_system
 
-- name: Ensure kpatch package is installed
+- name: Ensure latest kpatch package is installed  # noqa: package-latest
   become: true
   ansible.builtin.package:
     name: kpatch
-    state: present
+    state: latest
   tags:
     - edpm_update_system
 

--- a/roles/edpm_update_system/tasks/kpatch.yml
+++ b/roles/edpm_update_system/tasks/kpatch.yml
@@ -27,12 +27,7 @@
     - edpm_update_system
 
 - name: Ensure further update stages will not update kernel
-  vars:
-    _kernel_packages:
+  ansible.builtin.set_fact:
+    _exclude_packages_kpatch:
       - kernel
       - kernel-core
-  ansible.builtin.set_fact:
-    _exclude_packages: >-
-      {{ _exclude_packages + _kernel_packages | ansible.builtin.unique }}
-  tags:
-    - edpm_update_system

--- a/roles/edpm_update_system/tasks/main.yml
+++ b/roles/edpm_update_system/tasks/main.yml
@@ -14,12 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Set up package exclusions
-  ansible.builtin.set_fact:
-    _exclude_packages: "{{ edpm_update_system_exclude_packages }}"
-  tags:
-    - edpm_update_system
-
 - name: Apply kernel patch via kpatch
   ansible.builtin.include_tasks: kpatch.yml
   when: edpm_update_system_enable_kpatch

--- a/roles/edpm_update_system/tasks/packages.yml
+++ b/roles/edpm_update_system/tasks/packages.yml
@@ -7,19 +7,21 @@
   tags:
     - edpm_update_system
 
-- name: Ensure openvswitch is excluded from bulk update
-  ansible.builtin.set_fact:
-    _exclude_packages: >-
-      {{ _exclude_packages + ['openvswitch'] | ansible.builtin.unique }}
-  tags:
-    - edpm_update_system
-
 - name: Apply package updates
   become: true
+  vars:
+    _exclude_packages_always:
+      - openvswitch
   ansible.builtin.dnf:  # noqa: package-latest
     name: "*"
     state: latest
     update_cache: true
-    exclude: "{{ _exclude_packages }}"
+    exclude: >-
+      {{
+        edpm_update_system_exclude_packages
+        + _exclude_packages_always
+        + _exclude_packages_kpatch | default([])
+        | ansible.builtin.unique
+      }}
   tags:
     - edpm_update_system


### PR DESCRIPTION
This implements three things requested in reviews of #962:

- Simpler and faster (fewer tasks executed) way of dealing with package exclusions.

- Reformulation of 'Apply package updates needed for service updates' into 'Apply essential package updates required by services'

- Making sure we have the latest kpatch package

Related: https://issues.redhat.com/browse/OSPRH-16546 