### PR TITLE
Fix permissions for Swift EDPM role

### DIFF
--- a/roles/edpm_swift/tasks/firewall.yml
+++ b/roles/edpm_swift/tasks/firewall.yml
@@ -14,7 +14,17 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Ensure firewall directory is present
+  become: true
+  ansible.builtin.file:
+    path: "/var/lib/edpm-config/firewall/"
+    state: directory
+    owner: root
+    group: root
+    mode: '0750'
+
 - name: Inject firewall rules for Swift
+  become: true
   osp.edpm.edpm_nftables_snippet:
     dest: /var/lib/edpm-config/firewall/swift.yaml
     content: |


### PR DESCRIPTION
Depending on the services deployed before the Swift role, the directory /var/lib/edpm-config/firewall might not exist and/or permissions are (correctly) limited to root, failing later when adding firewall rules.

JIRA: [OSPRH-17624](https://issues.redhat.com//browse/OSPRH-17624)