### PR TITLE
Generate SSL certificates for ovn-controller

### DIFF
--- a/roles/edpm_neutron_metadata/defaults/main.yml
+++ b/roles/edpm_neutron_metadata/defaults/main.yml
@@ -62,8 +62,8 @@ edpm_neutron_metadata_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/t
 edpm_neutron_metadata_tls_cacert_volumes: []
 
 edpm_neutron_metadata_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/cacerts/{{ edpm_neutron_metadata_service_name }}/tls-ca-bundle.pem:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/rbac/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_metadata_service_name }}/rbac/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
 
 edpm_neutron_metadata_healthcheck: true

--- a/roles/edpm_neutron_metadata/meta/argument_specs.yml
+++ b/roles/edpm_neutron_metadata/meta/argument_specs.yml
@@ -134,9 +134,9 @@ argument_specs:
         type: list
         elements: str
         default:
-          - /var/lib/openstack/certs/neutron_metadata_agent/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z
-          - /var/lib/openstack/certs/neutron_metadata_agent/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
-          - /var/lib/openstack/certs/neutron_metadata_agent/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
+          - /var/lib/openstack/cacerts/neutron-metadata/tls-ca-bundle.pem:/etc/pki/tls/certs/ovndbca.crt:ro,z
+          - /var/lib/openstack/certs/neutron-metadata/rbac/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z
+          - /var/lib/openstack/certs/neutron-metadata/rbac/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z
       edpm_neutron_metadata_healthcheck:
         type: bool
         default: true

--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -35,9 +35,9 @@ edpm_neutron_ovn_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/tls-ca
 edpm_neutron_ovn_tls_cacert_volumes: []
 
 edpm_neutron_ovn_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/cacerts/{{ edpm_neutron_ovn_service_name }}/tls-ca-bundle.pem:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/rbac/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_neutron_ovn_service_name }}/rbac/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
 
 # Neutron conf
 # DEFAULT

--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -68,13 +68,18 @@ edpm_ovn_controller_tls_cacert_volumes: []
 
 edpm_ovn_controller_tls_volumes:
   - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/rbac/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_service_name }}/rbac/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
 
 edpm_ovn_tls_enabled: "{{ edpm_tls_certs_enabled | default(False) }}"
 
+# OVN chassis system-id: a deterministic UUID5 derived from the hostname.
+# Using a UUID is the recommended practice for OVN system-id.
+edpm_ovn_system_id: "{{ canonical_hostname | to_uuid(namespace='6ba7b810-9dad-11d1-80b4-00c04fd430c8') }}"
+
 # Set external_id data from provided variables
 edpm_ovn_ovs_external_ids:
+  system-id: "{{ edpm_ovn_system_id }}"
   hostname: "{{ canonical_hostname }}"
   ovn-bridge: "{{ edpm_ovn_bridge }}"
   ovn-bridge-mappings: >-

--- a/roles/edpm_ovn/molecule/default/verify-tasks.yml
+++ b/roles/edpm_ovn/molecule/default/verify-tasks.yml
@@ -106,3 +106,9 @@
     /usr/bin/ovs-vsctl get open_vswitch . external_ids:hostname
   register: output
   failed_when: output.stdout != 'edpm-0.localdomain'
+
+- name: Verify system-id is a UUID in external_id
+  ansible.builtin.shell: >
+    /usr/bin/ovs-vsctl get open_vswitch . external_ids:system-id
+  register: output
+  failed_when: output.stdout != '"572cb2ee-c4d3-5e40-81b7-bb0cb922a53b"'

--- a/roles/edpm_ovn/molecule/rbac_certs/cleanup.yml
+++ b/roles/edpm_ovn/molecule/rbac_certs/cleanup.yml
@@ -1,0 +1,1 @@
+../default/cleanup.yml

--- a/roles/edpm_ovn/molecule/rbac_certs/collections.yml
+++ b/roles/edpm_ovn/molecule/rbac_certs/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_ovn/molecule/rbac_certs/converge.yml
+++ b/roles/edpm_ovn/molecule/rbac_certs/converge.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - ansible.builtin.include_role:
+        name: "osp.edpm.edpm_ovn"
+      vars:
+        tenant_ip: "{{ ansible_host }}"
+        edpm_ovn_dbs:
+          - "{{ ansible_host }}"
+        edpm_ovn_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"
+        edpm_tls_certs_enabled: true

