### PR TITLE
Fix: rework edpm_container_standalone for quadlet-only deployment

### DIFF
--- a/molecule/test-helpers/verify_systemd_unit.yaml
+++ b/molecule/test-helpers/verify_systemd_unit.yaml
@@ -1,16 +1,16 @@
 
 - name: verify systemd unit exists
   block:
-    - name: Check if systemd file exists {{ item.name }}
+    - name: Query systemd for unit fragment path {{ item.name }}
       become: true
-      ansible.builtin.stat:
-        path: "/etc/systemd/system/{{ item.name }}"
-      register: unit_exists
+      ansible.builtin.command: systemctl show {{ item.name }} -p FragmentPath --value
+      register: unit_fragment
+      changed_when: false
       when: item.osp_service | default(true)
     - name: Assert systemd unit exists {{ item.name }}
       ansible.builtin.assert:
         that:
-          - unit_exists.stat.exists
+          - unit_fragment.stdout | length > 0
         fail_msg: "Systemd unit file for {{ item.name }} does not exist"
       when: item.osp_service | default(true)
     - name: Check if systemd unit is enabled {{ item.name }}
@@ -21,10 +21,13 @@
       changed_when: false
       ignore_errors: true
     - name: Assert systemd unit is enabled {{ item.name }}
+      vars:
+        _allowed_states: >-
+          {{ item.enabled | default(["enabled", "generated"]) }}
       ansible.builtin.assert:
         that:
-          - unit_enabled.stdout == item.enabled | default("enabled")
-        fail_msg: "Systemd unit {{ item.name }} is not enabled"
+          - unit_enabled.stdout in (_allowed_states if _allowed_states is not string else [_allowed_states])
+        fail_msg: "Systemd unit {{ item.name }} is not enabled (got '{{ unit_enabled.stdout }}')"
     - name: Check if systemd unit is running {{ item.name }}
       when: item.running | default(true)
       ansible.builtin.command: systemctl is-active {{ item.name }}

--- a/plugins/modules/container_config_hash.py
+++ b/plugins/modules/container_config_hash.py
@@ -23,6 +23,7 @@ import glob
 import hashlib
 import json
 import os
+import re
 import yaml
 
 
@@ -42,7 +43,12 @@ version_added: '2.9'
 short_description: Generate config hashes for container startup configs
 notes: []
 description:
-  - Generate config hashes for container startup configs
+  - Compute SHA-256 hashes from container config volume mounts.
+    When called with 'quadlet_staging_dir' and 'containers', reads
+    Volume= lines from each staged Quadlet .container file, computes
+    the hash, and writes it into the 'config_hash' comment placeholder
+    (Quadlet path). When called without parameters, scans container
+    startup configs and updates them in place (container_manage path).
 requirements:
   - None
 options:
@@ -51,6 +57,18 @@ options:
       - Ansible check mode is enabled
     type: bool
     default: False
+  quadlet_staging_dir:
+    description:
+      - Path to the directory containing staged Quadlet .container files.
+        Used together with 'containers' to compute and inject config hashes.
+    type: path
+    default: ''
+  containers:
+    description:
+      - List of container names to process in the staging directory.
+        Each name maps to a staged file named edpm_<name>.container.
+    type: list
+    default: []
   config_vol_prefix:
     description:
       - Config volume prefix
@@ -61,18 +79,28 @@ options:
 EXAMPLES = """
 - name: Update config hashes for container startup configs
   container_config_hash:
+
+- name: Inject config hashes into staged Quadlet files
+  container_config_hash:
+    quadlet_staging_dir: /var/lib/edpm-config/quadlet-rendered
+    containers:
+      - ovn_controller
 """
 
 CONTAINER_STARTUP_CONFIG = '/var/lib/edpm-config/container-startup-config'
 BUF_SIZE = 65536
-SHARED_CONFIG_NAMESPACES = ('certs', 'cacerts', 'configs')
+SHARED_CONFIG_NAMESPACES = ('certs', 'cacerts', 'config', 'healthchecks')
 
 
 class ContainerConfigHashManager:
-    """Notes about this module.
+    """Generate config hashes for container change detection.
 
