### PR TITLE
Fix edpm_cleanup service matching and artifact removal

### DIFF
--- a/roles/edpm_cleanup/README.md
+++ b/roles/edpm_cleanup/README.md
@@ -131,12 +131,8 @@ edpm_cleanup_remove_config_dirs: true
 # Remove containers with managed_by=edpm_ansible label that are not tracked in state file
 edpm_cleanup_orphaned_containers: false
 
-# List of container names to exclude from orphaned container cleanup
-# These containers use edpm_container_manage which doesn't track state
-edpm_cleanup_excluded_containers:
-  - nova_compute
-  - nova_compute_init
-  - nova_nvme_cleaner
+# Deprecated compatibility variable (no-op)
+edpm_cleanup_excluded_containers: []
 
 # Generic paths to clean up per service
 # Use __SERVICE_NAME__ as a placeholder that will be replaced during cleanup
@@ -194,12 +190,11 @@ edpm_cleanup_orphaned_containers: true
 **How it works:**
 1. Queries all containers with `managed_by=edpm_ansible` label
 2. Compares against containers tracked in state file
-3. Excludes containers listed in `edpm_cleanup_excluded_containers`
-4. Removes any containers not found in state file
-5. Logs the list of orphaned containers before removal
+3. Removes any containers not found in state file
+4. Logs the list of orphaned containers before removal
 
-**Excluded Containers:**
-Some containers (like nova_compute) use `edpm_container_manage` which adds the `managed_by=edpm_ansible` label but doesn't track containers in the state file. These are excluded by default via `edpm_cleanup_excluded_containers` to prevent accidental removal.
+**Deprecated Variable:**
+`edpm_cleanup_excluded_containers` is deprecated and no longer affects cleanup behavior.
 
 **Use Cases:**
 - Cleaning up after failed migrations
