### PR TITLE
Make edpm-ansible ansible 2.19 compatible

### DIFF
--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,5 +1,5 @@
 # this is required for the docs build jobs
-ansible-core>=2.15.0,<2.19.0
+ansible-core>=2.15.0
 sphinx>=2.0.0,!=2.1.0 # BSD
 reno>=3.1.0 # Apache-2.0
 doc8>=0.8.1 # Apache-2.0

--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.15.0,<2.19.0
+ansible-core>=2.15.0
 molecule>=5.1.0,<6.0.0
 molecule-plugins[podman,vagrant]>=23.5.0
 pytest-testinfra

--- a/openstack_ansibleee/requirements.txt
+++ b/openstack_ansibleee/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.16.1,<2.19.0
+ansible-core>=2.16.1
 ansible-runner>=2.4.0
 ansible-builder>=3.1.0
 dumb-init>=1.2.2

--- a/plugins/action/container_systemd.py
+++ b/plugins/action/container_systemd.py
@@ -25,6 +25,11 @@ import yaml
 
 from ansible.errors import AnsibleActionFail
 from ansible.plugins.action import ActionBase
+try:
+    from ansible.template import trust_as_template
+except ImportError:
+    def trust_as_template(data):
+        return data
 from ansible.utils.display import Display
 
 
@@ -200,11 +205,10 @@ class ActionModule(ActionBase):
             'systemd-service.j2'
         )
         if not os.path.exists(source):
-            raise AnsibleActionFail('Template {} was '
-                                    'not found'.format(source))
+            raise AnsibleActionFail('Template {} was not found'.format(source))
         with open(source) as template_file:
             data = template_file.read()