-    It will generate container config hash that will be consumed by
-    the edpm-container-manage role that is using podman_container module.
+    Quadlet path: reads Volume= lines from staged .container files in
+    the staging directory, computes hashes, and writes them into the
+    '# config_hash=' comment placeholder in each file.
+
+    Container_manage path (legacy): scans JSON startup configs and updates
+    EDPM_CONFIG_HASH in place.
     """
 
     def __init__(self, module, results):
@@ -86,11 +114,80 @@ class ContainerConfigHashManager:
 
         # Set parameters
         self.config_vol_prefix = args['config_vol_prefix']
+        staging_dir = args.get('quadlet_staging_dir', '')
+        containers = args.get('containers', [])
 
-        # Update container-startup-config with new config hashes
-        self._update_hashes()
+        # TODO(quadlet-migration): Remove _update_hashes() and its helpers
+        # (_find, _match_config_volumes, _update_container_config, _remove_file)
+        # once all services are migrated to Quadlet.
+        if staging_dir and containers:
+            self._update_hash_from_quadlet(staging_dir, containers)
+        else:
+            self._update_hashes()
 
         self.module.exit_json(**self.results)
+
+    def _update_hash_from_quadlet(self, staging_dir, containers):
+        """Read staged Quadlet .container files, compute config hashes
+        from Volume= lines, and write hashes into the
+        '# config_hash=' comment line in each file.
+
+        :param staging_dir: path to the staging directory
+        :param containers: list of container names to process
+        """
+        hashes = {}
+
+        # edpm_ prefix matches the systemd unit naming convention
+        # used by quadlet.yml when rendering templates.
+        for name in containers:
+            file_path = os.path.join(
+                staging_dir, 'edpm_' + name + '.container')
+
+            if not os.path.exists(file_path):
+                self.module.fail_json(
+                    msg='Quadlet staging file not found: {}'.format(
+                        file_path))
+
+            content = self._slurp(file_path)
+
+            if not re.search(
+                    r'^# config_hash=',
+                    content, re.MULTILINE):
+                self.module.fail_json(
+                    msg='No config_hash placeholder in: {}'.format(
+                        file_path))
+
+            volume_lines = re.findall(
+                r'^Volume=(.+)$', content, re.MULTILINE)
+            prefix = self.config_vol_prefix
+            config_bases = set()
+            for v in volume_lines:
+                host_path = v.split(":")[0]
+                if host_path.startswith(prefix):
+                    config_bases.add(
+                        self._get_config_base(prefix, host_path))
+
+            if config_bases:
+                checksums = [
+                    self._calculate_checksum(vol_path)
+                    for vol_path in sorted(config_bases)
+                ]
+                new_hash = '-'.join(checksums)
+            else:
+                new_hash = ''
+
+            content = re.sub(
+                r'^(# config_hash=).*$',
+                r'\g<1>' + new_hash,
+                content,
+                flags=re.MULTILINE)
+
+            with open(file_path, 'w') as f:
+                f.write(content)
+
+            hashes[name] = new_hash
+
+        self.results['hashes'] = hashes
 
     def _remove_file(self, path):
         """Remove a file.

--- a/roles/edpm_container_standalone/README.md
+++ b/roles/edpm_container_standalone/README.md
@@ -11,7 +11,90 @@ The `edpm_container_standalone` role provides a unified interface for deploying 
 
 **Key Concept:** Services are defined at the playbook level, not the role level. When a playbook deploys multiple roles, they can all be tracked under a single service name for unified lifecycle management.
 
