### PR TITLE
EDPM deployment should not do network cleanup by default

### DIFF
--- a/docs/source/roles/role-edpm_network_config.rst
+++ b/docs/source/roles/role-edpm_network_config.rst
@@ -19,10 +19,14 @@ This Ansible role does the following tasks:
   - Checks for the presence of required RPMS
   - Uses "provider" ifcfg/nmstate based on flag "edpm_network_config_nmstate"
 
-Note: By default this role will cleanup devices/interfaces not in
-"edpm_network_config_template". If there is requirement to keep them
-for pre-provisioned nodes, "edpm_network_config_nonconfigured_cleanup"
-ansible var can be set to "false".
+Note: * With nmstate-provider as the default for os-net-config,
+        using "edpm_network_config_nonconfigured_cleanup" is not recommended.
+        Instead, enabling flag "edpm_network_config_remove_config"
+        with appropriate remove_config section added in
+        "edpm_network_config_template" is the supported option
+
+      * "edpm_network_config_nonconfigured_cleanup" SHOULD NOT be set for
+        update/adoption usecase
 
 Here is an example playbook to run os-net-config tool:
 
@@ -37,4 +41,22 @@ Here is an example playbook to run os-net-config tool:
             edpm_network_config_template: "{{ nic_config_file }}"
 
 .. literalinclude:: ../../../roles/edpm_network_config/tasks/os_net_config.yml
+   :language: YAML
+
+Here is an example playbook to run os-net-config tool with --remove_config section:
+
+.. code-block:: YAML
+
+    - name: Cleanup and apply network configuration only
+      include_role:
+        name: edpm_network_config
+      vars:
+        edpm_network_config_template:
+          "{{ nic_config_file }}"
+        edpm_network_config:
+          remove_config: true
+
+An example of using ``remove_config`` is available in:
+
+.. literalinclude:: ../../../roles/edpm_network_config/molecule/default/converge.yml
    :language: YAML

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -59,7 +59,7 @@ edpm_network_config_safe_defaults: false
 edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"
 edpm_dns_search_domains: []
-edpm_network_config_nonconfigured_cleanup: true
+edpm_network_config_nonconfigured_cleanup: false
 edpm_network_config_remove_config: false
 # Control resolv.conf management by NetworkManager
 # false = disable NetworkManager resolv.conf update (default)

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -94,9 +94,9 @@ argument_specs:
       edpm_network_config_nonconfigured_cleanup:
         type: bool
         description: >
-          For developer use only (use edpm_network_config_remove_config instead).
           Cleanup network interfaces not in network config
-        default: true
+          Note: For developer use only (use edpm_network_config_remove_config instead).
+        default: false
       edpm_network_config_remove_config:
         type: bool
         description: >

--- a/roles/edpm_network_config/molecule/default/converge.yml
+++ b/roles/edpm_network_config/molecule/default/converge.yml
@@ -37,7 +37,7 @@
     edpm_network_config_nmstate: false
     edpm_network_config_hide_sensitive_logs: false
     edpm_network_config_update: false
-    edpm_network_config_remove_config: false
+    edpm_network_config_remove_config: true
     edpm_bootstrap_network_resolvconf_update: false
     edpm_network_config_debug: true
   pre_tasks:
@@ -91,6 +91,13 @@
       ansible.builtin.command: ip addr show
       register: ip_addr
       changed_when: false
+
+    - name: Verify vlan200 was removed by "remove_config" flag
+      ansible.builtin.assert:
+        that:
+          - "'vlan200' not in ip_addr.stdout"
+        fail_msg: "FAILED: vlan200 interface still exists in ip addr output"
+        success_msg: "SUCCESS: vlan200 interface was removed"
 
     - name: Debug ip link state
       ansible.builtin.debug:

--- a/roles/edpm_network_config/molecule/default/prepare.yml
+++ b/roles/edpm_network_config/molecule/default/prepare.yml
@@ -23,6 +23,21 @@
       test_deps_extra_packages:
         - iproute
         - NetworkManager
+
+- name: Add custom RDO component repository
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Add RDO component/common repository
+      ansible.builtin.yum_repository:
+        name: rdo-component-common
+        description: RDO Trunk Component Common Repository
+        baseurl: https://trunk.rdoproject.org/centos9-master/component/common/current/
+        gpgcheck: no
+        enabled: yes
+        priority: 1
+
 - name: Prepare
   hosts: all
   gather_facts: false

--- a/roles/edpm_network_config/molecule/nmstate/converge.yml
+++ b/roles/edpm_network_config/molecule/nmstate/converge.yml
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
 - name: Converge
   hosts: all
   gather_facts: false
@@ -30,10 +29,12 @@
           state: up
           ipv4:
             address:
-            - ip: 192.168.180.2
-              prefix-length: 24
+              - ip: 192.168.180.2
+                prefix-length: 24
             dhcp: false
             enabled: true
+          ipv6:
+            enabled: false
   pre_tasks:
     - name: Gather user fact
       ansible.builtin.setup:


### PR DESCRIPTION
With nmstate-provider set as default for os-net-config, default cleanup during greenfield/update/adoption is not desired.

Relates-to: https://github.com/os-net-config/os-net-config/pull/217/

Jira(s): https://issues.redhat.com/browse/OSPRH-16537
           https://issues.redhat.com/browse/OSPRH-17036
           https://issues.redhat.com/browse/OSPRH-16760