### PR TITLE
Fix redhat.yml if rhc_organization is not defined

### DIFF
--- a/playbooks/redhat.yml
+++ b/playbooks/redhat.yml
@@ -1,5 +1,18 @@
 ---
-
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
 - name: RH subscription management and Insights
   hosts: "{{ edpm_override_hosts | default('all', true) }}"
   strategy: linear
@@ -25,5 +38,3 @@
         - rhc_auth | length > 0
       tags:
         - edpm_bootstrap
-      vars:
-        rhc_organization: "{{ rhc_organization | int | default(omit) }}"  # noqa: jinja[invalid]


### PR DESCRIPTION
When `rhc_organization` is not defined ansible fails as

```
Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while templating '{{ rhc_organization | int | default(omit) }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: recursive loop detected in template string: {{ rhc_organization | int | default(omit) }}. maximum recursion depth exceeded"}
```

It happens as ansible tries to evaluate `rhc_organization` by looking up rhc_organization, which references itself as it cannot ommit as int is specified before default(ommit). rhel-system-roles.rhc is desinged to handle rhc_organization as string and integer and was tested by simple playbook

```
    - name: Register systems
      hosts: osp-compute-1
      vars:
        rhc_auth:
          login:
            username: *******
            password: *******
        rhc_organization: "********"
        rhc_repositories:
          - {name: "*", state: disabled}
          - {name: "rhel-9-for-x86_64-baseos-eus-rpms", state: enabled}
          - {name: "rhel-9-for-x86_64-appstream-eus-rpms", state: enabled}
          - {name: "rhel-9-for-x86_64-highavailability-eus-rpms", state: enabled}
          - {name: "fast-datapath-for-rhel-9-x86_64-rpms", state: enabled}
          - {name: "rhoso-18.0-for-rhel-9-x86_64-rpms", state: enabled}
          - {name: "rhceph-7-tools-for-rhel-9-x86_64-rpms", state: enabled}
        rhc_release: 9.4
      roles:
        - rhel-system-roles.rhc
```
as well as int.

This patch removes `| int` as this limitation is artificial alluwing us not to refactor any deeper.

Alternatevely we can use `edpm_*` prefix as `edpm_rhc_auth` `edmp_rhc_organization`. However this will require further refactoring of OpenStackDataPlaneNodeSet and documentation as well. Another way is to try to template jinja for `rhc_organization` differently. Though the easiest way is to remove "| int" to stop recursive lookup

Jira: https://issues.redhat.com/browse/OSPRH-17827