### PR TITLE
Let NetworkManager manage resolv.conf after all downloads

### DIFF
--- a/roles/edpm_network_config/tasks/dns_nm_configs.yml
+++ b/roles/edpm_network_config/tasks/dns_nm_configs.yml
@@ -29,7 +29,7 @@
   when: edpm_bootstrap_network_resolvconf_update
   become: true
   block:
-    - name: Set 'dns=none' in /etc/NetworkManager/NetworkManager.conf
+    - name: Unset 'dns=none' in /etc/NetworkManager/NetworkManager.conf
       community.general.ini_file:
         path: "{{ item }}"
         state: absent
@@ -42,7 +42,7 @@
       loop:
         - /etc/NetworkManager/NetworkManager.conf
         - /etc/NetworkManager/conf.d/99-cloud-init.conf
-    - name: Set 'rc-manager=unmanaged' in /etc/NetworkManager/NetworkManager.conf
+    - name: Unset 'rc-manager=unmanaged' in /etc/NetworkManager/NetworkManager.conf
       community.general.ini_file:
         path: "{{ item }}"
         state: absent

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -41,9 +41,6 @@
         state: restarted
       when: nm_ovs_status.changed  # noqa: no-handler
 
-- name: Import DNS NetworkManager configs tasks
-  ansible.builtin.import_tasks: dns_nm_configs.yml
-
 - name: Configure network with network role from system roles [nmstate]
   when: edpm_network_config_tool == 'nmstate'
   become: true

--- a/roles/edpm_network_config/tasks/network_config.yml
+++ b/roles/edpm_network_config/tasks/network_config.yml
@@ -48,6 +48,9 @@
   retries: "{{ edpm_network_config_download_retries }}"
   delay: "{{ edpm_network_config_download_delay }}"
 
+- name: Import DNS NetworkManager configs tasks
+  ansible.builtin.import_tasks: dns_nm_configs.yml
+
 - name: Ensure /var/lib/edpm-config directory exists
   become: true
   ansible.builtin.file:


### PR DESCRIPTION
Changing NetworkManager to manage resolv.conf results in resolv.conf entries by cloud-init overwritten when using unprovisioned nodes. Let's change it just beforre running os-net-config so that tasks to download packages does not fail.

jira: https://issues.redhat.com/browse/OSPRH-19018