### PR TITLE
Don't change all fact files to executables

### DIFF
--- a/roles/edpm_bootstrap/tasks/bootc.yml
+++ b/roles/edpm_bootstrap/tasks/bootc.yml
@@ -29,7 +29,6 @@
       ansible.builtin.file:
         state: directory
         path: /etc/ansible/facts.d
-        recurse: true
         mode: '755'
 
     - name: Ensure /etc/ansible/facts.d/bootc.fact exists


### PR DESCRIPTION
We create some fact files like[1] that are not executables. If bootstrap service is run multiple times this would cause issues as in the jira.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/blob/main/roles/edpm_bootstrap/tasks/bootstrap_command.yml#L36

jira: https://issues.redhat.com/browse/OSPRH-20166