-## Basic Usage
+## Deployment Methods
+
+The role supports two container deployment methods, selected via the `edpm_container_standalone_use_quadlet` flag:
+
+- **`false` (default):** Uses `edpm_container_manage` with JSON container definitions — the traditional EDPM approach.
+- **`true`:** Uses Podman Quadlet with native `.container` unit files managed by systemd.
+
+Services can be migrated from `container_manage` to Quadlet one at a time. Both methods share the same state tracking, kolla config, and service lifecycle features.
+
+## Quadlet Deployment
+
+### Deploying a Service with Quadlet
+
+```yaml
+- name: Deploy my service via Quadlet
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_container_standalone
+  vars:
+    edpm_container_standalone_use_quadlet: true
+    edpm_container_standalone_service: myservice
+    edpm_container_standalone_quadlet_defs:
+      myservice: "/path/to/myservice.container.j2"
+    edpm_container_standalone_kolla_config_files:
+      myservice:
+        command: /usr/bin/myservice-server
+        config_files:
+          - source: /var/lib/kolla/config_files/myservice.conf
+            dest: /etc/myservice/myservice.conf
+            owner: myservice
+            perm: "0600"
+```
+
+This will:
+1. Create kolla configuration files in `/var/lib/kolla/config_files/`
+2. Render the Quadlet template to a staging file in `/var/lib/edpm-config/quadlet-rendered/`
+3. Compute a config hash from `Volume=` lines in the staged file and inject it into the `EDPM_CONFIG_HASH=` placeholder
+4. Copy the staged file to `/etc/containers/systemd/edpm_myservice.container` (only if content differs)
+5. Reload systemd and start/restart the service as needed
+6. Register the service in the state file
+
+### Quadlet Template Format
+
+Each service provides a Jinja2 template for its `.container` unit file:
+
+```ini
+[Unit]
+Description=myservice container
+
+[Container]
+ContainerName=myservice
+Image={{ edpm_myservice_image }}
+Network=host
+Exec=/usr/bin/myservice-server
+Environment=KOLLA_CONFIG_STRATEGY=COPY_ALWAYS
+# config_hash=
+Volume=/var/lib/openstack/config/myservice:/var/lib/kolla/config_files/src:ro
+Label=managed_by=edpm_ansible
+
+[Service]
+Restart=always
+TimeoutStartSec=900
+TimeoutStopSec=84
+
+[Install]
+WantedBy=multi-user.target
+```
+
+The `# config_hash=` comment placeholder is filled in after template rendering. The hash module reads `Volume=` lines from the staged file, computes a SHA-256 hash from config files under `/var/lib/openstack/`, and writes the hash into the placeholder. The final `.container` file is only updated when the content (including hash) actually changes, providing automatic config change detection with no separate volume variable needed.
+
+### Quadlet Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `edpm_container_standalone_use_quadlet` | `false` | Enable Quadlet deployment path |
+| `edpm_container_standalone_quadlet_dir` | `/etc/containers/systemd` | Directory for `.container` unit files |
+| `edpm_container_standalone_quadlet_staging_dir` | `/var/lib/edpm-config/quadlet-rendered` | Staging directory for rendered templates |
+| `edpm_container_standalone_quadlet_defs` | `{}` | Dict mapping container names to template paths |
+
+### Idempotency
+
+The Quadlet path is idempotent: if neither the template nor the config files change, re-running the role produces no restarts. The template is rendered to a staging directory, the config hash is injected, then the result is copied to the final `.container` file only if content differs.
+
+<!-- TODO(quadlet-migration): Remove this section once all services are migrated to Quadlet. -->
+## Container Manage Deployment (Default)
 
 ### Deploying a Simple Service
 

--- a/roles/edpm_container_standalone/defaults/main.yml
+++ b/roles/edpm_container_standalone/defaults/main.yml
@@ -23,6 +23,7 @@
 edpm_container_standalone_service: ""
 # Directory for kolla config files
 edpm_container_kolla_config_dir: /var/lib/kolla/config_files
+# TODO(quadlet-migration): Remove startup_config_dir and container_defs once all services are migrated.
 # Directory for container startup configs
 edpm_container_startup_config_dir: /var/lib/edpm-config/container-startup-config
 # Hash with keys of container name and value of YAML kolla config file.
@@ -64,6 +65,19 @@ edpm_container_standalone_volumes: "{{
   }}"
 
 edpm_deploy_identifier: ''
+
+# Quadlet support
+# TODO(quadlet-migration): Remove use_quadlet flag once all services are migrated.
+# When true, uses Podman Quadlet (.container files) instead of
+# edpm_container_manage. Can be enabled per-service for incremental migration.
+edpm_container_standalone_use_quadlet: false
+# Directory where Quadlet .container files are written
+edpm_container_standalone_quadlet_dir: /etc/containers/systemd
+# Staging directory for rendered templates before hash injection
+edpm_container_standalone_quadlet_staging_dir: /var/lib/edpm-config/quadlet-rendered
+# Dict mapping container name to Jinja2 template path for its .container file.
+# Each service role provides its own templates.
+edpm_container_standalone_quadlet_defs: {}
 
 # State file tracking
 edpm_container_track_state: true

