### PR TITLE
Enable cifmw-crc-podified-edpm-baremetal-bootc job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,6 +3,7 @@
     name: openstack-k8s-operators/edpm-ansible
     templates:
       - podified-multinode-edpm-baremetal-pipeline
+      - podified-multinode-edpm-baremetal-bootc-pipeline
     github-check:
       jobs:
         - noop


### PR DESCRIPTION
Enable cifmw-crc-podified-edpm-baremetal-bootc job

Enables the podified-multinode-edpm-baremetal-bootc-pipeline on
edpm-ansible, which runs the new cifmw-crc-podified-edpm-baremetal-bootc
job.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3311
Signed-off-by: James Slagle <jslagle@redhat.com>
