### PR TITLE
Fix Swift role if edpm_swift_disks is undefined

### DIFF
--- a/roles/edpm_swift/tasks/disks.yml
+++ b/roles/edpm_swift/tasks/disks.yml
@@ -16,6 +16,8 @@
 
 - name: Setup Swift disks
   become: true
+  tags: swiftdisk
+  when: hostvars[inventory_hostname]['edpm_swift_disks'] is defined
   block:
     - name: Create partitions for Swift
       community.general.parted:


### PR DESCRIPTION
If edpm_swift_disks is undefined setting up disks should be simply skipped. This is most likely intended, for example when adopting an existing deployment and using already existing disks and mountpoints.