### PR TITLE
Fix growvols shell command YAML syntax

### DIFF
--- a/roles/edpm_growvols/tasks/main.yml
+++ b/roles/edpm_growvols/tasks/main.yml
@@ -36,7 +36,8 @@
         growvols_path: "{{ find_growvols.stdout_lines[0] }}"
 
     - name: "Running {{ growvols_path + growvols_args }}"
-      ansible.builtin.shell: "{{ growvols_path }} --yes {{ growvols_args }}"
+      ansible.builtin.shell: >-
+        {{ growvols_path }} --yes {{ growvols_args }}
       become: true
       register: run_growvols
       changed_when: run_growvols.rc == 0


### PR DESCRIPTION
Use folded style for multi-line growvols_args to remove trailing newlines from shell command to prevent execution issue.