### PR TITLE
Use prometheus-podman-exporter image from oko quay

### DIFF
--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -25,7 +25,7 @@ edpm_telemetry_config_dest: "/var/lib/openstack/{{ edpm_telemetry_service_name }
 # Image to use for node_exporter
 edpm_telemetry_node_exporter_image: quay.io/prometheus/node-exporter:v1.5.0
 # Image to use for podman_exporter
-edpm_telemetry_podman_exporter_image: quay.io/navidys/prometheus-podman-exporter:v1.10.1
+edpm_telemetry_podman_exporter_image: quay.io/openstack-k8s-operators/prometheus-podman-exporter:latest
 # Image to use for Ceilometer
 edpm_telemetry_ceilometer_compute_image: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
 # Image to use for openstack_network_exporter


### PR DESCRIPTION
Now that we have a workflow setup to automatically build prometheus-podman-exporter latest image whenever there is new content in openstack-k8s-operators/prometheus-podman-exporter main branch. We can consume those images by default instead of relating on upstream images, which may have slightly different content.

Related PRs:
https://github.com/openstack-k8s-operators/openstack-operator/pull/1925
https://github.com/openstack-k8s-operators/telemetry-operator/pull/900

Closes: https://redhat.atlassian.net/browse/OSPRH-29306