### PR TITLE
Fix: Use edpm_service_types instead of edpm_services

### DIFF
--- a/roles/edpm_download_cache/defaults/main.yml
+++ b/roles/edpm_download_cache/defaults/main.yml
@@ -25,6 +25,6 @@ edpm_download_cache_packages: true
 
 edpm_download_cache_container_images: true
 
-edpm_download_cache_running_services: "{{ edpm_services_override | default(edpm_services) }}"
+edpm_download_cache_running_services: "{{ edpm_service_types }}"
 
 edpm_download_cache_podman_auth_file: "~/.config/containers/auth.json"

--- a/roles/edpm_download_cache/meta/argument_specs.yml
+++ b/roles/edpm_download_cache/meta/argument_specs.yml
@@ -18,9 +18,9 @@ argument_specs:
         description: Enable caching of container images
       edpm_download_cache_running_services:
         type: list
-        default: edpm_services
+        default: edpm_service_types
         description: >
-          Used to select which list of services are running
+          Used to select which list of service types are running
           on the machine. The list is provided by openstack-operator.
       edpm_download_cache_podman_auth_file:
         type: str

--- a/roles/edpm_download_cache/molecule/default/converge.yml
+++ b/roles/edpm_download_cache/molecule/default/converge.yml
@@ -19,7 +19,7 @@
   hosts: all
   gather_facts: false
   vars:
-    edpm_services:
+    edpm_service_types:
       - bootstrap
       - configure-network
       - validate-network

--- a/roles/edpm_update/meta/argument_specs.yml
+++ b/roles/edpm_update/meta/argument_specs.yml
@@ -19,7 +19,7 @@ argument_specs:
         description: List of packages to exclude from the update
       edpm_update_running_services:
         type: list
-        default: edpm_services
+        default: edpm_service_types
         description: >
-          Used to select which list of services are running
+          Used to select which list of service types are running
           on the machine. The list is provided by openstack-operator.

--- a/roles/edpm_update_services/meta/argument_specs.yml
+++ b/roles/edpm_update_services/meta/argument_specs.yml
@@ -23,7 +23,7 @@ argument_specs:
         description: List of packages to exclude from the update
       edpm_update_services_running_services:
         type: list
-        default: edpm_services
+        default: edpm_service_types
         description: >
-          Used to select which list of services are running
+          Used to select which list of service types are running
           on the machine. The list is provided by openstack-operator.


### PR DESCRIPTION
The edpm_download_cache role was using edpm_services (service names) to determine which services to pre-download content for. This is incorrect because service names are user-defined and opaque (e.g., "nova-cell2-ai" for multi-cell deployments).

Changed to use edpm_service_types which contains the standardized service types (e.g., "nova", "ovn") that correctly match regardless of custom service naming.

Jira: [OSPRH-21328](https://issues.redhat.com//browse/OSPRH-21328)