--- a/roles/edpm_container_standalone/meta/argument_specs.yml
+++ b/roles/edpm_container_standalone/meta/argument_specs.yml
@@ -16,6 +16,7 @@ argument_specs:
           - /dev/log:/dev/log
         description: List of volumes in a mount point format.
         type: list
+      # TODO(quadlet-migration): Remove container_defs and startup_config_dir once all services are migrated.
       edpm_container_standalone_container_defs:
         default: {}
         description: Parsed container definitions.
@@ -92,3 +93,25 @@ argument_specs:
           If true, remove the container from the state file instead of adding/updating.
           Used when a container needs to be removed from state tracking.
         type: bool
+      # TODO(quadlet-migration): Remove use_quadlet once all services are migrated.
+      edpm_container_standalone_use_quadlet:
+        default: false
+        description: |
+          When true, deploy containers using Podman Quadlet (.container files)
+          instead of edpm_container_manage. Can be enabled per-service to
+          incrementally migrate services to Quadlet.
+        type: bool
+      edpm_container_standalone_quadlet_dir:
+        default: /etc/containers/systemd
+        description: Directory where Quadlet .container unit files are written.
+        type: path
+      edpm_container_standalone_quadlet_staging_dir:
+        default: /var/lib/edpm-config/quadlet-rendered
+        description: Staging directory for rendered templates before hash injection and deployment.
+        type: path
+      edpm_container_standalone_quadlet_defs:
+        default: {}
+        description: |
+          Dict mapping container name to Jinja2 template path for its
+          Quadlet .container file. Each service role provides its own templates.
+        type: dict

--- a/roles/edpm_container_standalone/molecule/quadlet/collections.yml
+++ b/roles/edpm_container_standalone/molecule/quadlet/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+- name: community.general

