### PR TITLE
Doc: Added note for nfs directory permissions for runner

### DIFF
--- a/docs/source/testing_with_ansibleee.rst
+++ b/docs/source/testing_with_ansibleee.rst
@@ -48,6 +48,17 @@ Make sure nfs-server and firewalld are started:
 
    % nft add rule inet firewalld filter_IN_libvirt_pre accept
 
+.. note::
+
+  If using NFSv4, ensure your edpm-ansible directory has a minimum permission
+  of ``2775`` (or ``2777`` for testing). The ansibleee runner container runs as
+  a non-root user, so it requires "others" read and execute permissions to
+  access the directory contents.
+
+    .. code-block:: console
+
+       % chmod 2775 ${HOME}/edpm-
+
 Create edpm-ansible PV and PVC
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
When using NFS setup for testing edpm-ansible locally, the directory permission needs to be set to minimum of read(4) and execute(1) for "other" for ansible-runner to access the directory content(playbooks).
The issue arises when following the [EL 9 Instructions](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_using_network_file_services/deploying-an-nfs-server_configuring-and-using-network-file-services) `# chmod 2770 /nfs/projects/` made the directory permission for others to be none which made runner unable to access the directory and therefore playbooks, and the OpenstackDataPlaneDeployment  failed with `playbook not found error`