### PR TITLE
Check if the bootc fact exits before evaluating

### DIFF
--- a/playbooks/configure_ovs_dpdk.yml
+++ b/playbooks/configure_ovs_dpdk.yml
@@ -17,7 +17,7 @@
       ansible.builtin.dnf:
         name: openvswitch
         state: present
-      when: not ansible_local.bootc
+      when: ansible_local.bootc is not defined or not ansible_local.bootc
 
     - name: Configure OvS DPDK configs
       ansible.builtin.import_role:

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -66,7 +66,7 @@
 
 - name: Include packages tasks
   ansible.builtin.include_tasks: packages.yml
-  when: not ansible_local.bootc
+  when: ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Set selinux state
   ansible.posix.selinux:

--- a/roles/edpm_bootstrap/tasks/fips.yml
+++ b/roles/edpm_bootstrap/tasks/fips.yml
@@ -40,7 +40,7 @@
 - name: Change FIPS status
   when:
     - edpm_bootstrap_fips_mode != 'check'
-    - not ansible_local.bootc
+    - ansible_local.bootc is not defined or not ansible_local.bootc
     - >
       edpm_bootstrap_fips_mode !=
       edpm_bootstrap_fips_fms_status |

--- a/roles/edpm_download_cache/tasks/main.yml
+++ b/roles/edpm_download_cache/tasks/main.yml
@@ -31,7 +31,7 @@
   ansible.builtin.include_tasks: packages.yml
   when:
     - edpm_download_cache_packages | bool
-    - not ansible_local.bootc
+    - ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Download container images
   ansible.builtin.include_tasks: container_images.yml

--- a/roles/edpm_kernel/tasks/kernelargs.yml
+++ b/roles/edpm_kernel/tasks/kernelargs.yml
@@ -74,7 +74,7 @@
   when:
     - set_kernel_args is defined
     - set_kernel_args is true
-    - not ansible_local.bootc
+    - ansible_local.bootc is not defined or not ansible_local.bootc
   block:
 
     - name: Check if the kernelargs entry is already present in the file

--- a/roles/edpm_kernel/tasks/main.yml
+++ b/roles/edpm_kernel/tasks/main.yml
@@ -36,7 +36,7 @@
       register: _install_packages_result
       when:
         - edpm_kernel_extra_packages | length > 0
-        - not ansible_local.bootc
+        - ansible_local.bootc is not defined or not ansible_local.bootc
       until: _install_packages_result is succeeded
       retries: "{{ edpm_kernel_download_retries }}"
       delay: "{{ edpm_kernel_download_delay }}"
@@ -45,7 +45,7 @@
       ansible.builtin.dnf:
         name: 'dracut-config-generic'
         state: absent
-      when: not ansible_local.bootc
+      when: ansible_local.bootc is not defined or not ansible_local.bootc
 
     - name: Ensure the /etc/modules-load.d/ directory exists
       ansible.builtin.file:

--- a/roles/edpm_libvirt/tasks/install.yml
+++ b/roles/edpm_libvirt/tasks/install.yml
@@ -22,7 +22,7 @@
   delay: "{{ edpm_libvirt_download_delay }}"
   notify:
     - Restart libvirt
-  when: not ansible_local.bootc
+  when: ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Ensure monolithic libvirt and tcp socket activation is not enabled or running
   tags:

--- a/roles/edpm_network_config/tasks/main.yml
+++ b/roles/edpm_network_config/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Install required packages
   ansible.builtin.import_tasks: package_management.yml
   when:
-    - not ansible_local.bootc
+    - ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Configure network with nmstate tool
   when: edpm_network_config_tool == 'nmstate'

--- a/roles/edpm_network_config/tasks/pre_config.yml
+++ b/roles/edpm_network_config/tasks/pre_config.yml
@@ -49,7 +49,7 @@
     name: osp.edpm.edpm_bootstrap
     tasks_from: "packages.yml"
   when:
-    - not ansible_local.bootc
+    - ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Ensure /var/lib/edpm-config directory exists
   become: true

