### PR TITLE
Fix: update_system and reboot roles for bootc image update

### DIFF
--- a/roles/edpm_reboot/tasks/main.yaml
+++ b/roles/edpm_reboot/tasks/main.yaml
@@ -34,13 +34,17 @@
   register: needs_restarting_output
   changed_when: false
   failed_when: needs_restarting_output.rc >= 2
+  when: ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Print return information from needs-restarting
   ansible.builtin.debug:
     var: needs_restarting_output.stdout
+  when: ansible_local.bootc is not defined or not ansible_local.bootc
 
 - name: Create reboot file for needs-restarting
-  when: needs_restarting_output.rc == 1
+  when:
+    - ansible_local.bootc is not defined or not ansible_local.bootc
+    - needs_restarting_output.rc == 1
   become: true
   block:
     - name: Create a reboot_required directory if it does not exist

--- a/roles/edpm_update_system/tasks/bootc.yml
+++ b/roles/edpm_update_system/tasks/bootc.yml
@@ -18,8 +18,31 @@
 - name: Update bootc image
   ansible.builtin.shell: bootc switch "{{ edpm_update_system_bootc_os_container_image }}"
   become: true
-  register: bootc_result
-  changed_when: bootc_result.rc != 0
+  register: bootc_switch_result
+  failed_when: bootc_switch_result.rc != 0
+  changed_when: false
+
+- name: Get bootc status after switch
+  ansible.builtin.shell: bootc status --format json
+  become: true
+  register: bootc_status
+  changed_when: false
+
+- name: Determine if update was applied
+  ansible.builtin.set_fact:
+    bootc_result:
+      changed: "{{
+        (bootc_status.stdout | from_json).status.staged is not none and
+        (bootc_status.stdout | from_json).status.staged.image.imageDigest != (bootc_status.stdout | from_json).status.booted.image.imageDigest }}"
+
+- name: Log bootc update status and reboot required information
+  ansible.builtin.debug:
+    msg: >-
+      {% if bootc_result.changed %}
+      Change/Update detected. Ready to reboot. Plan your reboot strategy before the reboot. Reboot can be disruptive and cannot be undone.
+      {% else %}
+      No change detected. Already running desired image. No reboot required.
+      {% endif %}
 
 - name: Create directory required by edpm-reboot role
   become: true


### PR DESCRIPTION
- Added better edge cases handling along with better error/debug messages

Cases handled for debug/error messages, reboot directory creation and check for needs-restarting for bootc mode
- [x] Fresh installation on a machine
- [x] Update request to same image (same digest)
- [x] Update to new/different image (new or same tag, different digest)
- [x] Already existing staged image
- [x] Better debug/error message (open for suggestions on detailed log info)
- [x] Handling reboot/restart Directory/file creation

Open to any other edge cases I missed here. 
