### PR TITLE
Don't try to ensure  network service is running

### DIFF
--- a/roles/edpm_network_config/tasks/package_management.yml
+++ b/roles/edpm_network_config/tasks/package_management.yml
@@ -60,8 +60,7 @@
       retries: "{{ edpm_network_config_download_retries }}"
       delay: "{{ edpm_network_config_download_delay }}"
 
-    - name: Ensure network service is enabled and started
+    - name: Ensure network service is enabled
       ansible.builtin.systemd:
-        name: "{{ edpm_bootstrap_network_service | default('network') }}"
+        name: network
         enabled: true
-        state: started


### PR DESCRIPTION
Some adoption jobs have issues when ensuring that network.service has been started possibly because of conflict with NetworkManager. We were not doing that earlier[1], so let's change that.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/blob/18.0-fr2/roles/edpm_network_config/tasks/network_config.yml#L152C13-L159

jira: https://issues.redhat.com/browse/OSPCIX-1042
Related-Issue: https://issues.redhat.com/browse/OSPRH-19018