### PR TITLE
Set test_deps_setup_edpm: true by default

### DIFF
--- a/molecule/common/test_deps/defaults/main.yml
+++ b/molecule/common/test_deps/defaults/main.yml
@@ -16,7 +16,7 @@
 
 
 test_deps_extra_packages: []
-test_deps_setup_edpm: false
+test_deps_setup_edpm: true
 test_deps_mirrors_file_path: /etc/ci/mirror_info.sh
 test_deps_setup_stream: true
 test_deps_setup_ceph: false


### PR DESCRIPTION
After https://github.com/openstack-k8s-operators/edpm-ansible/pull/978, we configure repos with repo-setup and remove ubi9.repo. repo-setup only runs  when `test_deps_setup_edpm: true`. Otherwise we can't install any of the molecule dependencies required.