--- a/roles/edpm_ovn/molecule/rbac_certs/molecule.yml
+++ b/roles/edpm_ovn/molecule/rbac_certs/molecule.yml
@@ -1,0 +1,1 @@
+../default/molecule.yml

--- a/roles/edpm_ovn/molecule/rbac_certs/prepare.yml
+++ b/roles/edpm_ovn/molecule/rbac_certs/prepare.yml
@@ -1,0 +1,148 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+- name: Prepare test_deps
+  hosts: all
+  gather_facts: false
+  roles:
+    - role: ../../../../molecule/common/test_deps
+      test_deps_setup_edpm: true
+      test_deps_setup_stream: true
+      test_deps_edpm_packages:
+        - centos-stream-release
+        - openvswitch
+        - libibverbs
+        - podman
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - ansible.builtin.include_role:
+        name: osp.edpm.env_data
+
+    # The openvswitch kernel module needs to be loaded on the host
+    - name: install and modprobe openvswitch
+      shell: |
+        sudo dnf -y install openvswitch
+        sudo modprobe openvswitch
+      delegate_to: localhost
+      run_once: true
+
+    # Create a test CA and pre-generate a node certificate to simulate
+    # what cert-manager + edpm_install_certs would produce. The cert is
+    # placed on the EDPM node at the path where edpm_install_certs copies
+    # it (as tls.crt / tls.key).
+    - name: Create test RBAC CA directory
+      ansible.builtin.file:
+        path: /tmp/ovn-rbac-test-ca
+        state: directory
+        mode: "0755"
+      delegate_to: localhost
+      run_once: true
+
+    - name: Generate test RBAC CA private key
+      ansible.builtin.command:
+        cmd: >
+          openssl genrsa
+          -out /tmp/ovn-rbac-test-ca/tls.key 2048
+        creates: /tmp/ovn-rbac-test-ca/tls.key
+      delegate_to: localhost
+      run_once: true
+
+    - name: Generate test RBAC CA certificate
+      ansible.builtin.command:
+        cmd: >
+          openssl req -new -x509
+          -key /tmp/ovn-rbac-test-ca/tls.key
+          -out /tmp/ovn-rbac-test-ca/tls.crt
+          -days 365
+          -subj "/CN=OVN SB DB Test CA"
+        creates: /tmp/ovn-rbac-test-ca/tls.crt
+      delegate_to: localhost
+      run_once: true
+
+    - name: Generate node private key
+      ansible.builtin.command:
+        cmd: >
+          openssl genrsa
+          -out /tmp/ovn-rbac-test-ca/node.key 2048
+        creates: /tmp/ovn-rbac-test-ca/node.key
+      delegate_to: localhost
+      run_once: true
+
+    - name: Generate node CSR with CN=UUID5(canonical_hostname)
+      ansible.builtin.command:
+        cmd: >
+          openssl req -new
+          -key /tmp/ovn-rbac-test-ca/node.key
+          -out /tmp/ovn-rbac-test-ca/node.csr
+          -subj "/CN={{ canonical_hostname | to_uuid(namespace='6ba7b810-9dad-11d1-80b4-00c04fd430c8') }}"
+      delegate_to: localhost
+      run_once: true
+
+    - name: Sign node certificate with test CA
+      ansible.builtin.command:
+        cmd: >
+          openssl x509 -req
+          -in /tmp/ovn-rbac-test-ca/node.csr
+          -CA /tmp/ovn-rbac-test-ca/tls.crt
+          -CAkey /tmp/ovn-rbac-test-ca/tls.key
+          -CAserial /tmp/ovn-rbac-test-ca/ca.srl
+          -CAcreateserial
+          -out /tmp/ovn-rbac-test-ca/node.crt
+          -days 365
+          -sha256
+      delegate_to: localhost
+      run_once: true
+
+    # Place certs on the EDPM node as edpm_install_certs would.
+    - name: Create RBAC cert directory on EDPM node
+      become: true
+      ansible.builtin.file:
+        path: /var/lib/openstack/certs/ovn/rbac
+        state: directory
+        mode: "0755"
+
+    - name: Copy RBAC certificate to EDPM node
+      become: true
+      ansible.builtin.copy:
+        src: /tmp/ovn-rbac-test-ca/node.crt
+        dest: /var/lib/openstack/certs/ovn/rbac/tls.crt
+        mode: "0600"
+
+    - name: Copy RBAC private key to EDPM node
+      become: true
+      ansible.builtin.copy:
+        src: /tmp/ovn-rbac-test-ca/node.key
+        dest: /var/lib/openstack/certs/ovn/rbac/tls.key
+        mode: "0600"
+
+    # Create the CA cert file at the path that the ovn_controller container
+    # expects to bind-mount when TLS is enabled.
+    - name: Create OVN certs directory on EDPM node
+      become: true
+      ansible.builtin.file:
+        path: /var/lib/openstack/certs/ovn/default
+        state: directory
+        mode: "0755"
+
+    - name: Copy CA cert to EDPM node
+      become: true
+      ansible.builtin.copy:
+        src: /tmp/ovn-rbac-test-ca/tls.crt
+        dest: /var/lib/openstack/certs/ovn/default/ca.crt
+        mode: "0644"
+
+  post_tasks: []

