### PR TITLE
Pin ansible-core to < 2.19.0

### DIFF
--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,5 +1,5 @@
 # this is required for the docs build jobs
-ansible-core>=2.15.0
+ansible-core>=2.15.0,<2.19.0
 sphinx>=2.0.0,!=2.1.0 # BSD
 reno>=3.1.0 # Apache-2.0
 doc8>=0.8.1 # Apache-2.0

--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.15.0
+ansible-core>=2.15.0,<2.19.0
 molecule>=5.1.0,<6.0.0
 molecule-plugins[podman,vagrant]>=23.5.0
 pytest-testinfra

--- a/openstack_ansibleee/requirements.txt
+++ b/openstack_ansibleee/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.16.1
+ansible-core>=2.16.1,<2.19.0
 ansible-runner>=2.4.0
 ansible-builder>=3.1.0
 dumb-init>=1.2.2


### PR DESCRIPTION
Ansible 2.19.0 has number of backward incompatible changes. Pin till we fix those.

jira: https://issues.redhat.com/browse/OSPRH-18609