### PR TITLE
fix: prevent libvirt password truncation in saslpasswd2

### DIFF
--- a/roles/edpm_libvirt/tasks/configure.yml
+++ b/roles/edpm_libvirt/tasks/configure.yml
@@ -77,7 +77,7 @@
     - name: Add libvirt password to sasl db
       ansible.builtin.command:
         cmd: saslpasswd2 -f /etc/libvirt/passwd.db -p -a libvirt -u openstack migration
-        stdin: "{{ sasl_password }}"
+        stdin: "{{ sasl_password | trim }}"
       changed_when: true
       when: edpm_libvirt_tls_certs_enabled|bool
     - name: Remove libvirt sasl db


### PR DESCRIPTION
Switches to ansible.builtin.command with stdin and trim to ensure long passwords (60+ chars) are correctly used.

resolve: #[OSPRH-26409](https://redhat.atlassian.net/browse/OSPRH-26409)