### PR TITLE
Check for ansible_local.bootc not just ansible_local

### DIFF
--- a/roles/edpm_update/tasks/main.yml
+++ b/roles/edpm_update/tasks/main.yml
@@ -42,7 +42,9 @@
   ansible.builtin.import_role:
     name: osp.edpm.edpm_update_system
     tasks_from: bootc.yml
-  when: ansible_local is defined and ansible_local.bootc
+  when:
+    - ansible_local.bootc is defined
+    - ansible_local.bootc
 
 - name: Update containers
   ansible.builtin.include_tasks: containers.yml

--- a/roles/edpm_update_system/tasks/main.yml
+++ b/roles/edpm_update_system/tasks/main.yml
@@ -37,4 +37,6 @@
 
 - name: Update OS (bootc)
   ansible.builtin.include_tasks: bootc.yml
-  when: ansible_local is defined and ansible_local.bootc
+  when:
+    - ansible_local.bootc is defined
+    - ansible_local.bootc


### PR DESCRIPTION
The actual fact ansible_local.bootc needs to be defined, not just
ansible_local.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3362
Jira: [OSPRH-20382](https://issues.redhat.com//browse/OSPRH-20382)
Signed-off-by: James Slagle <jslagle@redhat.com>
