### PR TITLE
Share NIC mapping tasks for nmstate and os-net-config

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -54,7 +54,20 @@ edpm_network_config_manage_service: true
 # Note: This only applies when edpm_network_config_tool is 'os-net-config'
 edpm_network_config_nmstate: true
 edpm_network_config_purge_provider: ""
+# NIC mapping for the nmstate and os-net-config paths: merged in nic_mapping.yml and passed to the
+# edpm_os_net_config_mappings module.
+# Legacy role variable: edpm_network_config_os_net_config_mappings. Additional/overriding mapping:
+# edpm_network_config_mappings (wins on duplicate keys, recursive merge).
 edpm_network_config_os_net_config_mappings: {}
+edpm_network_config_mappings: {}
+
+# edpm_network_config_mapping_file is not a user variable: nmstate_tool.yml and
+# os_net_config_tool.yml set it before nic_mapping.yml runs.
+# Maintainer note: ansible-playbook extra vars (-e) have higher precedence than set_fact and can
+# still override this name; that is unsupported and may break mapping paths. There is no role-level
+# way to forbid extra vars; avoid documenting this key for operators.
+# Resolved NIC mapping (mapped_nics); written by files/edpm_derived_nic_mapping.py on nmstate path
+edpm_network_config_derived_nic_mapping_file: /var/lib/edpm-config/derived_nic_mapping.yaml
 edpm_network_config_safe_defaults: false
 edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -51,7 +51,21 @@ edpm_network_config_manage_service: true
 # Note: This only applies when edpm_network_config_tool is 'os-net-config'
 edpm_network_config_nmstate: true
 edpm_network_config_purge_provider: ""
+# NIC mapping for BOTH the nmstate and os-net-config paths (not gated by edpm_network_config_tool):
+# merged in nic_mapping.yml and passed to the edpm_os_net_config_mappings module.
+# Legacy role variable: edpm_network_config_os_net_config_mappings. Additional/overriding mapping:
+# edpm_network_config_mappings (wins on duplicate keys, recursive merge).
+# If left empty / no host match: os-net-config falls back to its own built-in default nic1/nic2/...
+# numbering; the nmstate path has no such fallback, so use real interface names in
+# edpm_network_config_template unless a mapping is provided. See meta/argument_specs.yml for details.
 edpm_network_config_os_net_config_mappings: {}
+edpm_network_config_mappings: {}
+
+# edpm_network_config_mapping_file is not a user variable: nmstate_tool.yml and
+# os_net_config_tool.yml set it before nic_mapping.yml runs.
+# Maintainer note: ansible-playbook extra vars (-e) have higher precedence than set_fact and can
+# still override this name; that is unsupported and may break mapping paths. There is no role-level
+# way to forbid extra vars; avoid documenting this key for operators.
 edpm_network_config_safe_defaults: false
 edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -55,7 +55,20 @@ argument_specs:
         default: true
       edpm_network_config_os_net_config_mappings:
         type: dict
-        description: "Per node and/or per node group configuration map. Used by the edpm_os_net_config_mappings module."
+        description: >
+          Legacy role variable: per-node / node-group NIC mapping for the nmstate and os-net-config
+          paths (merged in nic_mapping.yml). Merged with edpm_network_config_mappings; the latter
+          wins on duplicate keys. The merged dict is passed to the edpm_os_net_config_mappings Ansible
+          module as net_config_data_lookup.
+        default: {}
+      edpm_network_config_mappings:
+        type: dict
+        description: >
+          Optional additional or overriding NIC mapping for the nmstate and os-net-config paths
+          (merged in nic_mapping.yml). Merged with edpm_network_config_os_net_config_mappings; this
+          variable wins on duplicate keys.
+          Must be a YAML mapping (dict). Do not use a block literal (|) after the key — that
+          produces a string and role validation will fail.
         default: {}
       edpm_network_config_purge_provider:
         type: str

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -55,7 +55,32 @@ argument_specs:
         default: true
       edpm_network_config_os_net_config_mappings:
         type: dict