--- a/roles/edpm_container_standalone/molecule/quadlet/converge.yml
+++ b/roles/edpm_container_standalone/molecule/quadlet/converge.yml
@@ -1,0 +1,212 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Test Quadlet container deployment
+  hosts: all
+  gather_facts: false
+  pre_tasks:
+    - name: Gather user fact
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - "user"
+
+    - name: Set basic user fact
+      ansible.builtin.set_fact:
+        ansible_user: "{{ ansible_user_id | default(lookup('env', 'USER')) }}"
+      when:
+        - ansible_user is undefined
+
+  tasks:
+    - name: Deploy test_service via Quadlet
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_container_standalone
+      vars:
+        edpm_container_standalone_use_quadlet: true
+        edpm_container_standalone_service: test_service
+        edpm_container_standalone_quadlet_defs:
+          test_service: "{{ playbook_dir }}/templates/test_service.container.j2"
+        edpm_container_standalone_kolla_config_files:
+          test_service:
+            command: 'sleep 3600'
+
+  post_tasks:
+    - name: Verify Quadlet .container file was created
+      become: true
+      ansible.builtin.stat:
+        path: /etc/containers/systemd/edpm_test_service.container
+      register: _quadlet_file
+
+    - name: Assert Quadlet file exists
+      ansible.builtin.assert:
+        that:
+          - _quadlet_file.stat.exists
+        fail_msg: "Quadlet .container file was not created"
+
+    - name: Read Quadlet file content
+      become: true
+      ansible.builtin.slurp:
+        src: /etc/containers/systemd/edpm_test_service.container
+      register: _quadlet_content
+
+    - name: Decode Quadlet file content
+      ansible.builtin.set_fact:
+        _quadlet_text: "{{ _quadlet_content.content | b64decode }}"
+
+    - name: Verify Quadlet file structure
+      ansible.builtin.assert:
+        that:
+          - "'[Container]' in _quadlet_text"
+          - "'ContainerName=test_service' in _quadlet_text"
+          - "'Image=quay.io/centos/centos:stream9' in _quadlet_text"
+          - "'Network=host' in _quadlet_text"
+          - "'Exec=sleep 3600' in _quadlet_text"
+          - "'PodmanArgs=--privileged' in _quadlet_text"
+          - "'[Service]' in _quadlet_text"
+          - "'Restart=always' in _quadlet_text"
+          - "'[Install]' in _quadlet_text"
+          - "'WantedBy=multi-user.target' in _quadlet_text"
+          - "'Label=managed_by=edpm_ansible' in _quadlet_text"
+        fail_msg: "Quadlet file content is incorrect"
+
+    - name: Verify config_hash is populated
+      ansible.builtin.assert:
+        that:
+          - "_quadlet_text is regex('# config_hash=.+')"
+        fail_msg: "config_hash was not injected into Quadlet file"
+
+    - name: Check edpm_test_service systemd service is active
+      become: true
+      ansible.builtin.command: systemctl is-active --quiet edpm_test_service
+      register: _service_active
+
+    - name: Assert systemd service is active
+      ansible.builtin.assert:
+        that:
+          - _service_active.rc == 0
+        fail_msg: "edpm_test_service systemd service is not active"
+
+    - name: Check test_service container exists
+      become: true
+      ansible.builtin.command: podman container exists test_service
+
+    - name: Verify kolla config file deployed
+      become: true
+      ansible.builtin.stat:
+        path: /var/lib/kolla/config_files/test_service.json
+      register: _kolla_config
+
+    - name: Assert kolla config exists
+      ansible.builtin.assert:
+        that:
+          - _kolla_config.stat.exists
+        fail_msg: "Kolla config JSON was not deployed"
+
+    - name: Verify state file tracking
+      block:
+        - name: Read deployed services state file
+          ansible.builtin.slurp:
+            src: /var/lib/edpm-config/deployed_services.yaml
+          register: _state_file
+
+        - name: Parse state data
+          ansible.builtin.set_fact:
+            _state_data: "{{ _state_file.content | b64decode | from_yaml }}"
+
+        - name: Assert service is tracked in state file
+          ansible.builtin.assert:
+            that:
+              - "'test_service' in _state_data.services"
+              - "'test_service' in _state_data.services.test_service.containers"
+            fail_msg: "Service not tracked in state file"
+
+- name: Test Quadlet idempotency
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Get container ID before re-run
+      become: true
+      ansible.builtin.command: podman inspect --format '{{ '{{' }}.Id{{ '}}' }}' test_service
+      register: _container_id_before
+
+    - name: Re-run test_service deployment (no config change)
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_container_standalone
+      vars:
+        edpm_container_standalone_use_quadlet: true
+        edpm_container_standalone_service: test_service
+        edpm_container_standalone_quadlet_defs:
+          test_service: "{{ playbook_dir }}/templates/test_service.container.j2"
+        edpm_container_standalone_kolla_config_files:
+          test_service:
+            command: 'sleep 3600'
+
+  post_tasks:
+    - name: Get container ID after re-run
+      become: true
+      ansible.builtin.command: podman inspect --format '{{ '{{' }}.Id{{ '}}' }}' test_service
+      register: _container_id_after
+
+    - name: Assert container was NOT recreated (idempotency)
+      ansible.builtin.assert:
+        that:
+          - _container_id_before.stdout == _container_id_after.stdout
+        fail_msg: "Container was recreated when nothing changed"
+
+- name: Test Quadlet container restart on config change
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Get container ID before config change
+      become: true
+      ansible.builtin.command: podman inspect --format '{{ '{{' }}.Id{{ '}}' }}' test_service
+      register: _container_id_before_change
+
+    - name: Re-deploy with changed template
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_container_standalone
+      vars:
+        edpm_container_standalone_use_quadlet: true
+        edpm_container_standalone_service: test_service
+        edpm_container_standalone_quadlet_defs:
+          test_service: "{{ playbook_dir }}/templates/test_service_updated.container.j2"
+        edpm_container_standalone_kolla_config_files:
+          test_service:
+            command: 'sleep 7200'
+
+  post_tasks:
+    - name: Get container ID after config change
+      become: true
+      ansible.builtin.command: podman inspect --format '{{ '{{' }}.Id{{ '}}' }}' test_service
+      register: _container_id_after_change
+
+    - name: Assert container was recreated after config change
+      ansible.builtin.assert:
+        that:
+          - _container_id_before_change.stdout != _container_id_after_change.stdout
+        fail_msg: "Container was NOT recreated after config change"
+
+    - name: Check service is still active after restart
+      become: true
+      ansible.builtin.command: systemctl is-active --quiet edpm_test_service
+      register: _service_active_after
+
+    - name: Assert service is active after restart
+      ansible.builtin.assert:
+        that:
+          - _service_active_after.rc == 0
+        fail_msg: "Service is not active after restart"

