### PR TITLE
  [edpm_iscsid] Fix SELinux context for iSCSI configuration files

### DIFF
--- a/roles/edpm_iscsid/tasks/configure.yml
+++ b/roles/edpm_iscsid/tasks/configure.yml
@@ -38,6 +38,7 @@
       ansible.builtin.copy:
         dest: /etc/iscsi/initiatorname.iscsi
         mode: "0644"
+        setype: etc_t
         content: "InitiatorName={{ iscsi_iname.stdout | trim }}"
 
     - name: Record the IQN has been reset

--- a/roles/edpm_iscsid/tasks/install.yml
+++ b/roles/edpm_iscsid/tasks/install.yml
@@ -64,13 +64,21 @@
             mv "{{ edpm_iscsid_tripleo_config_dir }}" "{{ edpm_iscsid_tripleo_config_dir }}.adopted"
           changed_when: true
 
+    - name: Ensure correct SELinux context for iSCSI configuration
+      ansible.builtin.file:
+        path: "{{ item }}"
+        setype: etc_t
+        recurse: true
+      loop:
+        - /etc/iscsi
+
     - name: Check SELinux context of iSCSI directories
-      ansible.builtin.command: "/usr/sbin/restorecon -nvr /etc/iscsi /var/lib/iscsi"
+      ansible.builtin.command: "/usr/sbin/restorecon -nvr /var/lib/iscsi"
       changed_when: false
       register: iscsi_selinux_status
 
     - name: Restore SELinux context of iSCSI directories
-      ansible.builtin.command: "/usr/sbin/restorecon -rF /etc/iscsi /var/lib/iscsi"
+      ansible.builtin.command: "/usr/sbin/restorecon -rF /var/lib/iscsi"
       when:
         - iscsi_selinux_status.stdout_lines | length > 0
       changed_when: true


### PR DESCRIPTION
  Files in /etc/iscsi/ were getting incorrect SELinux context
  (container_file_t instead of etc_t) during TripleO adoption, causing
  iscsid service to fail with "can't open InitiatorName configuration
  file" errors due to SELinux denials.

  When copying files from the TripleO container path
  /var/lib/config-data/puppet-generated/iscsid/etc/iscsi/ to the host
  /etc/iscsi/, files inherit the source container_file_t context.
  The restorecon command alone is insufficient since SELinux policy
  may not define explicit file contexts for all paths.

  Changes:
  - Explicitly set setype: etc_t for all files in /etc/iscsi/ after adoption in install.yml
  - Add setype: etc_t when creating initiatorname.iscsi in configure.yml
  - Remove /etc/iscsi from restorecon (now handled explicitly)

  This fix should work for both adoption and greenfield deployments.