### PR TITLE
Add sigstore signature verification support to edpm_podman role

### DIFF
--- a/roles/edpm_podman/defaults/main.yml
+++ b/roles/edpm_podman/defaults/main.yml
@@ -105,3 +105,9 @@ edpm_podman_auth_file: ~/.config/containers/auth.json
 edpm_podman_registries_conf: ""
 edpm_podman_disconnected_ocp: false
 edpm_podman_disconnected_conf_file: 10-edpm-podman-disconnected.conf
+
+edpm_container_signature_verification: false
+edpm_container_signature_cosign_key_data: ""
+edpm_container_signature_cosign_key_path: "/etc/pki/containers/cosign-redhat.pub"
+edpm_container_signature_registry_mappings: []
+edpm_container_signature_signed_prefix: ""

--- a/roles/edpm_podman/meta/argument_specs.yml
+++ b/roles/edpm_podman/meta/argument_specs.yml
@@ -163,3 +163,41 @@ argument_specs:
         description: >
           Indicates whether the OCP environment we're deployed from is using a custom
           registry and specifically a ImageContentSourcePolicy to set registry mirrors.
+      edpm_container_signature_verification:
+        type: bool
+        default: false
+        description: >
+          Enable sigstore cosign signature verification for container images
+          pulled from a disconnected mirror registry. When enabled, podman will
+          verify cosign signatures (.sig OCI tag attachments) in the mirror
+          registry before pulling images. Auto-populated by the openstack-operator
+          from the ClusterImagePolicy CR.
+      edpm_container_signature_cosign_key_data:
+        type: str
+        default: ""
+        description: >
+          Base64-encoded cosign public key (PEM format) for verifying sigstore
+          signatures. Auto-populated by the openstack-operator from the
+          ClusterImagePolicy CR keyData field.
+      edpm_container_signature_cosign_key_path:
+        type: str
+        default: "/etc/pki/containers/cosign-redhat.pub"
+        description: >
+          Filesystem path where the cosign public key will be written on the
+          EDPM node. The key data comes from edpm_container_signature_cosign_key_data.
+      edpm_container_signature_registry_mappings:
+        type: list
+        default: []
+        description: >
+          List of source-to-mirror registry mappings for signature
+          verification. Each entry is a dict with 'source' (original
+          registry prefix, used as policy.json key) and 'mirror' (mirror
+          registry, used for sigstore attachment lookups). Auto-populated
+          by the openstack-operator from IDMS/ICSP and ClusterImagePolicy.
+      edpm_container_signature_signed_prefix:
+        type: str
+        default: ""
+        description: >
+          Optional original registry prefix where images were signed. When set,
+          edpm_podman writes a remapIdentity signedIdentity policy to map mirror
+          registry references back to the original signing identity.

--- a/roles/edpm_podman/molecule/install/converge.yml
+++ b/roles/edpm_podman/molecule/install/converge.yml
@@ -17,13 +17,64 @@
 
 - name: Converge
   hosts: all
+  vars:
+    test_cosign_key_data: "dGVzdC1jb3NpZ24tcHVibGljLWtleS1kYXRh"
   tasks:
-    - name: Run install
-      include_role:
+    - name: Run install without remapped signed identity
+      ansible.builtin.include_role:
         name: osp.edpm.edpm_podman
         tasks_from: install.yml
         vars_from: "redhat.yml"
-    # https://bugs.launchpad.net/bugs/1889510
+      vars:
+        edpm_podman_disconnected_ocp: true
+        edpm_container_signature_verification: true
+        edpm_container_signature_registry_mappings:
+          - source: "registry.redhat.io/rhoso"
+            mirror: "mirror.example.com:5000/rhoso"
+        edpm_container_signature_cosign_key_data: "{{ test_cosign_key_data }}"
+
     - name: Test podman network ls
       become: true
-      command: podman network ls
+      ansible.builtin.command: podman network ls
+      changed_when: false
+
+    - name: Read merged container policy
+      become: true
+      ansible.builtin.slurp:
+        src: /etc/containers/policy.json
+      register: policy_json
+
+    - name: Assert sigstore policy was merged keyed by source registry
+      ansible.builtin.assert:
+        that:
+          - policy.transports.docker["registry.redhat.io/rhoso"][0].type == "sigstoreSigned"
+          - policy.transports.docker["registry.redhat.io/rhoso"][0].keyPath == "/etc/pki/containers/cosign-redhat.pub"
+          - "'signedIdentity' not in policy.transports.docker['registry.redhat.io/rhoso'][0]"
+          - policy.transports.docker["registry.redhat.io"][0].type == "signedBy"
+          - policy.transports.docker["registry.access.redhat.com"][0].type == "signedBy"
+      vars:
+        policy: "{{ policy_json.content | b64decode | from_json }}"
+
+    - name: Read written cosign key
+      become: true
+      ansible.builtin.slurp:
+        src: /etc/pki/containers/cosign-redhat.pub
+      register: cosign_key
+
+    - name: Assert cosign key content matches
+      ansible.builtin.assert:
+        that:
+          - cosign_key.content | b64decode == "test-cosign-public-key-data"
+
+    - name: Read sigstore registries configuration
+      become: true
+      ansible.builtin.slurp:
+        src: /etc/containers/registries.d/99-edpm-sigstore-verification.yaml
+      register: sigstore_registries
+
+    - name: Assert sigstore attachments are enabled for the mirror registry
+      ansible.builtin.assert:
+        that:
+          - registries.docker["mirror.example.com:5000/rhoso"]["use-sigstore-attachments"] | bool
+      vars:
+        registries: "{{ sigstore_registries.content | b64decode | from_yaml }}"