--- a/roles/edpm_container_standalone/molecule/quadlet/molecule.yml
+++ b/roles/edpm_container_standalone/molecule/quadlet/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_container_standalone/molecule/quadlet/prepare.yml
+++ b/roles/edpm_container_standalone/molecule/quadlet/prepare.yml
@@ -1,0 +1,42 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+- name: Prepare test_deps
+  hosts: all
+  gather_facts: false
+  roles:
+    - role: ../../../../molecule/common/test_deps
+      test_deps_extra_packages:
+        - podman
+      test_deps_setup_edpm: true
+      test_deps_setup_stream: true
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  become: true
+  roles:
+    - role: osp.edpm.env_data
+  tasks:
+    - name: Create test config directory for hash computation
+      ansible.builtin.file:
+        path: /var/lib/openstack/configs/test_service
+        state: directory
+        mode: "0755"
+
+    - name: Create test config file for hash computation
+      ansible.builtin.copy:
+        content: "test_config_value=1"
+        dest: /var/lib/openstack/configs/test_service/test.conf
+        mode: "0644"

--- a/roles/edpm_container_standalone/molecule/quadlet/templates/test_service.container.j2
+++ b/roles/edpm_container_standalone/molecule/quadlet/templates/test_service.container.j2
@@ -1,0 +1,25 @@
+# DO NOT REMOVE - used by container_config_hash module #
+# config_hash=
+
+[Unit]
+Description=test_service container
+
+[Container]
+ContainerName=test_service
+Image=quay.io/centos/centos:stream9
+Network=host
+User=root
+PodmanArgs=--privileged
+LogDriver=journald
+Exec=sleep 3600
+Environment=KOLLA_CONFIG_STRATEGY=COPY_ALWAYS
+Volume=/var/lib/openstack/configs/test_service/test.conf:/etc/test_service/test.conf:ro,z
+Label=managed_by=edpm_ansible
+
+[Service]
+Restart=always
+TimeoutStartSec=900
+TimeoutStopSec=84
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/edpm_container_standalone/molecule/quadlet/templates/test_service_updated.container.j2
+++ b/roles/edpm_container_standalone/molecule/quadlet/templates/test_service_updated.container.j2
@@ -1,0 +1,25 @@
+# DO NOT REMOVE - used by container_config_hash module
+# config_hash=
+
+[Unit]
+Description=test_service container
+
+[Container]
+ContainerName=test_service
+Image=quay.io/centos/centos:stream9
+Network=host
+User=root
+PodmanArgs=--privileged
+LogDriver=journald
+Exec=sleep 7200
+Environment=KOLLA_CONFIG_STRATEGY=COPY_ALWAYS
+Volume=/var/lib/openstack/configs/test_service/test.conf:/etc/test_service/test.conf:ro,z
+Label=managed_by=edpm_ansible
+
+[Service]
+Restart=always
+TimeoutStartSec=900
+TimeoutStopSec=84
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/edpm_container_standalone/tasks/main.yml
+++ b/roles/edpm_container_standalone/tasks/main.yml
@@ -43,32 +43,40 @@
     mode: "0600"
   loop: "{{ edpm_container_standalone_kolla_config_files | dict2items }}"
 
-- name: "Create config file {{ edpm_container_startup_config_dir + '/' + edpm_container_standalone_service }}"
-  ansible.builtin.file:
-    path: "{{ edpm_container_startup_config_dir }}/{{ edpm_container_standalone_service }}"
-    state: directory
-    mode: "0755"
+# TODO(quadlet-migration): Remove the when: guard once all services are migrated.
+- name: "Deploy containers via Quadlet: [ {{ edpm_container_standalone_service }} ]"
+  ansible.builtin.include_tasks: quadlet.yml
+  when: edpm_container_standalone_use_quadlet | bool
 
