### PR TITLE
Fail when edpm_ddp_package used on a bootc system

### DIFF
--- a/roles/edpm_ddp_package/tasks/main.yml
+++ b/roles/edpm_ddp_package/tasks/main.yml
@@ -14,6 +14,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Gather ansible_local facts
+  ansible.builtin.setup:
+    filter: ansible_local
+
+- name: Fail if bootc
+  ansible.builtin.debug:
+    msg: The edpm_ddp_package role can not be used on a bootc system.
+  failed_when: ansible_local.bootc | bool
+
 - name: Apply user provided DDP package
   when: edpm_ddp_package | string != "" and edpm_ddp_package | string != "ddp"
   block:


### PR DESCRIPTION
Fail when edpm_ddp_package used on a bootc system

The role can't be used on a bootc system since it needs to rebuild the
initramfs with dracut. Fail gracefully with a message instead.

Jira: [OSPRH-11512](https://issues.redhat.com//browse/OSPRH-11512)
Signed-off-by: James Slagle <jslagle@redhat.com>