--- a/roles/edpm_podman/tasks/install.yml
+++ b/roles/edpm_podman/tasks/install.yml
@@ -149,6 +149,110 @@
           option: network_backend
           value: "\"{{ edpm_container_default_network_backend }}\""
 
+    - name: Configure sigstore signature verification for mirror registries
+      when:
+        - edpm_container_signature_verification | bool
+        - edpm_podman_disconnected_ocp | bool
+      block:
+        - name: Validate signature verification prerequisites
+          ansible.builtin.assert:
+            that:
+              - edpm_container_signature_registry_mappings | length > 0
+              - edpm_container_signature_cosign_key_data | length > 0
+            fail_msg: >-
+              edpm_container_signature_verification is enabled but required
+              variables are missing. These are normally auto-set by the
+              openstack-operator from the ClusterImagePolicy CR.
+
+        - name: Ensure cosign key directory exists
+          ansible.builtin.file:
+            path: "{{ edpm_container_signature_cosign_key_path | dirname }}"
+            state: directory
+            mode: "0755"
+            owner: root
+            group: root
+
+        - name: Ensure sigstore registries directory exists
+          ansible.builtin.file:
+            path: /etc/containers/registries.d
+            state: directory
+            mode: "0755"
+            owner: root
+            group: root
+
+        - name: Write cosign public key to EDPM node
+          ansible.builtin.copy:
+            content: "{{ edpm_container_signature_cosign_key_data | b64decode }}"
+            dest: "{{ edpm_container_signature_cosign_key_path }}"
+            owner: root
+            group: root
+            mode: "0644"
+            setype: cert_t
+
+        - name: Read current container policy
+          ansible.builtin.slurp:
+            src: /etc/containers/policy.json
+          register: edpm_podman_policy_current
+
+        - name: Build per-source-registry sigstore policy entries
+          ansible.builtin.set_fact:
+            _edpm_sigstore_registry_policies: >-
+              {{
+                _edpm_sigstore_registry_policies | default({})
+                | combine({
+                    item.source: [{
+                      'type': 'sigstoreSigned',
+                      'keyPath': edpm_container_signature_cosign_key_path
+                    } | combine(
+                      (edpm_container_signature_signed_prefix | length > 0)
+                      | ternary(
+                          {
+                            'signedIdentity': {
+                              'type': 'remapIdentity',
+                              'prefix': item.source,
+                              'signedPrefix': edpm_container_signature_signed_prefix
+                            }
+                          },
+                          {}
+                        ),
+                      recursive=True
+                    )]
+                  })
+              }}
+          loop: "{{ edpm_container_signature_registry_mappings }}"
+
+        - name: Write merged container signature verification policy
+          ansible.builtin.copy:
+            content: "{{ edpm_podman_updated_policy | to_nice_json }}\n"
+            dest: /etc/containers/policy.json
+            owner: root
+            group: root
+            setype: etc_t
+            mode: "0644"
+            backup: true
+          vars:
+            edpm_podman_updated_policy: >-
+              {{
+                (edpm_podman_policy_current.content | b64decode | from_json)
+                | combine(
+                    {
+                      'transports': {
+                        'docker': _edpm_sigstore_registry_policies
+                      }
+                    },
+                    recursive=True
+                  )
+              }}
+
+        - name: Write sigstore registries.d configuration
+          ansible.builtin.template:
+            src: sigstore-registries.yaml.j2
+            dest: /etc/containers/registries.d/99-edpm-sigstore-verification.yaml
+            owner: root
+            group: root
+            setype: etc_t
+            mode: "0644"
+
     - name: Enable podman.socket service
       when:
         - edpm_podman_enable_socket | bool

--- a/roles/edpm_podman/templates/sigstore-registries.yaml.j2
+++ b/roles/edpm_podman/templates/sigstore-registries.yaml.j2
@@ -1,0 +1,5 @@
+docker:
+{% for mapping in edpm_container_signature_registry_mappings %}
+  {{ mapping.mirror }}:
+    use-sigstore-attachments: true
+{% endfor %}


### PR DESCRIPTION
When the openstack-operator detects a ClusterImagePolicy CR with sigstore (cosign) signature verification for a mirror registry, it auto-populates ansible vars that this role consumes to configure signature verification on EDPM data plane nodes.

jira: [OSPRH-28352](https://redhat.atlassian.net/browse/OSPRH-28352)