-- name: "Render container definitions: [{{ edpm_container_standalone_service }} ]"
-  ansible.builtin.copy:
-    content: "{{ item.value | to_nice_json }}"
-    dest: "{{ edpm_container_startup_config_dir }}/{{ edpm_container_standalone_service }}/{{ item.key }}.json"
-    mode: "0644"
-  # NOTE(tkajinam): Some containers can contain secrets in their environments.
-  #                 Hide the output to avoid dumping these to output.
-  no_log: true
-  loop: "{{ edpm_container_standalone_container_defs | dict2items }}"
+# TODO(quadlet-migration): Remove this entire block once all services are migrated.
+- name: "Deploy containers via edpm_container_manage: [ {{ edpm_container_standalone_service }} ]"
+  when: not (edpm_container_standalone_use_quadlet | bool)
+  block:
+    - name: "Create config dir {{ edpm_container_startup_config_dir + '/' + edpm_container_standalone_service }}"
+      ansible.builtin.file:
+        path: "{{ edpm_container_startup_config_dir }}/{{ edpm_container_standalone_service }}"
+        state: directory
+        mode: "0755"
 
-- name: "Run containers: [ {{ edpm_container_standalone_service }} ]"
-  ansible.builtin.include_role:
-    name: edpm_container_manage
-  vars:
-    edpm_container_manage_config: "{{ edpm_container_startup_config_dir }}/{{ edpm_container_standalone_service }}"
-    edpm_container_manage_config_patterns: "*.json"
-    edpm_container_manage_config_id: "{{ edpm_container_standalone_service }}"
-    edpm_container_manage_containers: "{{ edpm_container_standalone_container_defs.keys() | list }}"
-    # Disable deprecated orphan cleanup - use edpm_cleanup role instead
-    edpm_container_manage_clean_orphans: false
+    - name: "Render container definitions: [{{ edpm_container_standalone_service }} ]"
+      ansible.builtin.copy:
+        content: "{{ item.value | to_nice_json }}"
+        dest: "{{ edpm_container_startup_config_dir }}/{{ edpm_container_standalone_service }}/{{ item.key }}.json"
+        mode: "0644"
+      # NOTE(tkajinam): Some containers can contain secrets in their environments. Hide the output to avoid dumping these to output.
+      no_log: true
+      loop: "{{ edpm_container_standalone_container_defs | dict2items }}"
+
+    - name: "Run containers: [ {{ edpm_container_standalone_service }} ]"
+      ansible.builtin.include_role:
+        name: edpm_container_manage
+      vars:
+        edpm_container_manage_config: "{{ edpm_container_startup_config_dir }}/{{ edpm_container_standalone_service }}"
+        edpm_container_manage_config_patterns: "*.json"
+        edpm_container_manage_config_id: "{{ edpm_container_standalone_service }}"
+        edpm_container_manage_containers: "{{ edpm_container_standalone_container_defs.keys() | list }}"
+        # Disable deprecated orphan cleanup - use edpm_cleanup role instead
+        edpm_container_manage_clean_orphans: false
 
 - name: Update service state file
   ansible.builtin.include_tasks: state_file_update.yml

