### PR TITLE
[Neutron OVN] Add BGP interconnect bridge OVS external-id for the ovn-bgp extension

### DIFF
--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -66,3 +66,7 @@ edpm_neutron_ovn_agent_ovn_ovn_sb_connection: ''
 # BGP peer bridges for the ovn-bgp extension.
 # Set this variable when the ovn-agent is configured with the ovn-bgp extension.
 edpm_neutron_ovn_agent_bgp_peer_bridges: ''
+
+# BGP interconnect bridge for the ovn-bgp extension.
+# Set this variable when the ovn-agent is configured with the ovn-bgp extension.
+edpm_neutron_ovn_agent_bgp_interconnect_bridge: "{{ neutron_physical_bridge_name | default('br-ex') }}"

--- a/roles/edpm_neutron_ovn/meta/argument_specs.yml
+++ b/roles/edpm_neutron_ovn/meta/argument_specs.yml
@@ -109,3 +109,11 @@ argument_specs:
           Each bridge connects the OVN overlay from the corresponding EDPM node with a BGP peering switch (leaf, ToR, ...).
           Set this variable when the ovn-agent is configured with the ovn-bgp extension.
         type: str
+      edpm_neutron_ovn_agent_bgp_interconnect_bridge:
+        default: "{{ neutron_physical_bridge_name | default('br-ex') }}"
+        description: >
+          BGP interconnect bridge required for the ovn-bgp extension.
+          This bridge connects the OVN overlay with the BGP fabric on the EDPM node.
+          Defaults to neutron_physical_bridge_name (br-ex if unset).
+          Set this variable when the ovn-agent is configured with the ovn-bgp extension.
+        type: str

--- a/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/collections.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/converge.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/converge.yml
@@ -1,0 +1,30 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - ansible.builtin.include_role:
+        name: "osp.edpm.edpm_neutron_ovn"
+      vars:
+        tenant_ip: "{{ ansible_host }}"
+        edpm_ovn_dbs:
+          - "{{ ansible_host }}"
+        edpm_neutron_ovn_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"
+        edpm_neutron_ovn_agent_bgp_peer_bridges: "br-peer1"
+        edpm_neutron_ovn_agent_bgp_interconnect_bridge: "br-custom"

--- a/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/molecule.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/molecule.yml
@@ -1,0 +1,1 @@
+../bgp_disabled/molecule.yml

--- a/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/prepare.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/test-data
+++ b/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/test-data
@@ -1,0 +1,1 @@
+../default/test-data

--- a/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/verify.yml
@@ -1,0 +1,16 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Verify neutron-bgp-peer-bridges
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open_vswitch . external_ids:neutron-bgp-peer-bridges
+      register: output
+      failed_when: output.stdout != 'br-peer1'
+
+    - name: Verify neutron-bgp-interconnect-bridge override
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open_vswitch . external_ids:neutron-bgp-interconnect-bridge
+      register: output
+      failed_when: output.stdout != 'br-custom'

--- a/roles/edpm_neutron_ovn/molecule/bgp_disabled/collections.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_disabled/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_neutron_ovn/molecule/bgp_disabled/converge.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_disabled/converge.yml
@@ -1,0 +1,28 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - ansible.builtin.include_role:
+        name: "osp.edpm.edpm_neutron_ovn"
+      vars:
+        tenant_ip: "{{ ansible_host }}"
+        edpm_ovn_dbs:
+          - "{{ ansible_host }}"
+        edpm_neutron_ovn_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"

--- a/roles/edpm_neutron_ovn/molecule/bgp_disabled/molecule.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_disabled/molecule.yml
@@ -1,0 +1,37 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: collections.yml
+driver:
+  name: podman
+platforms:
+- command: /sbin/init
+  dockerfile: ../../../../molecule/common/Containerfile.j2
+  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
+  name: instance
+  privileged: true
+  registry:
+    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
+  ulimits:
+  - host
+provisioner:
+  log: true
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          instance:
+            canonical_hostname: edpm-0.localdomain
+scenario:
+  test_sequence:
+  - dependency
+  - destroy
+  - create
+  - prepare
+  - converge
+  - verify
+  - destroy
+verifier:
+  name: ansible

--- a/roles/edpm_neutron_ovn/molecule/bgp_disabled/prepare.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_disabled/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/roles/edpm_neutron_ovn/molecule/bgp_disabled/test-data
+++ b/roles/edpm_neutron_ovn/molecule/bgp_disabled/test-data
@@ -1,0 +1,1 @@
+../default/test-data

--- a/roles/edpm_neutron_ovn/molecule/bgp_disabled/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_disabled/verify.yml
@@ -1,0 +1,16 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Check neutron-bgp-peer-bridges is not set
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl --if-exists get open_vswitch . external_ids:neutron-bgp-peer-bridges
+      register: output
+      failed_when: output.stdout != ''
+
+    - name: Check neutron-bgp-interconnect-bridge is not set
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl --if-exists get open_vswitch . external_ids:neutron-bgp-interconnect-bridge
+      register: output
+      failed_when: output.stdout != ''

