### PR TITLE
Exclude AI personal configs from commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ docs/source/collections/**
 docs_build
 Gemfile.lock
 .ruby
+
+# Cursor AI - personal configs not to commit
+.cursor
+# Claude AI
+.claude


### PR DESCRIPTION
This patch excludes AI configs of popular AI tools from commits