-        description: "Per node and/or per node group configuration map. Used by the edpm_os_net_config_mappings module."
+        description: >
+          Legacy role variable: per-node / node-group NIC mapping. Applies to BOTH
+          edpm_network_config_tool values (nmstate and os-net-config) — it is not gated by that
+          variable and is merged with edpm_network_config_mappings in nic_mapping.yml (the latter
+          wins on duplicate keys). The merged dict is passed to the edpm_os_net_config_mappings
+          Ansible module as net_config_data_lookup, which resolves nic1/nic2/... to real interfaces
+          by MAC address or dmiString+id match and writes the result to
+          /etc/os-net-config/mapping.yaml (os-net-config path) or
+          /var/lib/edpm-config/template_nic_mapping.yaml (nmstate path).
+          If this and edpm_network_config_mappings are both left at their default ({}), or neither
+          matches this host, no mapping file is written. In that case the os-net-config path falls
+          back to os-net-config's own built-in default nic1/nic2/... numbering (embedded interfaces
+          such as em/eth/eno first, then other active NICs, both ordered alphanumerically); the
+          nmstate path has no equivalent built-in fallback, so nic aliases in
+          edpm_network_config_template are only resolved when a mapping is supplied here (or via
+          edpm_network_config_mappings) — otherwise use real interface names in the template.
+        default: {}
+      edpm_network_config_mappings:
+        type: dict
+        description: >
+          Optional additional or overriding NIC mapping for the nmstate and os-net-config paths
+          (merged in nic_mapping.yml). Merged with edpm_network_config_os_net_config_mappings; this
+          variable wins on duplicate keys. See edpm_network_config_os_net_config_mappings above for
+          how the merged mapping is used and what happens when no mapping is provided/matched.
+          Must be a YAML mapping (dict). Do not use a block literal (|) after the key — that
+          produces a string and role validation will fail.
         default: {}
       edpm_network_config_purge_provider:
         type: str

