### PR TITLE
Revert "Force rhc_organization variable to be interger"

### DIFF
--- a/playbooks/redhat.yml
+++ b/playbooks/redhat.yml
@@ -25,5 +25,3 @@
         - rhc_auth | length > 0
       tags:
         - edpm_bootstrap
-      vars:
-        rhc_organization: "{{ rhc_organization | int | default(omit) }}"  # noqa: jinja[invalid]


### PR DESCRIPTION
This reverts commit 8bd53873ef86aff19aa6eb0a6e5f1a80487ef58d.

When `rhc_organization` is not defined ansible fails as
```
Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while templating '{{ rhc_organization | int | default(omit) }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: recursive loop detected in template string: {{ rhc_organization | int | default(omit) }}. maximum recursion depth exceeded"}
```
It happens as ansible tries to evaluate `rhc_organization` by looking up `rhc_organization`, which references itself. rhel-system-roles.rhc is desinged to handle rhc_organization as string and integer and was tested by simple playbook
```
- name: Register systems hosts: osp-compute-1 vars: rhc_auth: login: username: ******* password: ******* rhc_organization: "********" rhc_repositories: - {name: "*", state: disabled} - {name: "rhel-9-for-x86_64-baseos-eus-rpms", state: enabled} - {name: "rhel-9-for-x86_64-appstream-eus-rpms", state: enabled} - {name: "rhel-9-for-x86_64-highavailability-eus-rpms", state: enabled} - {name: "fast-datapath-for-rhel-9-x86_64-rpms", state: enabled} - {name: "rhoso-18.0-for-rhel-9-x86_64-rpms", state: enabled} - {name: "rhceph-7-tools-for-rhel-9-x86_64-rpms", state: enabled} rhc_release: 9.4 roles:
    - rhel-system-roles.rhc
```
as well as int setting `rhc_organization` without quotes

This patch reverts "r8bd538" as it was fixed on operator level by [1](https://issues.redhat.com/browse/OSPRH-15097) and data is transferred in proper format from OpenStackDataPlaneNodeSet to dataplanenodeset secret.

Jira: https://issues.redhat.com/browse/OSPRH-17827