--- a/roles/edpm_neutron_ovn/molecule/bgp_enabled/collections.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_enabled/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_neutron_ovn/molecule/bgp_enabled/converge.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_enabled/converge.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - ansible.builtin.include_role:
+        name: "osp.edpm.edpm_neutron_ovn"
+      vars:
+        tenant_ip: "{{ ansible_host }}"
+        edpm_ovn_dbs:
+          - "{{ ansible_host }}"
+        edpm_neutron_ovn_config_src: "{{lookup('env', 'MOLECULE_SCENARIO_DIRECTORY')}}/test-data"
+        edpm_neutron_ovn_agent_bgp_peer_bridges: "br-peer1,br-peer2"

--- a/roles/edpm_neutron_ovn/molecule/bgp_enabled/molecule.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_enabled/molecule.yml
@@ -1,0 +1,1 @@
+../bgp_disabled/molecule.yml

--- a/roles/edpm_neutron_ovn/molecule/bgp_enabled/prepare.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_enabled/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/roles/edpm_neutron_ovn/molecule/bgp_enabled/test-data
+++ b/roles/edpm_neutron_ovn/molecule/bgp_enabled/test-data
@@ -1,0 +1,1 @@
+../default/test-data

--- a/roles/edpm_neutron_ovn/molecule/bgp_enabled/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_enabled/verify.yml
@@ -1,0 +1,16 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Verify neutron-bgp-peer-bridges
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open_vswitch . external_ids:neutron-bgp-peer-bridges
+      register: output
+      failed_when: output.stdout != '"br-peer1,br-peer2"'
+
+    - name: Verify neutron-bgp-interconnect-bridge defaults to br-ex
+      ansible.builtin.shell: >
+        /usr/bin/ovs-vsctl get open_vswitch . external_ids:neutron-bgp-interconnect-bridge
+      register: output
+      failed_when: output.stdout != 'br-ex'

--- a/roles/edpm_neutron_ovn/tasks/configure.yml
+++ b/roles/edpm_neutron_ovn/tasks/configure.yml
@@ -54,13 +54,17 @@
         mode: "0644"
       loop: "{{ edpm_neutron_ovn_secrets.files }}"
 
-    # Configure BGP peer bridges in OVS when the ovn-agent is configured
+    # Configure BGP external-ids in OVS when the ovn-agent is configured
     # with the ovn-bgp extension.
-    - name: Set neutron-bgp-peer-bridges in OVS external-ids
+    - name: Set neutron-bgp external-ids in OVS
       become: true
       ansible.builtin.command:
         cmd: >-
           ovs-vsctl --no-wait -- set Open_vSwitch .
           external-ids:neutron-bgp-peer-bridges={{ edpm_neutron_ovn_agent_bgp_peer_bridges }}
+          external-ids:neutron-bgp-interconnect-bridge={{ edpm_neutron_ovn_agent_bgp_interconnect_bridge }}
+      # edpm_neutron_ovn_agent_bgp_interconnect_bridge has a non-empty default, but
+      # edpm_neutron_ovn_agent_bgp_peer_bridges is empty by default and should only be
+      # set when BGP is enabled, so it is used as the gate for this task.
       when: edpm_neutron_ovn_agent_bgp_peer_bridges != ''
       changed_when: true


### PR DESCRIPTION
## Summary

- Add `edpm_neutron_ovn_agent_bgp_interconnect_bridge` variable to configure the `neutron-bgp-interconnect-bridge` external-id in OVS when the ovn-agent uses the ovn-bgp extension.
- Defaults to `neutron_physical_bridge_name` (falls back to `br-ex` if unset).
- Both `neutron-bgp-peer-bridges` and `neutron-bgp-interconnect-bridge` are set together in a single `ovs-vsctl` call, gated on `edpm_neutron_ovn_agent_bgp_peer_bridges` being non-empty (which signals BGP is enabled).

Equivalent of https://review.opendev.org/c/openstack/devstack/+/988977

## Test plan

- [x] Deploy with `edpm_neutron_ovn_agent_bgp_peer_bridges` unset — verify the `ovs-vsctl` task is skipped. (molecule scenario: `bgp_disabled`)
- [x] Deploy with `edpm_neutron_ovn_agent_bgp_peer_bridges` set — verify both `neutron-bgp-peer-bridges` and `neutron-bgp-interconnect-bridge` are set in OVS external-ids (`ovs-vsctl list Open_vSwitch`). (molecule scenario: `bgp_enabled`)
- [x] Verify `edpm_neutron_ovn_agent_bgp_interconnect_bridge` can be overridden independently of `neutron_physical_bridge_name`. (molecule scenario: `bgp_custom_interconnect_bridge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)