### PR TITLE
Fix rsync permission issue for Swift

### DIFF
--- a/roles/edpm_swift/templates/rsync.yaml.j2
+++ b/roles/edpm_swift/templates/rsync.yaml.j2
@@ -13,3 +13,5 @@ volumes:
   {{ edpm_swift_volumes }}
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS
+cap_add:
+  - NET_BIND_SERVICE


### PR DESCRIPTION
rsync uses port 873 to replicate data between Swift storage nodes. Because it is running unprivileged it needs the NET_BIND_SERVICE cap to make this work by default without any customization.