### PR TITLE
Explicitly install sos report in EDPM nodes

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -46,6 +46,9 @@ edpm_bootstrap_packages_bootstrap:
   - systemd-container
   - crypto-policies-scripts
   - grubby
+  # sos allows must-gather to trigger sosreports on the EDPM
+  # nodes
+  - sos
 
 edpm_bootstrap_release_version_package:
   - rhoso-release


### PR DESCRIPTION
It might happen that the `sos` package is not installed by default in a system where it doesn't appear as a dependency for other packages. For this reason this patch makes it part of the default `EDPM` bootstrap packages to explicitly install it if not present.

Jira: https://issues.redhat.com/browse/OSPRH-17414