### PR TITLE
Publish ansible-runner summary to termination log

### DIFF
--- a/openstack_ansibleee/Containerfile
+++ b/openstack_ansibleee/Containerfile
@@ -26,11 +26,18 @@ RUN $REMOTE_SOURCE_DIR/openstack_ansibleee/setup.sh
 COPY --from=builder /usr/share/ansible /usr/share/ansible
 COPY $REMOTE_SOURCE/openstack_ansibleee/settings /runner/env/settings
 COPY $REMOTE_SOURCE/openstack_ansibleee/edpm_entrypoint.sh /opt/builder/bin/edpm_entrypoint
+COPY $REMOTE_SOURCE/openstack_ansibleee/edpm_run_and_summarize.sh /opt/builder/bin/edpm_run_and_summarize.sh
+COPY $REMOTE_SOURCE/openstack_ansibleee/write_runner_summary.py /opt/builder/bin/write_runner_summary.py
 
 RUN sed '1d' /usr/local/lib/python${PYV}/site-packages/ansible_builder/_target_scripts/entrypoint >> /opt/builder/bin/edpm_entrypoint
-RUN mkdir /runner/project && chmod -R 775 /runner && chmod +x /opt/builder/bin/edpm_entrypoint && chmod ug+rw /etc/passwd
+RUN mkdir /runner/project && \
+    chmod -R 775 /runner && \
+    chmod +x /opt/builder/bin/edpm_entrypoint \
+        /opt/builder/bin/edpm_run_and_summarize.sh \
+        /opt/builder/bin/write_runner_summary.py && \
+    chmod ug+rw /etc/passwd
 
 ENV EDPM_SYSTEMROLES='fedora.linux_system_roles'
 WORKDIR /runner
 LABEL ansible-execution-environment=true
-ENTRYPOINT ["/opt/builder/bin/edpm_entrypoint", "dumb-init"]
+ENTRYPOINT ["/opt/builder/bin/edpm_entrypoint", "dumb-init", "--", "/opt/builder/bin/edpm_run_and_summarize.sh"]

--- a/openstack_ansibleee/edpm_run_and_summarize.sh
+++ b/openstack_ansibleee/edpm_run_and_summarize.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -u
+
+write_runner_summary() {
+    local summary_helper
+    local runner_path
+    local runner_python
+    summary_helper="${EDPM_AEE_SUMMARY_HELPER:-/opt/builder/bin/write_runner_summary.py}"
+    runner_path="$(command -v ansible-runner 2>/dev/null || true)"
+    runner_python="$(sed -n '1s/^#!//p' "${runner_path}" 2>/dev/null || true)"
+
+    if [ -n "${runner_python}" ] && [ -x "${runner_python}" ]; then
+        "${runner_python}" "${summary_helper}" >/dev/null 2>&1 || true
+    fi
+}
+
+if [ "$#" -eq 0 ]; then
+    write_runner_summary
+    exit 0
+fi
+
+"$@"
+rc=$?
+
+write_runner_summary
+
+exit "${rc}"

