### PR TITLE
Ability to customize the list of RPMs included in system and services update

### DIFF
--- a/roles/edpm_update_services/defaults/main.yml
+++ b/roles/edpm_update_services/defaults/main.yml
@@ -23,6 +23,10 @@ edpm_update_services_enable_packages_update: true
 # Toggle to enable/disable containers update
 edpm_update_services_enable_containers_update: true
 
+# List of essential packages to include in the services update
+edpm_update_services_include_packages:
+  - openstack-selinux
+
 # List of packages to exclude from the update
 edpm_update_services_exclude_packages: []
 

--- a/roles/edpm_update_services/meta/argument_specs.yml
+++ b/roles/edpm_update_services/meta/argument_specs.yml
@@ -12,6 +12,11 @@ argument_specs:
         type: bool
         default: true
         description: Toggle to enable/disable containers update
+      edpm_update_services_include_packages:
+        type: list
+        default:
+          - openstack-selinux
+        description: List of essential packages to include in the services update
       edpm_update_services_exclude_packages:
         type: list
         default: []

--- a/roles/edpm_update_services/tasks/packages.yml
+++ b/roles/edpm_update_services/tasks/packages.yml
@@ -8,8 +8,7 @@
       - kernel-core
       - openvswitch
   ansible.builtin.dnf:  # noqa: package-latest
-    name:
-      - openstack-selinux
+    name: "{{ edpm_update_services_include_packages }}"
     state: latest
     update_cache: true
     exclude: >-

--- a/roles/edpm_update_system/defaults/main.yml
+++ b/roles/edpm_update_system/defaults/main.yml
@@ -23,5 +23,9 @@ edpm_update_system_enable_kpatch: false
 # Toggle to enable/disable packages update
 edpm_update_system_enable_packages_update: true
 
+# List of packages to include in the update
+edpm_update_system_include_packages:
+  - "*"
+
 # List of packages to exclude from the update
 edpm_update_system_exclude_packages: []

--- a/roles/edpm_update_system/meta/argument_specs.yml
+++ b/roles/edpm_update_system/meta/argument_specs.yml
@@ -12,6 +12,11 @@ argument_specs:
         type: bool
         default: true
         description: Toggle to enable/disable packages update
+      edpm_update_system_include_packages:
+        type: list
+        default:
+          - "*"
+        description: List of packages to include in the update
       edpm_update_system_exclude_packages:
         type: list
         default: []

--- a/roles/edpm_update_system/tasks/packages.yml
+++ b/roles/edpm_update_system/tasks/packages.yml
@@ -13,7 +13,7 @@
     _exclude_packages_always:
       - openvswitch
   ansible.builtin.dnf:  # noqa: package-latest
-    name: "*"
+    name: "{{ edpm_update_system_include_packages }}"
     state: latest
     update_cache: true
     exclude: >-


### PR DESCRIPTION
Add `edpm_update_system_include_packages` and `edpm_update_services_include_packages` variables.

Resolves: https://issues.redhat.com/browse/OSPRH-16543
Resolves: https://issues.redhat.com/browse/OSPRH-16544