--- a/roles/edpm_container_standalone/tasks/quadlet.yml
+++ b/roles/edpm_container_standalone/tasks/quadlet.yml
@@ -1,0 +1,89 @@
+---
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Quadlet-based container deployment using staged file hash injection.
+# Flow: render template to staging dir -> inject config hash -> copy to final (if changed) -> restart
+# The template is the single source of truth for Volume= lines. The hash module
+# reads them from the staged file, so no separate variable is needed.
+
+- name: Ensure quadlet directory exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ edpm_container_standalone_quadlet_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Ensure quadlet staging directory exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ edpm_container_standalone_quadlet_staging_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: "Render Quadlet templates for {{ edpm_container_standalone_service }}"
+  become: true
+  ansible.builtin.template:
+    src: "{{ item.value }}"
+    dest: "{{ edpm_container_standalone_quadlet_staging_dir }}/edpm_{{ item.key }}.container"
+    mode: "0644"
+  loop: "{{ edpm_container_standalone_quadlet_defs | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: "Compute and inject config hashes for {{ edpm_container_standalone_service }}"
+  become: true
+  container_config_hash:
+    quadlet_staging_dir: "{{ edpm_container_standalone_quadlet_staging_dir }}"
+    containers: "{{ edpm_container_standalone_quadlet_defs.keys() | list }}"
+
+- name: "Deploy Quadlet .container files for {{ edpm_container_standalone_service }}"
+  become: true
+  ansible.builtin.copy:
+    src: "{{ edpm_container_standalone_quadlet_staging_dir }}/edpm_{{ item.key }}.container"
+    dest: "{{ edpm_container_standalone_quadlet_dir }}/edpm_{{ item.key }}.container"
+    remote_src: true
+    mode: "0644"
+  loop: "{{ edpm_container_standalone_quadlet_defs | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  register: _edpm_quadlet_files
+
+- name: Identify changed containers
+  ansible.builtin.set_fact:
+    _edpm_changed_containers: >-
+      {{ _edpm_quadlet_files.results
+         | selectattr('changed')
+         | map(attribute='item.key')
+         | list }}
+
+- name: Reload systemd daemon for quadlet generator
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: _edpm_changed_containers | length > 0  # noqa: no-handler
+
+- name: "Restart changed Quadlet containers for {{ edpm_container_standalone_service }}"
+  become: true
+  ansible.builtin.systemd:
+    name: "edpm_{{ item }}.service"
+    state: restarted
+  loop: "{{ _edpm_changed_containers }}"
+  loop_control:
+    label: "{{ item }}"
+  register: _edpm_quadlet_svc
+  retries: 5
+  delay: 5
+  until: _edpm_quadlet_svc is not failed

--- a/roles/edpm_container_standalone/tasks/state_file_update.yml
+++ b/roles/edpm_container_standalone/tasks/state_file_update.yml
@@ -101,6 +101,16 @@
               services: "{{ _edpm_filtered_services | default({}) }}"
 
 # Add/update service in state file
+# TODO(quadlet-migration): Once all services are migrated to quadlet,
+# replace the ternary with: edpm_container_standalone_quadlet_defs.keys() | list
+- name: Determine container names from definitions
+  ansible.builtin.set_fact:
+    _edpm_container_names: >-
+      {{ (edpm_container_standalone_quadlet_defs
+          if edpm_container_standalone_use_quadlet | bool
+          else edpm_container_standalone_container_defs).keys() | list }}
+  when: not (edpm_container_state_remove | bool)
+
 - name: Update service in state data
   ansible.builtin.set_fact:
     _edpm_state_data: >-
@@ -108,10 +118,12 @@
         _edpm_state_data | combine({
           'services': _edpm_state_data.services | combine({
             _edpm_state_service_name: {
-              'containers': (
-                _edpm_state_data.services.get(_edpm_state_service_name, {}).get('containers', []) +
-                edpm_container_standalone_container_defs.keys() | list
-              ) if edpm_container_state_append else (edpm_container_standalone_container_defs.keys() | list),
+              'containers':
+                (_edpm_state_data.services.get(
+                  _edpm_state_service_name, {}).get('containers', []) +
+                  _edpm_container_names
+                ) if edpm_container_state_append
+                else _edpm_container_names,
               'updated_at': lookup('pipe', 'date -Iseconds')
             }
           }, recursive=True)


### PR DESCRIPTION
Reworked the standalone role to use only Quadlet for container deployment, removing the old container_manage path. It now detects config and certificate changes by computing a hash before rendering templates, so containers restart only when something actually changed. Added automatic cleanup of leftover artifacts from the old deployment method and molecule tests covering the full lifecycle - deploy, idempotency, config-change restart, and cleanup.

Jira: [OSPRH-30094](https://redhat.atlassian.net/browse/OSPRH-30094)
Jira: [OSPRH-30963](https://redhat.atlassian.net/browse/OSPRH-30963)