--- a/openstack_ansibleee/write_runner_summary.py
+++ b/openstack_ansibleee/write_runner_summary.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Summarize ansible-runner artifacts for pod termination logs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _latest_run_dir(artifacts_root: Path) -> Path | None:
+    if not artifacts_root.exists():
+        return None
+
+    candidates = [path for path in artifacts_root.iterdir() if path.is_dir()]
+    if not candidates:
+        return None
+
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _latest_stats_event(job_events_dir: Path) -> dict[str, Any]:
+    if not job_events_dir.exists():
+        return {}
+
+    for event_file in job_events_dir.glob("*.json"):
+        try:
+            event_data = _load_json(event_file)
+            if event_data.get("event") != "playbook_on_stats":
+                continue
+
+            return event_data
+        except (json.JSONDecodeError, OSError, TypeError):
+            continue
+
+    return {}
+
+
+def _host_keys(stats_dict: Any) -> set[str]:
+    if not isinstance(stats_dict, dict):
+        return set()
+
+    return {str(host) for host in stats_dict.keys()}
+
+
+def build_summary(run_dir: Path) -> dict[str, Any]:
+    stats_event = _latest_stats_event(run_dir / "job_events")
+    event_data = stats_event.get("event_data", {})
+
+    total_hosts = _host_keys(event_data.get("processed"))
+    failure_hosts = _host_keys(event_data.get("failures"))
+    unreachable_hosts = _host_keys(event_data.get("dark"))
+    impacted_hosts = failure_hosts | unreachable_hosts
+
+    total_count = len(total_hosts)
+    failed_count = len(failure_hosts)
+    unreachable_count = len(unreachable_hosts)
+    impacted_count = len(impacted_hosts)
+
+    failure_pct = 0
+    if total_count:
+        failure_pct = ((impacted_count * 100) + (total_count // 2)) // total_count
+
+    summary = {
+        "failedHostList": sorted(failure_hosts),
+        "totalHosts": total_count,
+        "failedHosts": failed_count,
+        "unreachableHosts": unreachable_count,
+        "unreachableHostList": sorted(unreachable_hosts),
+        "failurePercent": failure_pct,
+    }
+
+    return summary
+
+
+def _write_summary(summary: dict[str, Any], output_path: Path) -> None:
+    payload = json.dumps(summary, separators=(",", ":"), sort_keys=True)
+    output_path.write_text(payload, encoding="utf-8")
+
+
+def main() -> int:
+    artifacts_root = Path(
+        os.environ.get("EDPM_AEE_ARTIFACTS_ROOT", "/runner/artifacts")
+    )
+    output_path = Path(
+        os.environ.get("EDPM_AEE_TERMINATION_LOG", "/dev/termination-log")
+    )
+
+    run_dir = _latest_run_dir(artifacts_root)
+    if run_dir is None:
+        return 0
+
+    summary = build_summary(run_dir)
+    _write_summary(summary, output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_write_runner_summary.py
+++ b/tests/test_write_runner_summary.py
@@ -1,0 +1,189 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+from openstack_ansibleee import write_runner_summary
+
+
+def _create_run_dir(tmp_path, run_name, counter, processed, failures, dark):
+    run_dir = tmp_path / "artifacts" / run_name
+    events_dir = run_dir / "job_events"
+    events_dir.mkdir(parents=True)
+    (run_dir / "rc").write_text("2", encoding="utf-8")
+    (run_dir / "status").write_text("failed", encoding="utf-8")
+    (events_dir / f"{counter}-stats.json").write_text(
+        json.dumps(
+            {
+                "counter": counter,
+                "event": "playbook_on_stats",
+                "event_data": {
+                    "processed": processed,
+                    "failures": failures,
+                    "dark": dark,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def test_build_summary_includes_failure_percentage(tmp_path):
+    run_dir = _create_run_dir(
+        tmp_path,
+        "run-one",
+        10,
+        {"host-a": 1, "host-b": 1, "host-c": 1},
+        {"host-b": 1},
+        {"host-c": 1},
+    )
+
+    summary = write_runner_summary.build_summary(run_dir)
+
+    assert summary == {
+        "failedHostList": ["host-b"],
+        "failedHosts": 1,
+        "failurePercent": 67,
+        "totalHosts": 3,
+        "unreachableHostList": ["host-c"],
+        "unreachableHosts": 1,
+    }
+
+
+def test_latest_run_dir_uses_most_recent_artifacts(tmp_path):
+    older_run = _create_run_dir(
+        tmp_path, "older-run", 2, {"host-a": 1}, {"host-a": 1}, {}
+    )
+    newer_run = _create_run_dir(
+        tmp_path, "newer-run", 3, {"host-a": 1, "host-b": 1}, {}, {}
+    )
+
+    os.utime(newer_run, None)
+    selected_run = write_runner_summary._latest_run_dir(tmp_path / "artifacts")
+
+    assert older_run != newer_run
+    assert selected_run == newer_run
+
+
+def test_latest_stats_event_skips_malformed_files(tmp_path):
+    events_dir = tmp_path / "job_events"
+    events_dir.mkdir()
+    (events_dir / "bad-json.json").write_text("{not-json", encoding="utf-8")
+    (events_dir / "not-stats.json").write_text(
+        json.dumps(
+            {
+                "counter": 1,
+                "event": "runner_on_ok",
+                "event_data": {"processed": {"host-a": 1}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (events_dir / "good.json").write_text(
+        json.dumps(
+            {
+                "counter": 2,
+                "event": "playbook_on_stats",
+                "event_data": {"processed": {"host-b": 1}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    latest_event = write_runner_summary._latest_stats_event(events_dir)
+
+    assert latest_event["counter"] == 2
+    assert latest_event["event_data"]["processed"] == {"host-b": 1}
+
+
+def test_host_keys_handles_unexpected_values():
+    assert write_runner_summary._host_keys(None) == set()
+    assert write_runner_summary._host_keys("not-a-dict") == set()
+    assert write_runner_summary._host_keys({"host-a": 1, "host-b": 0}) == {
+        "host-a",
+        "host-b",
+    }
+
+
+def test_build_summary_handles_missing_job_events(tmp_path):
+    run_dir = tmp_path / "artifacts" / "run-one"
+    run_dir.mkdir(parents=True)
+
+    summary = write_runner_summary.build_summary(run_dir)
+
+    assert summary == {
+        "failedHostList": [],
+        "failedHosts": 0,
+        "failurePercent": 0,
+        "totalHosts": 0,
+        "unreachableHostList": [],
+        "unreachableHosts": 0,
+    }
+
+
+def test_build_summary_handles_zero_processed_hosts(tmp_path):
+    run_dir = _create_run_dir(
+        tmp_path,
+        "run-zero",
+        4,
+        {},
+        {"host-b": 1},
+        {},
+    )
+
+    summary = write_runner_summary.build_summary(run_dir)
+
+    assert summary == {
+        "failedHostList": ["host-b"],
+        "failedHosts": 1,
+        "failurePercent": 0,
+        "totalHosts": 0,
+        "unreachableHostList": [],
+        "unreachableHosts": 0,
+    }
+
+
+def test_main_writes_summary_to_requested_output(tmp_path, monkeypatch):
+    _create_run_dir(
+        tmp_path,
+        "run-one",
+        8,
+        {"host-a": 1, "host-b": 1},
+        {"host-b": 1},
+        {},
+    )
+    output_path = tmp_path / "termination.log"
+
+    monkeypatch.setenv("EDPM_AEE_ARTIFACTS_ROOT", str(tmp_path / "artifacts"))
+    monkeypatch.setenv("EDPM_AEE_TERMINATION_LOG", str(output_path))
+
+    assert write_runner_summary.main() == 0
+
+    written_summary = json.loads(output_path.read_text(encoding="utf-8"))
+    assert written_summary["failedHostList"] == ["host-b"]
+    assert written_summary["unreachableHostList"] == []
+    assert written_summary["totalHosts"] == 2
+    assert written_summary["failedHosts"] == 1
+    assert written_summary["failurePercent"] == 50
+
+
+def test_main_returns_zero_when_no_artifacts_exist(tmp_path, monkeypatch):
+    output_path = tmp_path / "termination.log"
+
+    monkeypatch.setenv("EDPM_AEE_ARTIFACTS_ROOT", str(tmp_path / "missing"))
+    monkeypatch.setenv("EDPM_AEE_TERMINATION_LOG", str(output_path))
+
+    assert write_runner_summary.main() == 0
+    assert not output_path.exists()


### PR DESCRIPTION
Wrap the execution environment runner command so completed jobs emit a compact summary that survives pod exit. Limit the payload to the host failure metrics that the operator persists in deployment status.

jira: [OSPRH-29788](https://redhat.atlassian.net/browse/OSPRH-29788)