@@ -273,22 +268,6 @@ Benefits of the new approach:
     - osp.edpm.edpm_cleanup
 ```
 
-### Customize Excluded Containers
+### Deprecated Excluded Containers Variable
 
-By default, nova containers are excluded from orphaned cleanup because they use `edpm_container_manage` which doesn't track state. You can customize this list:
-
-```yaml
-- hosts: edpm_nodes
-  vars:
-    edpm_services:
-      - nova
-    edpm_cleanup_orphaned_containers: true
-    # Add or remove containers from exclusion list
-    edpm_cleanup_excluded_containers:
-      - nova_compute
-      - nova_compute_init
-      - nova_nvme_cleaner
-      - my_custom_container
-  roles:
-    - osp.edpm.edpm_cleanup
-```
+`edpm_cleanup_excluded_containers` is retained only for compatibility and is no longer honored during cleanup.

--- a/roles/edpm_cleanup/defaults/main.yml
+++ b/roles/edpm_cleanup/defaults/main.yml
@@ -29,15 +29,14 @@ edpm_cleanup_remove_config_dirs: true
 # Remove containers with managed_by=edpm_ansible label that are not tracked in state file
 edpm_cleanup_orphaned_containers: false
 
-# List of container names to exclude from orphaned container cleanup
-# These containers use edpm_container_manage which doesn't track state
-edpm_cleanup_excluded_containers:
-  - nova_compute
-  - nova_compute_init
-  - nova_nvme_cleaner
+# Deprecated compatibility variable. Excluded containers are no longer honored.
+edpm_cleanup_excluded_containers: []
+
+# Base directory for container healthcheck scripts
+edpm_cleanup_healthcheck_base_dir: /var/lib/openstack/healthchecks
 
 # Generic paths to clean up per service
 # Use __SERVICE_NAME__ as a placeholder that will be replaced during cleanup
 edpm_cleanup_generic_paths:
-  - "/var/lib/openstack/healthchecks/__SERVICE_NAME__"
+  - "{{ edpm_cleanup_healthcheck_base_dir }}/__SERVICE_NAME__"
   - "/var/lib/openstack/__SERVICE_NAME__"

--- a/roles/edpm_cleanup/meta/argument_specs.yml
+++ b/roles/edpm_cleanup/meta/argument_specs.yml
@@ -49,20 +49,19 @@ argument_specs:
           Use with caution - only enable if you want to clean up orphaned containers.
         type: bool
       edpm_cleanup_excluded_containers:
-        default:
-          - nova_compute
-          - nova_compute_init
-          - nova_nvme_cleaner
+        default: []
         description: |
-          List of container names to exclude from orphaned container cleanup.
-          These containers use edpm_container_manage which doesn't track state in the
-          deployed_services.yaml file. Without this exclusion, they would be incorrectly
-          identified as orphaned when edpm_cleanup_orphaned_containers is enabled.
+          Deprecated compatibility variable. Excluded containers are no longer
+          honored during cleanup.
         type: list
         elements: str
+      edpm_cleanup_healthcheck_base_dir:
+        default: /var/lib/openstack/healthchecks
+        description: Base directory containing per-container healthcheck paths.
+        type: path
       edpm_cleanup_generic_paths:
         default:
-          - "/var/lib/openstack/healthchecks/__SERVICE_NAME__"
+          - "{{ edpm_cleanup_healthcheck_base_dir }}/__SERVICE_NAME__"
           - "/var/lib/openstack/__SERVICE_NAME__"
         description: >-
           List of generic file/directory paths to clean up per service.

--- a/roles/edpm_cleanup/molecule/default/converge.yml
+++ b/roles/edpm_cleanup/molecule/default/converge.yml
@@ -32,7 +32,8 @@
       when:
         - ansible_user is undefined
   vars:
-    edpm_container_standalone_service: test_service1
+    edpm_container_standalone_service: test_service1_container
+    edpm_service_name: test_service1
     edpm_container_standalone_container_defs:
       test_service1_container:
         image: quay.io/centos/centos:stream9
@@ -47,6 +48,13 @@
         command: 'sleep 3600'
   roles:
     - role: "osp.edpm.edpm_container_standalone"
+  tasks:
+    - name: Create container-scoped healthcheck directory for first service
+      become: true
+      ansible.builtin.file:
+        path: /var/lib/openstack/healthchecks/test_service1_container
+        state: directory
+        mode: '0755'
 
 - name: Deploy second service
   hosts: all
@@ -72,7 +80,7 @@
   hosts: all
   gather_facts: false
   vars:
-    edpm_services:
+    edpm_service_types:
       - test_service2
   roles:
     - role: osp.edpm.edpm_cleanup
@@ -141,7 +149,7 @@
       ansible.builtin.include_role:
         name: osp.edpm.edpm_cleanup
       vars:
-        edpm_services:
+        edpm_service_types:
           - test_service2
           - test_service3
         edpm_cleanup_orphaned_containers: true

--- a/roles/edpm_cleanup/molecule/default/verify.yml
+++ b/roles/edpm_cleanup/molecule/default/verify.yml
@@ -131,6 +131,30 @@
         fail_msg: "Kolla config for test_service3_container_a should still exist"
         success_msg: "Kolla config for test_service3_container_a still exists as expected"
 
+    - name: Check if startup config directory for test_service1 container exists
+      ansible.builtin.stat:
+        path: /var/lib/edpm-config/container-startup-config/test_service1_container
+      register: _service1_startup_dir
+
+    - name: Verify startup config directory for test_service1 container was removed
+      ansible.builtin.assert:
+        that:
+          - not _service1_startup_dir.stat.exists
+        fail_msg: "Startup config directory for test_service1_container should not exist"
+        success_msg: "Startup config directory for test_service1_container was removed"
+
+    - name: Check if healthcheck directory for test_service1 container exists
+      ansible.builtin.stat:
+        path: /var/lib/openstack/healthchecks/test_service1_container
+      register: _service1_healthcheck_dir
+
+    - name: Verify healthcheck directory for test_service1 container was removed
+      ansible.builtin.assert:
+        that:
+          - not _service1_healthcheck_dir.stat.exists
+        fail_msg: "Healthcheck directory for test_service1_container should not exist"
+        success_msg: "Healthcheck directory for test_service1_container was removed"
+
 - name: Verify image pruning after service cleanup
   hosts: all
   gather_facts: false

--- a/roles/edpm_cleanup/tasks/cleanup_services.yml
+++ b/roles/edpm_cleanup/tasks/cleanup_services.yml
@@ -37,12 +37,12 @@
         combine({'services': {}}, recursive=True)
       }}
 
-- name: Determine services to clean up (services in state file not in edpm_services)
+- name: Determine services to clean up
   ansible.builtin.set_fact:
     _edpm_services_to_cleanup: >-
       {{
         _edpm_cleanup_state_data.services.keys() | default([]) |
-        difference(edpm_services | default([])) |
+        difference(edpm_service_types | unique | list) |
         list
       }}
 
@@ -115,8 +115,7 @@
         _edpm_orphaned_containers: >-
           {{
             _edpm_all_managed_containers |
-            difference(_edpm_tracked_containers) |
-            difference(edpm_cleanup_excluded_containers | default([]))
+            difference(_edpm_tracked_containers)
           }}
 
     - name: Remove orphaned containers
@@ -155,6 +154,21 @@
       when:
         - _edpm_orphaned_containers | length > 0
         - _edpm_orphaned_startup_configs.results is defined
+
+    - name: Remove container-scoped startup config directories for orphaned containers
+      ansible.builtin.file:
+        path: "{{ edpm_container_startup_config_dir }}/{{ item }}"
+        state: absent
+      loop: "{{ _edpm_orphaned_containers }}"
+      when: _edpm_orphaned_containers | length > 0
+
+    - name: Remove healthcheck directories for orphaned containers
+      become: true
+      ansible.builtin.file:
+        path: "{{ edpm_cleanup_healthcheck_base_dir }}/{{ item }}"
+        state: absent
+      loop: "{{ _edpm_orphaned_containers }}"
+      when: _edpm_orphaned_containers | length > 0
 
 - name: Prune unused container images and volumes
   become: true

--- a/roles/edpm_cleanup/tasks/cleanup_single_service.yml
+++ b/roles/edpm_cleanup/tasks/cleanup_single_service.yml
@@ -45,12 +45,26 @@
   # This removes /var/lib/edpm-config/container-startup-config/<service>/
   # including all *.json container definition files within it
 
+- name: Remove container-scoped startup config directories
+  ansible.builtin.file:
+    path: "{{ edpm_container_startup_config_dir }}/{{ item }}"
+    state: absent
+  loop: "{{ _edpm_cleanup_service_containers }}"
+  when: edpm_cleanup_remove_config_dirs | bool
+
 - name: Remove generic service files and directories
   become: true
   ansible.builtin.file:
     path: "{{ item | replace('__SERVICE_NAME__', _edpm_cleanup_service_name) }}"
     state: absent
   loop: "{{ edpm_cleanup_generic_paths }}"
+
+- name: Remove container healthcheck directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ edpm_cleanup_healthcheck_base_dir }}/{{ item }}"
+    state: absent
+  loop: "{{ _edpm_cleanup_service_containers }}"
 
 - name: Remove kolla config files for each container
   become: true


### PR DESCRIPTION
Use service types when comparing the state file so aliased service names do not trigger cleanup for still-active services. Remove container-scoped startup configs and healthchecks from tracked container names, and cover both regressions in the cleanup molecule scenario.

jira: https://redhat.atlassian.net/browse/OSPRH-29452