### PR TITLE
[frr][neutron_ovn] Changes needed to enable ovn-bgp at ovn-agent

### DIFF
--- a/roles/edpm_frr/defaults/main.yml
+++ b/roles/edpm_frr/defaults/main.yml
@@ -90,3 +90,8 @@ edpm_frr_images_download_delay: "{{ edpm_download_delay | default(60) }}"
 
 # number of retries for download tasks
 edpm_frr_images_download_retries: "{{ edpm_download_retries | default(5) }}"
+
+# ovn-bgp extension related vars
+edpm_frr_ovn_vrf_advertise: ''
+edpm_frr_ovn_vrf_learn: ''
+edpm_frr_conf_custom_router_bgp_ovn: ''

--- a/roles/edpm_frr/meta/argument_specs.yml
+++ b/roles/edpm_frr/meta/argument_specs.yml
@@ -134,6 +134,10 @@ argument_specs:
         default: ''
         description: ''
         type: str
+      edpm_frr_conf_custom_router_bgp_ovn:
+        default: ''
+        description: Custom router BGP configuration for OVN VRF.
+        type: str
       edpm_frr_config_basedir:
         default: /var/lib/openstack/frr
         description: Path to FRR configuration directory.
@@ -166,6 +170,14 @@ argument_specs:
         default: 3
         description: ''
         type: int
+      edpm_frr_ovn_vrf_advertise:
+        default: ''
+        description: VRF name for OVN-BGP extension, used to advertise BGP routes to workload IP addresses
+        type: str
+      edpm_frr_ovn_vrf_learn:
+        default: ''
+        description: VRF name for OVN-BGP extension, used to learn BGP routes
+        type: str
       edpm_frr_version:
         default: 7.0
         description: ''

--- a/roles/edpm_frr/templates/config/frr.conf.j2
+++ b/roles/edpm_frr/templates/config/frr.conf.j2
@@ -9,6 +9,62 @@ service integrated-vtysh-config
 line vty
 {{ edpm_frr_conf_custom_globals }}
 
+{% if edpm_frr_ovn_vrf_learn|length %}
+vrf {{ edpm_frr_ovn_vrf_learn }}
+{% if edpm_frr_bgp_ipv4 %}
+  ip protocol bgp route-map rm-install-only-default
+{% endif %}
+{% if edpm_frr_bgp_ipv6 %}
+  ipv6 protocol bgp route-map rm-install-only-default
+{% endif %}
+exit-vrf
+
+router bgp {{ edpm_frr_bgp_asn }} vrf {{ edpm_frr_ovn_vrf_learn }}
+{% if edpm_frr_bgp_ipv4 %}
+  address-family ipv4 unicast
+    ! Leak everything from root (including dynamic next-hops)
+    import vrf default
+  exit-address-family
+{% endif %}
+{% if edpm_frr_bgp_ipv6 %}
+  address-family ipv6 unicast
+    ! Leak everything from root (including dynamic next-hops)
+    import vrf default
+  exit-address-family
+{% endif %}
+exit
+
+{% if edpm_frr_bgp_ipv4 %}
+route-map rm-install-only-default permit 10
+  match ip address prefix-list only-default
+{% endif %}
+
+{% if edpm_frr_bgp_ipv6 %}
+route-map rm-install-only-default permit 11
+  match ipv6 address prefix-list only-default
+{% endif %}
+{% endif %}
+
+{% if edpm_frr_ovn_vrf_advertise|length %}
+router bgp {{ edpm_frr_bgp_asn }} vrf {{ edpm_frr_ovn_vrf_advertise }}
+  bgp log-neighbor-changes
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+  {{ edpm_frr_conf_custom_router_bgp_ovn }}
+
+{% if edpm_frr_bgp_ipv4 %}
+  address-family ipv4 unicast
+    redistribute kernel
+  exit-address-family
+{% endif %}
+
+{% if edpm_frr_bgp_ipv6 %}
+  address-family ipv6 unicast
+    redistribute kernel
+  exit-address-family
+{% endif %}
+{% endif %}
+
 router bgp {{ edpm_frr_bgp_asn }}
   bgp router-id {{ hostvars[inventory_hostname][edpm_frr_bgp_ipv4_src_network ~ '_ip'] }}
   bgp log-neighbor-changes
