### PR TITLE
[edpm_libvirt] Update virsh regex for cephx

### DIFF
--- a/roles/edpm_libvirt/tasks/virsh-secret.yml
+++ b/roles/edpm_libvirt/tasks/virsh-secret.yml
@@ -38,4 +38,4 @@
     KEY: "{{ cephx_key.stdout | regex_replace('\"', '') }}"
   when:
     - cephx_key.stdout is defined
-    - cephx_key.stdout | regex_replace('\"', '') | regex_search('^[a-zA-Z0-9+/]{38}==$') | length > 0
+    - cephx_key.stdout | regex_replace('\"', '') | regex_search('^[a-zA-Z0-9+/]{30,60}={0,2}$') | length > 0


### PR DESCRIPTION
Update virsh-secret tasks file in edpm_libvirt role to handle a wider variety of cephx keys because not all cephx keys conform to the existing regex.

Jira: [OSPRH-29669](https://redhat.atlassian.net/browse/OSPRH-29669)