### PR TITLE
Fix: container_config_hash over-scoped directory hashing

### DIFF
--- a/plugins/modules/container_config_hash.py
+++ b/plugins/modules/container_config_hash.py
@@ -65,6 +65,7 @@ EXAMPLES = """
 
 CONTAINER_STARTUP_CONFIG = '/var/lib/edpm-config/container-startup-config'
 BUF_SIZE = 65536
+SHARED_CONFIG_NAMESPACES = ('certs', 'cacerts', 'configs')
 
 
 class ContainerConfigHashManager:
@@ -178,14 +179,15 @@ class ContainerConfigHashManager:
         :param volume: string
         :returns: string
         """
-        # crawl the volume's path upwards until we find the
-        # volume's base, where the hashed config file resides
         path = volume
         base = prefix.rstrip(os.path.sep)
-        base_generated = os.path.join(base, 'ansible-generated')
+        shared_bases = tuple(
+            os.path.join(base, namespace)
+            for namespace in SHARED_CONFIG_NAMESPACES
+        )
         while path.startswith(prefix):
             dirname = os.path.dirname(path)
-            if dirname == base or dirname == base_generated:
+            if dirname == base or dirname in shared_bases:
                 return path
             else:
                 path = dirname
@@ -208,8 +210,12 @@ class ContainerConfigHashManager:
             self.module.fail_json(
                 msg='Error fetching volumes. Prefix: '
                     '{} - Config: {}'.format(prefix, config))
-        return sorted([self._get_config_base(prefix, v.split(":")[0])
-                       for v in volumes if v.startswith(prefix)])
+        matched = set()
+        for v in volumes:
+            host_path = v.split(":")[0]
+            if host_path.startswith(prefix):
+                matched.add(self._get_config_base(prefix, host_path))
+        return sorted(matched)
 
     def _update_hashes(self):
         """Update container startup config with new config hashes if needed.


### PR DESCRIPTION
get_config_base() walked up from each volume path to the first child of /var/lib/openstack/, then hashed all files under that shared parent. This caused a single file change (e.g. one service's cert rotation) to change the EDPM_CONFIG_HASH for every service mounting from the same parent directory, triggering unnecessary container restarts.

Introduce SHARED_CONFIG_NAMESPACES (certs, cacerts, configs) to scope
the walk-up to the service-level directory under shared namespaces to prevent duplicate hash generation for same service

Fix: [OSPRH-29551](https://redhat.atlassian.net/browse/OSPRH-29551) [OSPRH-29555](https://redhat.atlassian.net/browse/OSPRH-29555)