### PR TITLE
[libvirt] Give more time to install

### DIFF
--- a/roles/edpm_libvirt/defaults/main.yml
+++ b/roles/edpm_libvirt/defaults/main.yml
@@ -22,9 +22,9 @@
 # service name this role manages
 edpm_libvirt_service_name: libvirt
 # seconds between retries for download tasks
-edpm_libvirt_download_delay: 5
+edpm_libvirt_download_delay: 30
 # number of retries for download tasks
-edpm_libvirt_download_retries: 5
+edpm_libvirt_download_retries: 10
 # this sould map to the libvirt
 edpm_libvirt_services:
   - virtlogd


### PR DESCRIPTION
Wait longer and repeat more times before giving up the installation. It's better to wait 5 min than loose 4 hours of previous deployment. We have seen couple of times failing this because of temporary network glitch or repo sync.