@@ -62,6 +118,9 @@ router bgp {{ edpm_frr_bgp_asn }}
 
 {% if edpm_frr_bgp_ipv4 %}
   address-family ipv4 unicast
+{% if edpm_frr_ovn_vrf_advertise|length %}
+    import vrf {{ edpm_frr_ovn_vrf_advertise }}
+{% endif %}
     redistribute connected
     neighbor uplink activate
 {% if edpm_frr_bgp_ipv4_allowas_in %}
@@ -75,6 +134,9 @@ router bgp {{ edpm_frr_bgp_asn }}
 
 {% if edpm_frr_bgp_ipv6 %}
   address-family ipv6 unicast
+{% if edpm_frr_ovn_vrf_advertise|length %}
+    import vrf {{ edpm_frr_ovn_vrf_advertise }}
+{% endif %}
     redistribute connected
     neighbor uplink activate
 {% if edpm_frr_bgp_ipv6_allowas_in %}

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -62,3 +62,7 @@ edpm_neutron_ovn_agent_ovn_ovsdb_connection_timeout: '180'
 edpm_neutron_ovn_agent_ovn_ovsdb_probe_interval: '60000'
 edpm_neutron_ovn_agent_ovn_ovn_nb_connection: ''
 edpm_neutron_ovn_agent_ovn_ovn_sb_connection: ''
+
+# BGP peer bridges for the ovn-bgp extension.
+# Set this variable when the ovn-agent is configured with the ovn-bgp extension.
+edpm_neutron_ovn_agent_bgp_peer_bridges: ''

--- a/roles/edpm_neutron_ovn/meta/argument_specs.yml
+++ b/roles/edpm_neutron_ovn/meta/argument_specs.yml
@@ -102,3 +102,10 @@ argument_specs:
         default: /var/lib/openstack/neutron-ovn-agent
         description: 'The directory that contains configuration files for Neutron OVN Agent.'
         type: str
+      edpm_neutron_ovn_agent_bgp_peer_bridges:
+        default: ''
+        description: >
+          BGP peer bridges required for the ovn-bgp extension.
+          Each bridge connects the OVN overlay from the corresponding EDPM node with a BGP peering switch (leaf, ToR, ...).
+          Set this variable when the ovn-agent is configured with the ovn-bgp extension.
+        type: str

--- a/roles/edpm_neutron_ovn/tasks/configure.yml
+++ b/roles/edpm_neutron_ovn/tasks/configure.yml
@@ -53,3 +53,14 @@
         setype: "container_file_t"
         mode: "0644"
       loop: "{{ edpm_neutron_ovn_secrets.files }}"
+
+    # Configure BGP peer bridges in OVS when the ovn-agent is configured
+    # with the ovn-bgp extension.
+    - name: Set neutron-bgp-peer-bridges in OVS external-ids
+      become: true
+      ansible.builtin.command:
+        cmd: >-
+          ovs-vsctl --no-wait -- set Open_vSwitch .
+          external-ids:neutron-bgp-peer-bridges={{ edpm_neutron_ovn_agent_bgp_peer_bridges }}
+      when: edpm_neutron_ovn_agent_bgp_peer_bridges != ''
+      changed_when: true


### PR DESCRIPTION
New ovn-bgp service plugin will be supported soon, replacing ovn-bgp-agent. When the new BGP solution is configured, changes in frr and neutron_ovn roles are necessary.

[OSPRH-22480](https://issues.redhat.com//browse/OSPRH-22480)