--- a/roles/edpm_nvmeof/tasks/install.yml
+++ b/roles/edpm_nvmeof/tasks/install.yml
@@ -38,4 +38,4 @@
   ansible.builtin.package:
     name: nvme-cli
     state: present
-  when: not ansible_local.bootc
+  when: ansible_local.bootc is not defined or not ansible_local.bootc

--- a/roles/edpm_ovs/tasks/download_cache.yml
+++ b/roles/edpm_ovs/tasks/download_cache.yml
@@ -18,4 +18,4 @@
   until: _install_packages_result is succeeded
   retries: "{{ edpm_ovs_download_retries }}"
   delay: "{{ edpm_ovs_download_delay }}"
-  when: not ansible_local.bootc
+  when: ansible_local.bootc is not defined or not ansible_local.bootc

--- a/roles/edpm_ovs/tasks/install.yml
+++ b/roles/edpm_ovs/tasks/install.yml
@@ -20,7 +20,7 @@
   until: edpm_ovs_package_install is succeeded
   retries: "{{ edpm_ovs_download_retries }}"
   delay: "{{ edpm_ovs_download_delay }}"
-  when: not ansible_local.bootc
+  when: ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Ensure ovs services are enabled and running
   tags:

--- a/roles/edpm_podman/tasks/install.yml
+++ b/roles/edpm_podman/tasks/install.yml
@@ -32,7 +32,7 @@
       until: edpm_podman_package_download is succeeded
       retries: "{{ edpm_podman_download_retries }}"
       delay: "{{ edpm_podman_download_delay }}"
-      when: not ansible_local.bootc
+      when: ansible_local.bootc is not defined or not ansible_local.bootc
 
     - name: Ensure we get the ansible interfaces facts
       when:

--- a/roles/edpm_reboot/tasks/main.yaml
+++ b/roles/edpm_reboot/tasks/main.yaml
@@ -27,7 +27,7 @@
   become: true
   ansible.builtin.dnf:
     name: yum-utils
-  when: not ansible_local.bootc
+  when: ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Check if reboot is required with needs-restarting
   ansible.builtin.command: needs-restarting -r

--- a/roles/edpm_sshd/tasks/install.yml
+++ b/roles/edpm_sshd/tasks/install.yml
@@ -34,7 +34,7 @@
       until: _sshd_install_result is succeeded
       retries: "{{ edpm_sshd_download_retries }}"
       delay: "{{ edpm_sshd_download_delay }}"
-      when: not ansible_local.bootc
+      when: ansible_local.bootc is not defined or not ansible_local.bootc
 
     # NOTE(mwhahaha): we need this here because in order to validate our generated
     # config, we need to ensure the host keys exist

--- a/roles/edpm_telemetry_logging/tasks/configure.yml
+++ b/roles/edpm_telemetry_logging/tasks/configure.yml
@@ -42,7 +42,7 @@
         state: present
       when:
         - telemetry_test is undefined or not telemetry_test
-        - not ansible_local.bootc
+        - ansible_local.bootc is not defined or not ansible_local.bootc
 
     - name: Copy Openshift CA to the node
       ansible.builtin.copy:

--- a/roles/edpm_tuned/tasks/main.yml
+++ b/roles/edpm_tuned/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Install packages
   ansible.builtin.include_tasks: install.yml
-  when: not ansible_local.bootc
+  when: ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Configure tuned
   ansible.builtin.include_tasks: configure.yml

--- a/roles/edpm_update/tasks/main.yml
+++ b/roles/edpm_update/tasks/main.yml
@@ -30,13 +30,13 @@
   ansible.builtin.include_tasks: kpatch.yml
   when:
     - edpm_update_enable_kpatch
-    - not ansible_local.bootc
+    - ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Update packages
   ansible.builtin.include_tasks: packages.yml
   when:
     - edpm_update_enable_packages_update
-    - not ansible_local.bootc
+    - ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Update OS (bootc)
   ansible.builtin.include_tasks: bootc.yml


### PR DESCRIPTION
Sometimes these roles are used without the bootstrap role and we should add the check if the bootc fact has been defined to the conditions to avoid backward incompatibility.

Jira: https://issues.redhat.com/browse/OSPCIX-1058