### PR TITLE
Support os-net-config provider migration

### DIFF
--- a/docs/source/playbooks/configure_network.rst
+++ b/docs/source/playbooks/configure_network.rst
@@ -6,6 +6,21 @@ Playbook - configure_network
     When the `edpm_network_config_tool` is set to `'os-net-config'`, the `ctlplane_gateway_ip` and `ctlplane_ip`
     variables must be set on the host for the playbook to function properly.
 
+
+.. warning::
+   When migrating between network providers, you MUST include ``minimum_config``
+   in your ``edpm_network_config_template`` to maintain control plane connectivity.
+
+Example::
+
+   .. code-block:: yaml
+
+      - edpm_network_config_template:
+          network_config:
+            - ...
+          minimum_config:
+            - ...
+
 Calls edpm_network_config role to set up network.
 Uses value of the `edpm_network_config_tool` variable to determine which tool to use.
 The `'nmstate'` value will leave the process to the `systemroles.network` role,

--- a/playbooks/configure_network.yml
+++ b/playbooks/configure_network.yml
@@ -16,10 +16,20 @@
           - "local"
 
     - name: Import edpm_ovs to install ovs packages
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: osp.edpm.edpm_ovs
+      when: edpm_network_config_purge_provider | default('') | length == 0
       tags:
         - edpm_ovs
+
+    - name: Purge edpm_network_config
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_network_config
+        tasks_from: purge_os_net_config.yml
+      when: edpm_network_config_purge_provider | default('') | length > 0
+      tags:
+        - edpm_purge_network_config
+
     # Sets up EDPM network using os-net-config
     - name: Import edpm_network_config
       ansible.builtin.import_role:

--- a/plugins/modules/edpm_os_net_config.py
+++ b/plugins/modules/edpm_os_net_config.py
@@ -72,6 +72,13 @@ options:
       - If enabled, use nmstate and network manager for network configuration.
     type: bool
     default: false
+  purge_provider:
+    description:
+      - Purge the network configuration created previously using the provider
+        specified in 'str' either ifcfg or nmstate.
+    type: str
+    default: ''
+
 """
 
 EXAMPLES = """
@@ -102,7 +109,7 @@ DEFAULT_CFG = '/etc/os-net-config/dhcp_all_interfaces.yaml'
 
 def _run_os_net_config(config_file, cleanup=False, debug=False,
                        detailed_exit_codes=False, noop=False,
-                       use_nmstate=False):
+                       use_nmstate=False, purge_provider=''):
     # Build os-net-config command
     argv = ['os-net-config --config-file {}'.format(config_file)]
     if cleanup:
@@ -117,6 +124,11 @@ def _run_os_net_config(config_file, cleanup=False, debug=False,
         argv.append('--provider nmstate')
     else:
         argv.append('--provider ifcfg')
+    if len(purge_provider) > 0:
+        argv.append('--purge-provider {}'.format(purge_provider))
+        argv.append('--minimum-config')
+        argv.append('--no-network-config')
+
     cmd = " ".join(argv)
 
     # Apply the provided network configuration
@@ -206,6 +218,7 @@ def main():
     detailed_exit_codes = args['detailed_exit_codes']
     safe_defaults = args['safe_defaults']
     use_nmsate = args['use_nmstate']
+    purge_provider = args['purge_provider']
     return_codes = [0]
     if detailed_exit_codes:
         return_codes.append(2)
@@ -214,7 +227,8 @@ def main():
     cmd, run = _run_os_net_config(config_file, cleanup, debug,
                                   detailed_exit_codes,
                                   module.check_mode,
-                                  use_nmstate=use_nmsate)
+                                  use_nmstate=use_nmsate,
+                                  purge_provider=purge_provider)
     results['stderr'] = run.stderr
     results['stdout'] = run.stdout
     if run.returncode not in return_codes and not module.check_mode:

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -53,6 +53,7 @@ edpm_network_config_manage_service: true
 # * false -> os-net-config uses ifcfg provider (legacy network scripts)
 # Note: This only applies when edpm_network_config_tool is 'os-net-config'
 edpm_network_config_nmstate: true
+edpm_network_config_purge_provider: ""
 edpm_network_config_os_net_config_mappings: {}
 edpm_network_config_safe_defaults: false
 edpm_network_config_template: ""

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -57,6 +57,18 @@ argument_specs:
         type: dict
         description: "Per node and/or per node group configuration map. Used by the edpm_os_net_config_mappings module."
         default: {}
+      edpm_network_config_purge_provider:
+        type: str
+        description: >
+          Purge the network configuration created previously using the provider specified in 'str'
+          either ifcfg or nmstate. Also ensure minimum_config should be provided in your
+          edpm_network_config_template variable to maintain control plane connectivity.
+          This variable should be used for day2 network provider migration.
+        default: ""
+        choices:
+          - ""
+          - "ifcfg"
+          - "nmstate"
       edpm_network_config_safe_defaults:
         type: bool
         description: >

--- a/roles/edpm_network_config/tasks/purge_os_net_config.yml
+++ b/roles/edpm_network_config/tasks/purge_os_net_config.yml
@@ -1,0 +1,66 @@
+---
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Apply network configuration with os-net-config.
+#
+
+- name: Purge os-net-config configuration
+  become: true
+  block:
+    - name: Remove os-net-config return code file
+      become: true
+      block:
+        - name: Check if os-net-config return code file exists
+          ansible.builtin.stat:
+            path: /var/lib/edpm-config/os-net-config.returncode
+          register: os_net_config_returncode_stat
+        - name: Remove file if os-net-config return code file exists
+          ansible.builtin.file:
+            path: /var/lib/edpm-config/os-net-config.returncode
+            state: absent
+          when: os_net_config_returncode_stat.stat.exists
+    - name: Set nic_config_file fact
+      ansible.builtin.set_fact:
+        nic_config_file: "/etc/os-net-config/config.yaml"
+    - name: Render network_config from template
+      no_log: "{{ edpm_network_config_hide_sensitive_logs | bool }}"
+      ansible.builtin.copy:
+        content: "{{ edpm_network_config_template }}"
+        dest: "{{ nic_config_file }}"
+        mode: '0644'
+        backup: true
+    - name: Retrieve and output nic_config_file contents for debug before applying
+      when: edpm_network_config_debug|bool
+      block:
+        - name: Retrieve content of nic_config_file before applying
+          ansible.builtin.slurp:
+            path: "{{ nic_config_file }}"
+          register: os_net_config_config
+        - name: Debug print nic_config_file contents
+          ansible.builtin.debug:
+            msg: "{{ os_net_config_config['content'] | b64decode | trim }}"
+    - name: Run edpm_os_net_config_module to purge network_config
+      edpm_os_net_config:
+        config_file: "{{ nic_config_file }}"
+        purge_provider: "{{ edpm_network_config_purge_provider }}"
+        debug: "{{ edpm_network_config_debug | bool }}"
+        detailed_exit_codes: true
+        safe_defaults: "{{ edpm_network_config_safe_defaults | bool }}"
+        use_nmstate: "{{ edpm_network_config_nmstate | bool }}"
+      async: "{{ edpm_network_config_async_timeout }}"
+      poll: "{{ edpm_network_config_async_poll }}"
+      register: network_config_result
+      when: not ansible_check_mode


### PR DESCRIPTION
This adds the functionality to migrate os-net-config backend provider. For migration users are expected to run `configure-network` service in `serviceOverride`  of a new OpenStackDataplaneDeployment CR.