--- a/roles/edpm_ovn/molecule/rbac_certs/test-data
+++ b/roles/edpm_ovn/molecule/rbac_certs/test-data
@@ -1,0 +1,1 @@
+../default/test-data

--- a/roles/edpm_ovn/molecule/rbac_certs/verify.yml
+++ b/roles/edpm_ovn/molecule/rbac_certs/verify.yml
@@ -1,0 +1,98 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include default tasks
+      ansible.builtin.include_tasks:
+        file: ../default/verify-tasks.yml
+
+    - name: Verify ovn-cms-options was not set by default
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open . external_ids
+      register: output
+      failed_when: "'ovn-cms-options' in output.stdout"
+
+    # Verify that RBAC certs exist at the path where edpm_install_certs
+    # places them and where the ovn_controller container volume-mounts from.
+    - name: Verify RBAC certificate exists on EDPM node
+      become: true
+      ansible.builtin.stat:
+        path: /var/lib/openstack/certs/ovn/rbac/tls.crt
+      register: rbac_cert
+
+    - name: Assert RBAC certificate exists
+      ansible.builtin.assert:
+        that:
+          - rbac_cert.stat.exists
+        fail_msg: "RBAC certificate does not exist at /var/lib/openstack/certs/ovn/rbac/tls.crt"
+
+    - name: Verify RBAC private key exists on EDPM node
+      become: true
+      ansible.builtin.stat:
+        path: /var/lib/openstack/certs/ovn/rbac/tls.key
+      register: rbac_key
+
+    - name: Assert RBAC private key exists
+      ansible.builtin.assert:
+        that:
+          - rbac_key.stat.exists
+        fail_msg: "RBAC private key does not exist at /var/lib/openstack/certs/ovn/rbac/tls.key"
+
+    - name: Verify RBAC certificate CN matches system-id UUID
+      become: true
+      ansible.builtin.shell: |
+        set -o pipefail
+        openssl x509 -in /var/lib/openstack/certs/ovn/rbac/tls.crt -noout -subject | \
+          sed -n 's/.*CN *= *\([^ ,]*\).*/\1/p'
+      register: cert_cn
+
+    - name: Get system-id from OVS external_ids
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open . external_ids:system-id
+      register: ovs_system_id
+
+    - name: Assert RBAC certificate CN matches system-id UUID
+      ansible.builtin.assert:
+        that:
+          - cert_cn.stdout == '572cb2ee-c4d3-5e40-81b7-bb0cb922a53b'
+          - ovs_system_id.stdout | replace('"', '') == cert_cn.stdout
+        fail_msg: >-
+          RBAC certificate CN '{{ cert_cn.stdout }}' does not match
+          expected UUID or OVS system-id '{{ ovs_system_id.stdout }}'
+
+    - name: Verify RBAC certificate issuer matches the CA
+      become: true
+      ansible.builtin.shell: |
+        set -o pipefail
+        openssl x509 -in /var/lib/openstack/certs/ovn/rbac/tls.crt -noout -issuer | \
+          sed -n 's/.*CN *= *\(.*\)/\1/p'
+      register: cert_issuer
+
+    - name: Assert RBAC certificate issuer is the test CA
+      ansible.builtin.assert:
+        that:
+          - "'OVN SB DB Test CA' in cert_issuer.stdout"
+        fail_msg: "RBAC certificate issuer is '{{ cert_issuer.stdout }}', expected 'OVN SB DB Test CA'"
+
+    - name: Fetch RBAC certificate to localhost for CA verification
+      become: true
+      ansible.builtin.fetch:
+        src: /var/lib/openstack/certs/ovn/rbac/tls.crt
+        dest: /tmp/ovn-rbac-test-ca/ovn-controller-cert.pem
+        flat: true
+
+    - name: Verify RBAC certificate is signed by the test CA
+      ansible.builtin.command:
+        cmd: >
+          openssl verify
+          -CAfile /tmp/ovn-rbac-test-ca/tls.crt
+          /tmp/ovn-rbac-test-ca/ovn-controller-cert.pem
+      register: cert_verify
+      delegate_to: localhost
+
+    - name: Assert RBAC certificate verification passed
+      ansible.builtin.assert:
+        that:
+          - cert_verify.rc == 0
+        fail_msg: "RBAC certificate verification failed: {{ cert_verify.stderr }}"

