### PR TITLE
Allow unprivileged rsync use port 873 for Swift

### DIFF
--- a/roles/edpm_swift/tasks/configure.yml
+++ b/roles/edpm_swift/tasks/configure.yml
@@ -25,6 +25,15 @@
   tags:
     - edpm_users
 
+- name: Allow unprivileged rsync use port 873
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_unprivileged_port_start
+    value: '873'
+    sysctl_set: true
+    sysctl_file: "/etc/sysctl.d/99-edpm-swift.conf"
+    state: present
+    reload: true
+
 - name: Gather user fact
   ansible.builtin.setup:
     gather_subset:


### PR DESCRIPTION
rsync uses port 873 to replicate data between Swift storage nodes. However, rsync is running unprivileged and thus not able by default to use port 873. This can be done by using the bootstrap role and setting edpm_kernel_sysctl_extra_settings accordingly.

Because this is always needed for Swift, this patch sets the required sysctl when configuring Swift, making it easier for human operators to deploy correctly.