--- a/roles/edpm_network_config/tasks/nic_mapping.yml
+++ b/roles/edpm_network_config/tasks/nic_mapping.yml
@@ -1,0 +1,61 @@
+---
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# nmstate / os-net-config: build interface_mapping (nic1 -> MAC or interface name, etc.)
+# and write edpm_network_config_mapping_file (set by nmstate_tool.yml or os_net_config_tool.yml).
+# Not an inventory variable; -e edpm_network_config_mapping_file=... overrides set_fact (unsupported).
+# Input: merged edpm_network_config_os_net_config_mappings (legacy) + edpm_network_config_mappings.
+# The edpm_os_net_config_mappings name refers to the Ansible module (plugins/modules/), not a role variable.
+
+- name: Merge NIC mapping lookups (edpm_network_config_os_net_config_mappings + edpm_network_config_mappings)
+  ansible.builtin.set_fact:
+    edpm_network_config_merged_mappings: >-
+      {{
+        edpm_network_config_os_net_config_mappings | default({})
+        | combine(edpm_network_config_mappings | default({}), recursive=True)
+      }}
+
+- name: Create directory for EDPM NIC mapping file
+  ansible.builtin.file:
+    path: "{{ edpm_network_config_mapping_file | dirname }}"
+    state: directory
+    mode: "0755"
+
+- name: Create NIC mappings from lookup data
+  edpm_os_net_config_mappings:
+    net_config_data_lookup:
+      "{{ edpm_network_config_merged_mappings }}"
+  when: not ansible_check_mode | bool
+  register: edpm_os_net_config_mappings_result
+
+- name: Fail when NIC mappings were provided but no host match
+  ansible.builtin.fail:
+    msg: |
+      The edpm_os_net_config_mappings module did not match this host, so
+      {{ edpm_network_config_mapping_file }} was not written.
+      Set edpm_network_config_os_net_config_mappings and/or edpm_network_config_mappings so a MAC
+      matches an address under /sys/class/net/*/address (see plugins/modules/edpm_os_net_config_mappings.py),
+      or use dmiString + id. inventory_hostname for this run is {{ inventory_hostname }}.
+  when:
+    - edpm_network_config_merged_mappings | length > 0
+    - edpm_os_net_config_mappings_result.mapping is none
+
+- name: Write EDPM NIC mapping file
+  ansible.builtin.copy:
+    content: "{{ edpm_os_net_config_mappings_result.mapping | to_nice_yaml }}"
+    dest: "{{ edpm_network_config_mapping_file }}"
+    mode: "0644"
+  when: edpm_os_net_config_mappings_result.mapping is not none

--- a/roles/edpm_network_config/tasks/nic_mapping.yml
+++ b/roles/edpm_network_config/tasks/nic_mapping.yml
@@ -1,0 +1,86 @@
+---
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# nmstate / os-net-config: build interface_mapping (nic1 -> MAC or interface name, etc.)
+# and write edpm_network_config_mapping_file (set by nmstate_tool.yml or os_net_config_tool.yml).
+# Not an inventory variable; -e edpm_network_config_mapping_file=... overrides set_fact (unsupported).
+# Input: merged edpm_network_config_os_net_config_mappings (legacy) + edpm_network_config_mappings.
+# The edpm_os_net_config_mappings name refers to the Ansible module (plugins/modules/), not a role variable.
+
+- name: Merge NIC mapping lookups (edpm_network_config_os_net_config_mappings + edpm_network_config_mappings)
+  ansible.builtin.set_fact:
+    edpm_network_config_merged_mappings: >-
+      {{
+        edpm_network_config_os_net_config_mappings | default({})
+        | combine(edpm_network_config_mappings | default({}), recursive=True)
+      }}
+
+- name: Create directory for EDPM NIC mapping file
+  ansible.builtin.file:
+    path: "{{ edpm_network_config_mapping_file | dirname }}"
+    state: directory
+    mode: "0755"
+
+# edpm_os_net_config_mappings is read-only (reads /sys/class/net/*/address and shells out to
+# dmidecode; never writes anything), so force it to run even under --check with check_mode: false.
+# The module declares supports_check_mode=False, which would otherwise make Ansible skip it in
+# check mode; skipping it would make edpm_os_net_config_mappings_result.mapping Undefined (not
+# None) whenever mapping data is configured, which would make the "Fail when NIC mappings were
+# provided but no host match" task below fail on every --check run regardless of whether the host
+# actually matches.
+- name: Create NIC mappings from lookup data
+  edpm_os_net_config_mappings:
+    net_config_data_lookup:
+      "{{ edpm_network_config_merged_mappings }}"
+  check_mode: false
+  register: edpm_os_net_config_mappings_result
+
+# Defensive: keep mapping in a variable that is always defined (a real mapping dict, or None for
+# "ran and found no host match"), so downstream "is none"/"is not none" checks and filters never
+# operate on an Undefined value.
+- name: Normalize NIC mapping result to a defined variable (None when no match)
+  ansible.builtin.set_fact:
+    edpm_os_net_config_mapping: "{{ edpm_os_net_config_mappings_result.mapping | default(None) }}"
+
+- name: Fail when NIC mappings were provided but no host match
+  ansible.builtin.fail:
+    msg: |
+      The edpm_os_net_config_mappings module did not match this host, so
+      {{ edpm_network_config_mapping_file }} was not written.
+      Set edpm_network_config_os_net_config_mappings and/or edpm_network_config_mappings so a MAC
+      matches an address under /sys/class/net/*/address (see plugins/modules/edpm_os_net_config_mappings.py),
+      or use dmiString + id. inventory_hostname for this run is {{ inventory_hostname }}.
+  when:
+    - edpm_network_config_merged_mappings | length > 0
+    - edpm_os_net_config_mapping is none
+
+- name: Write EDPM NIC mapping file
+  ansible.builtin.copy:
+    content: "{{ edpm_os_net_config_mapping | to_nice_yaml }}"
+    dest: "{{ edpm_network_config_mapping_file }}"
+    mode: "0644"
+  when: edpm_os_net_config_mapping is not none
+
+# Not gated on ansible_check_mode: the file/copy modules below already simulate correctly under
+# --check (no real write/delete happens), and since the discovery task above always runs for real
+# (check_mode: false), edpm_os_net_config_mapping reflects the true match state even in check mode.
+# edpm_network_config_mapping_file is the only mapping output this role manages, so this is the
+# only place it can go stale.
+- name: Remove stale NIC mapping file when nothing matched/configured this run
+  ansible.builtin.file:
+    path: "{{ edpm_network_config_mapping_file }}"
+    state: absent
+  when: edpm_os_net_config_mapping is none

--- a/roles/edpm_network_config/tasks/nmstate_tool.yml
+++ b/roles/edpm_network_config/tasks/nmstate_tool.yml
@@ -31,6 +31,14 @@
     # For nmstate, always enable NetworkManager DNS management
     edpm_bootstrap_network_resolvconf_update: true
 
+- name: Set NIC mapping file path for nmstate path (internal, not user-overridable)
+  ansible.builtin.set_fact:
+    edpm_network_config_mapping_file: /var/lib/edpm-config/template_nic_mapping.yaml
+
+- name: Create EDPM NIC mapping file (nmstate path)
+  become: true
+  ansible.builtin.import_tasks: nic_mapping.yml
+
 - name: Check nmstate return code for conditional logic
   become: true
   block:

--- a/roles/edpm_network_config/tasks/nmstate_tool.yml
+++ b/roles/edpm_network_config/tasks/nmstate_tool.yml
@@ -23,6 +23,10 @@
     # For nmstate, always enable NetworkManager DNS management
     edpm_bootstrap_network_resolvconf_update: true
 
+- name: Set NIC mapping file path for nmstate path (internal, not user-overridable)
+  ansible.builtin.set_fact:
+    edpm_network_config_mapping_file: /var/lib/edpm-config/template_nic_mapping.yaml
+
 - name: Check nmstate return code for conditional logic
   become: true
   block:
@@ -45,6 +49,9 @@
       ((nmstate_returncode_slurp.content | b64decode | int) != 0)) or
       (not nmstate_returncode_stat.stat.exists)
   block:
+    - name: Create EDPM NIC mapping file (nmstate path)
+      ansible.builtin.import_tasks: nic_mapping.yml
+
     - name: Render network_state variable
       ansible.builtin.set_fact:
         network_state: "{{ edpm_network_config_template | from_yaml }}"

--- a/roles/edpm_network_config/tasks/os_net_config_tool.yml
+++ b/roles/edpm_network_config/tasks/os_net_config_tool.yml
@@ -40,6 +40,13 @@
       ((os_net_config_returncode_slurp.content | b64decode | int) != 0)) or
       (not os_net_config_returncode_stat.stat.exists)
 
+- name: Create EDPM NIC mapping file (os-net-config path)
+  become: true
+  vars:
+    # Internal path for nic_mapping output; not exposed in role defaults.
+    edpm_network_config_mapping_file: /etc/os-net-config/mapping.yaml
+  ansible.builtin.import_tasks: nic_mapping.yml
+
 - name: Apply network configuration using os-net-config
   become: true
   # The conditions here are when we want to apply the NetworkConfig:
@@ -53,26 +60,6 @@
       ((os_net_config_returncode_slurp.content | b64decode | int) != 0)) or
       (not os_net_config_returncode_stat.stat.exists)
   block:
-    - name: Create /etc/os-net-config directory
-      ansible.builtin.file:
-        path: /etc/os-net-config
-        state: directory
-        mode: "0755"
-
-    - name: Create os-net-config mappings from lookup data
-      edpm_os_net_config_mappings:
-        net_config_data_lookup:
-          "{{ edpm_network_config_os_net_config_mappings }}"
-      when: not ansible_check_mode | bool
-      register: os_net_config_mappings_result
-
-    - name: Write os-net-config mappings file /etc/os-net-config/mapping.yaml
-      ansible.builtin.copy:
-        content: "{{ os_net_config_mappings_result.mapping | to_nice_yaml }}"
-        dest: /etc/os-net-config/mapping.yaml
-        mode: "0644"
-      when: os_net_config_mappings_result.changed | bool  # noqa: no-handler
-
     - name: Manage NetworkConfig with edpm_os_net_config module
       block:
         - name: Remove /var/lib/edpm-config/scripts directory

--- a/roles/edpm_network_config/tasks/os_net_config_tool.yml
+++ b/roles/edpm_network_config/tasks/os_net_config_tool.yml
@@ -53,25 +53,11 @@
       ((os_net_config_returncode_slurp.content | b64decode | int) != 0)) or
       (not os_net_config_returncode_stat.stat.exists)
   block:
-    - name: Create /etc/os-net-config directory
-      ansible.builtin.file:
-        path: /etc/os-net-config
-        state: directory
-        mode: "0755"
-
-    - name: Create os-net-config mappings from lookup data
-      edpm_os_net_config_mappings:
-        net_config_data_lookup:
-          "{{ edpm_network_config_os_net_config_mappings }}"
-      when: not ansible_check_mode | bool
-      register: os_net_config_mappings_result
-
-    - name: Write os-net-config mappings file /etc/os-net-config/mapping.yaml
-      ansible.builtin.copy:
-        content: "{{ os_net_config_mappings_result.mapping | to_nice_yaml }}"
-        dest: /etc/os-net-config/mapping.yaml
-        mode: "0644"
-      when: os_net_config_mappings_result.changed | bool  # noqa: no-handler
+    - name: Create EDPM NIC mapping file (os-net-config path)
+      vars:
+        # Internal path for nic_mapping output; not exposed in role defaults.
+        edpm_network_config_mapping_file: /etc/os-net-config/mapping.yaml
+      ansible.builtin.import_tasks: nic_mapping.yml
 
     - name: Manage NetworkConfig with edpm_os_net_config module
       block:


### PR DESCRIPTION
Add nic_mapping.yml to merge edpm_network_config_os_net_config_mappings with edpm_network_config_mappings (recursive combine) and run edpm_os_net_config_mappings, failing when lookup data is present but no host match is found, then write the resolved YAML to the path chosen by each tool (template_nic_mapping.yaml for nmstate, /etc/os-net-config/ mapping.yaml for os-net-config).

Remove the duplicated mapping block from the os-net-config apply path and document both mapping variables in defaults and meta/argument_specs, including that edpm_network_config_mapping_file is internal and that extra vars can override set_fact.

Assisted-by: Cursor Agent

Signed-off-by: Karthik Sundaravel <ksundara@redhat.com>

PS: I'll make a followup PR that does the NIC mapping for nmstate tool