--- a/roles/edpm_ovn_bgp_agent/defaults/main.yml
+++ b/roles/edpm_ovn_bgp_agent/defaults/main.yml
@@ -69,9 +69,9 @@ edpm_ovn_bgp_agent_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/tls-
 edpm_ovn_bgp_agent_tls_cacert_volumes: []
 
 edpm_ovn_bgp_agent_tls_volumes:
-  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+  - "/var/lib/openstack/cacerts/{{ edpm_ovn_bgp_agent_service_name }}/tls-ca-bundle.pem:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/rbac/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+  - "/var/lib/openstack/certs/{{ edpm_ovn_bgp_agent_service_name }}/rbac/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
 
 # we need to add the InternalTLSCAFile and do a if/then/else in case tls-e
 

--- a/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
+++ b/roles/edpm_ovn_bgp_agent/meta/argument_specs.yml
@@ -142,6 +142,6 @@ argument_specs:
         type: list
         description: list of mounted TLS certificate volumes
         default:
-          - "/var/lib/openstack/certs/ovn-bgp-agent/default/ca.crt:/etc/pki/tls/certs/ovndbca.crt:ro,z"
-          - "/var/lib/openstack/certs/ovn-bgp-agent/default/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
-          - "/var/lib/openstack/certs/ovn-bgp-agent/default/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"
+          - "/var/lib/openstack/cacerts/ovn-bgp-agent/tls-ca-bundle.pem:/etc/pki/tls/certs/ovndbca.crt:ro,z"
+          - "/var/lib/openstack/certs/ovn-bgp-agent/rbac/tls.crt:/etc/pki/tls/certs/ovndb.crt:ro,z"
+          - "/var/lib/openstack/certs/ovn-bgp-agent/rbac/tls.key:/etc/pki/tls/private/ovndb.key:ro,Z"


### PR DESCRIPTION
With this patch instead of using the same SSL certificate by ovn-controller on each EDMP node in the environment, there is separate certificate generated, with uniq CN name which match system-id set in that chassis and signed with certificate from SB.
That way OVN RBAC can be used for the connections from ovn-controller running on the EDPM nodes to the OVS SB database.

Certificates are generated in the ansibleee POD as that's where secret with the OVN SB Certificate is also mounted.

Closes: #[OSPRH-1921](https://redhat.atlassian.net/browse/OSPRH-1921)