### PR TITLE
[edpm_users] Prevent system user account expiration on hardened systems

### DIFF
--- a/roles/edpm_users/defaults/main.yml
+++ b/roles/edpm_users/defaults/main.yml
@@ -28,3 +28,5 @@ edpm_users_users:
   - {"name": "hugetlbfs", "gid": "42477", "group_only": true}
 edpm_users_extra_dirs:
   - {"path": "/var/lib/vhost_sockets", "owner": "qemu", "group": "qemu", "setype": "virt_cache_t", "seuser": "system_u", "mode": "0755"}
+# Account expiration for system users. -1 means never expire.
+edpm_users_account_expires: -1

--- a/roles/edpm_users/molecule/default/verify.yml
+++ b/roles/edpm_users/molecule/default/verify.yml
@@ -54,3 +54,21 @@
         that:
           # 2: the users in the group
           - "'nova' in libvirt_group.ansible_facts.getent_group.libvirt[2]"
+
+    - name: Check account expiration for system users
+      ansible.builtin.command: "chage -l {{ item }}"
+      register: user_expiration
+      changed_when: false
+      failed_when: false
+      loop:
+        - "qemu"
+        - "libvirt"
+        - "nova"
+
+    - name: Assert that system user accounts never expire
+      ansible.builtin.assert:
+        that:
+          - "'Account expires' in item.stdout"
+          - "'never' in item.stdout"
+        fail_msg: "User {{ item.item }} account should never expire"
+      loop: "{{ user_expiration.results }}"

--- a/roles/edpm_users/tasks/create_users_and_groups.yml
+++ b/roles/edpm_users/tasks/create_users_and_groups.yml
@@ -45,3 +45,4 @@
         shell: "{{ item.shell }}"
         comment: "{{ item.comment }}"
         groups: "{{ item.groups | default('') }}"
+        expires: "{{ edpm_users_account_expires }}"


### PR DESCRIPTION
Set account expiration to never expire for system users created by
the edpm_users role. This prevents authentication failures on systems
with PASS_MAX_DAYS configured in /etc/login.defs.

Jira: [OSPRH-26189](https://redhat.atlassian.net/browse/OSPRH-26189)
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: James Slagle <jslagle@redhat.com>