-        return data
+            return trust_as_template(data)
 
     def _create_units(self, container_config, task_vars):
         """Create system units and get list of changed services

--- a/roles/edpm_kernel/tasks/hugepages.yml
+++ b/roles/edpm_kernel/tasks/hugepages.yml
@@ -19,7 +19,7 @@
     _converted_hugepages: {}
     _nonconfig_hugepages: {}
     _hugepages_modification: false
-  when: edpm_kernel_hugepages | length
+  when: edpm_kernel_hugepages | default({}) | length > 0
   block:
     - name: Rewrite edpm_kernel_hugepages to use integers as keys
       ansible.builtin.set_fact:

--- a/roles/edpm_libvirt/tasks/virsh-secret.yml
+++ b/roles/edpm_libvirt/tasks/virsh-secret.yml
@@ -38,4 +38,4 @@
     KEY: "{{ cephx_key.stdout | regex_replace('\"', '') }}"
   when:
     - cephx_key.stdout is defined
-    - cephx_key.stdout | regex_replace('\"', '') | regex_search('^[a-zA-Z0-9+/]{38}==$')
+    - cephx_key.stdout | regex_replace('\"', '') | regex_search('^[a-zA-Z0-9+/]{38}==$') | length > 0

--- a/roles/edpm_nftables/templates/dport.j2
+++ b/roles/edpm_nftables/templates/dport.j2
@@ -1,19 +1,19 @@
-{%- set ns = namespace(_dport='') %}
+{%- set ns = namespace(dport='') %}
 {%- if 'dport' in rule %}
 {%    if rule['dport'] is iterable and (rule['dport'] is not string and rule['dport'] is not mapping) -%}
-{%      set ns._dport = rule['dport'] |join(', ') -%}
+{%      set ns.dport = rule['dport'] |join(', ') -%}
 {%    else -%}
-{%      set ns._dport = rule['dport'] -%}
+{%      set ns.dport = rule['dport'] -%}
 {%    endif -%}
 {%- endif %}
 {#- This is for legacy things - Really, use dport... #}
 {%- if 'port' in rule %}
 {%    if rule['port'] is iterable and (rule['port'] is not string and rule['port'] is not mapping) -%}
-{%      set ns._dport = rule['port'] |join(', ') -%}
+{%      set ns.dport = rule['port'] |join(', ') -%}
 {%    else -%}
-{%      set ns._dport = rule['port'] -%}
+{%      set ns.dport = rule['port'] -%}
 {%    endif -%}
 {%- endif %}
-{%- if ns._dport != '' %}
- {{ rule.get('proto', false)|ternary('', 'tcp ') }}dport { {{ ns._dport |replace(':', '-') }} }
+{%- if ns.dport != '' %}
+ {{ rule.get('proto', false)|ternary('', 'tcp ') }}dport { {{ ns.dport |replace(':', '-') }} }
 {%- endif %}

--- a/roles/edpm_ovn/tasks/cleanup.yml
+++ b/roles/edpm_ovn/tasks/cleanup.yml
@@ -31,44 +31,51 @@
   changed_when: false
   ignore_errors: true
 
+- name: Initialize cleanup_ovn_cms_options_stdout variable
+  ansible.builtin.set_fact:
+    cleanup_ovn_cms_options_stdout: "{{ cleanup_ovn_cms_options.stdout | default('') }}"
+  when: cleanup_ovn_cms_options.rc == 0
+
 - name: Cleanup enable-chassis-as-gw when chassis GW not enabled
   ansible.builtin.set_fact:
-    cleanup_ovn_cms_options: "{{ cleanup_ovn_cms_options | regex_replace('enable-chassis-as-gw' ~ ',?', '') }}"
+    cleanup_ovn_cms_options_stdout: "{{ cleanup_ovn_cms_options_stdout | regex_replace('enable-chassis-as-gw' ~ ',?', '') }}"
   when:
     - not edpm_enable_chassis_gw | bool
     - cleanup_ovn_cms_options.rc == 0
+    - cleanup_ovn_cms_options_stdout | length > 0
 
 - name: Cleanup enable-chassis-as-extport-host when chassis extport not enabled
   ansible.builtin.set_fact:
-    cleanup_ovn_cms_options: "{{ cleanup_ovn_cms_options | regex_replace('enable-chassis-as-extport-host' ~ ',?', '') }}"
+    cleanup_ovn_cms_options_stdout: "{{ cleanup_ovn_cms_options_stdout | regex_replace('enable-chassis-as-extport-host' ~ ',?', '') }}"
   when:
     - not edpm_enable_chassis_extport | bool
     - cleanup_ovn_cms_options.rc == 0
+    - cleanup_ovn_cms_options_stdout | length > 0
 
 - name: Cleanup availability-zones
   when:
     - edpm_ovn_availability_zones | length == 0
     - cleanup_ovn_cms_options.rc == 0
+    - cleanup_ovn_cms_options_stdout | length > 0
   block:
     - name: Filter out availability-zones from stdout when undefined
       ansible.builtin.set_fact:
-        filtered_azs:
-          stdout: "{{ cleanup_ovn_cms_options.stdout | regex_replace('availability-zones=[^,]*' ~ ',?', '') }}"
+        filtered_azs: "{{ cleanup_ovn_cms_options_stdout | regex_replace('availability-zones=[^,]*' ~ ',?', '') }}"
 
     - name: Update cleanup_ovn_cms_options with filtered azs
       ansible.builtin.set_fact:
-        cleanup_ovn_cms_options: "{{ cleanup_ovn_cms_options | combine(filtered_azs | default({})) }}"
+        cleanup_ovn_cms_options_stdout: "{{ filtered_azs }}"
 
 - name: Set updated OVN CMS Options to the local OVSDB
   become: true
   ansible.builtin.shell: >
-    ovs-vsctl set Open_vSwitch . external_ids:ovn-cms-options={{ cleanup_ovn_cms_options.stdout }}
+    ovs-vsctl set Open_vSwitch . external_ids:ovn-cms-options={{ cleanup_ovn_cms_options_stdout }}
   register: cleanup_ovn_cms_options_set
   changed_when: cleanup_ovn_cms_options_set.rc == 0
   failed_when: cleanup_ovn_cms_options_set.rc != 0
   when:
     - cleanup_ovn_cms_options.rc == 0
-    - cleanup_ovn_cms_options.stdout != ""
+    - cleanup_ovn_cms_options_stdout | length > 0
 
 - name: Clear OVN CMS Options if updated string is empty
   become: true
@@ -79,4 +86,4 @@
   failed_when: cleanup_ovn_cms_options_remove.rc != 0
   when:
     - cleanup_ovn_cms_options.rc == 0
-    - cleanup_ovn_cms_options.stdout == ""
+    - cleanup_ovn_cms_options_stdout | length == 0

--- a/roles/edpm_ovs_dpdk/tasks/configure.yml
+++ b/roles/edpm_ovs_dpdk/tasks/configure.yml
@@ -17,10 +17,10 @@
 - name: Check valid input for edpm_ovs_dpdk_pmd_core_list
   ansible.builtin.fail:
     msg: "List of PMD cores cannot be empty - edpm_ovs_dpdk_pmd_core_list"
-  when: not edpm_ovs_dpdk_pmd_core_list|string or edpm_ovs_dpdk_pmd_core_list == 'null'
+  when: edpm_ovs_dpdk_pmd_core_list|string|length == 0 or edpm_ovs_dpdk_pmd_core_list == 'null'
 
 - name: PMD cores config
-  when: edpm_ovs_dpdk_pmd_core_list|string
+  when: edpm_ovs_dpdk_pmd_core_list|string|length > 0
   block:
     - name: Apply PMD cores config
       ansible.builtin.set_fact:
@@ -47,7 +47,7 @@
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(dpdk_extra) }}"
 
 - name: Set socket-mem and socket-limit config
-  when: edpm_ovs_dpdk_socket_memory|string
+  when: edpm_ovs_dpdk_socket_memory|string|length > 0
   block:
     - name: Apply socket-mem config
       ansible.builtin.set_fact:
@@ -64,7 +64,7 @@
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(dpdk_socket_mem) | combine(dpdk_socket_limit) }}"
 
 - name: Set Revalidator threads config
-  when: edpm_ovs_dpdk_revalidator_cores|string
+  when: edpm_ovs_dpdk_revalidator_cores|string|length > 0
   block:
     - name: Apply Revalidator threads config
       ansible.builtin.set_fact:
@@ -76,7 +76,7 @@
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(n_revalidator_threads) }}"
 
 - name: Set Handler threads config
-  when: edpm_ovs_dpdk_handler_cores|string
+  when: edpm_ovs_dpdk_handler_cores|string|length > 0
   block:
     - name: Apply Handler threads config
       ansible.builtin.set_fact:
@@ -88,7 +88,7 @@
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(n_handler_threads) }}"
 
 - name: Set EMC Insertion Probability config
-  when: edpm_ovs_dpdk_emc_insertion_probablity|string
+  when: edpm_ovs_dpdk_emc_insertion_probablity|string|length > 0
   block:
     - name: Apply EMC Insertion Probability config
       ansible.builtin.set_fact:
@@ -149,7 +149,7 @@
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(pmd_auto_lb) }}"
 
 - name: Set minimum PMD thread load threshold
-  when: edpm_ovs_dpdk_pmd_load_threshold|string
+  when: edpm_ovs_dpdk_pmd_load_threshold|string|length > 0
   block:
     - name: Apply minimum PMD thread load threshold
       ansible.builtin.set_fact:
@@ -161,7 +161,7 @@
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(pmd_auto_lb_load_threshold) }}"
 
 - name: Set PMD load variance improvement threshold
-  when: edpm_ovs_dpdk_pmd_improvement_threshold|string
+  when: edpm_ovs_dpdk_pmd_improvement_threshold|string|length > 0
   block:
     - name: Apply PMD load variance improvement threshold
       ansible.builtin.set_fact:
@@ -173,7 +173,7 @@
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(pmd_auto_lb_improvement_threshold) }}"
 
 - name: Set PMD auto load balancing interval
-  when: edpm_ovs_dpdk_pmd_rebal_interval|string
+  when: edpm_ovs_dpdk_pmd_rebal_interval|string|length > 0
   block:
     - name: Apply PMD auto load balancing interval
       ansible.builtin.set_fact:
@@ -185,7 +185,7 @@
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(pmd_auto_lb_rebal_interval) }}"
 
 - name: OVN bridge datapath type config
-  when: edpm_ovn_datapath_type|string
+  when: edpm_ovn_datapath_type|string|length > 0
   block:
     - name: Apply PMD cores config
       ansible.builtin.set_fact:
@@ -197,7 +197,7 @@
         edpm_ovs_external_ids: "{{ {} | combine(ovn_bridge_datapath_type) }}"
 
 - name: Set shared memory pool config
-  when: edpm_ovs_dpdk_shared_mem_pool|string
+  when: edpm_ovs_dpdk_shared_mem_pool|string|length > 0
   block:
     - name: Apply shared memory pool config
       ansible.builtin.set_fact:
@@ -209,7 +209,7 @@
         edpm_ovs_other_config: "{{ edpm_ovs_other_config | combine(dpdk_shared_mem_pool) }}"
 
 - name: Set PMD maximum sleep time
-  when: edpm_ovs_dpdk_pmd_sleep_max|string
+  when: edpm_ovs_dpdk_pmd_sleep_max|string|length > 0
   block:
     - name: Apply PMD maximum sleep time
       ansible.builtin.set_fact:

--- a/roles/edpm_pre_adoption_validation/tasks/kernel_args.yml
+++ b/roles/edpm_pre_adoption_validation/tasks/kernel_args.yml
@@ -41,4 +41,4 @@
   # In the other hand neither the edpm_kernel role during deployment and
   # adoption nor this adoption check enforces to list the existing kernel args
   # in edpm_kernel_args ansible variable.
-  failed_when: not (cmdline | regex_search( '^.*' + edpm_kernel_args | default('') + '.*$' | string ))
+  failed_when: not (cmdline | regex_search( '^.*' + edpm_kernel_args | default('') + '.*$' | string))

--- a/roles/edpm_ssh_known_hosts/tasks/main.yml
+++ b/roles/edpm_ssh_known_hosts/tasks/main.yml
@@ -48,9 +48,9 @@
 
     - name: Gather facts if they don't exist
       when:
-        - ("'ssh_host_key_rsa_public' not in ansible_facts") or
-          ("'ssh_host_key_ed25519_public' not in ansible_facts") or
-          ("'ssh_host_key_ecdsa_public' not in ansible_facts")
+        - ('ssh_host_key_rsa_public' not in ansible_facts) or
+          ('ssh_host_key_ed25519_public' not in ansible_facts) or
+          ('ssh_host_key_ecdsa_public' not in ansible_facts)
       ansible.builtin.setup:
         gather_subset:
           - "!all"


### PR DESCRIPTION
Ports edpm-ansible to ansible 2.19

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1547
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3168
Depends-On: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/1023

jira: https://issues.redhat.com/browse/OSPRH-18609