### PR TITLE
Add edpm_instanceha_monitoring role for heartbeat sender

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -29,6 +29,7 @@ jobs:
         - edpm_derive_pci_device_spec
         - edpm_download_cache
         - edpm_growvols
+        - edpm_instanceha_monitoring
         - edpm_network_config
         - edpm_neutron_dhcp
         - edpm_neutron_metadata

--- a/playbooks/instanceha_monitoring.yml
+++ b/playbooks/instanceha_monitoring.yml
@@ -1,0 +1,28 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Deploy EDPM InstanceHA Monitoring
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  gather_facts: false
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  environment: "{{ edpm_playbook_environment | default({}) }}"
+  tasks:
+    - name: Deploy InstanceHA monitoring
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_instanceha_monitoring
+      tags:
+        - edpm_instanceha_monitoring

--- a/roles/edpm_instanceha_monitoring/defaults/main.yml
+++ b/roles/edpm_instanceha_monitoring/defaults/main.yml
@@ -1,0 +1,38 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of
+# "edpm_instanceha_monitoring"
+
+# Whether to enable the heartbeat sender on compute nodes.
+# When enabled, compute nodes send periodic UDP heartbeat packets to the
+# instanceha pod. This allows instanceha to distinguish host OS failure
+# from nova-compute process crash and avoid unnecessary fencing.
+edpm_instanceha_monitoring_heartbeat_enabled: false
+
+# IP address of the instanceha pod on the heartbeat network.
+# Required when heartbeat_enabled is true.
+# This is typically the instanceha pod's IP from a network-attachment-definition.
+edpm_instanceha_monitoring_heartbeat_ip: ""
+
+# UDP port for heartbeat packets (must match instanceha's HEARTBEAT_PORT).
+edpm_instanceha_monitoring_heartbeat_port: 7411
+
+# Interval in seconds between heartbeat sends.
+edpm_instanceha_monitoring_heartbeat_interval: 30

--- a/roles/edpm_instanceha_monitoring/handlers/main.yml
+++ b/roles/edpm_instanceha_monitoring/handlers/main.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Reload systemd daemon
+  become: true
+  ansible.builtin.systemd_service:
+    daemon_reload: true

--- a/roles/edpm_instanceha_monitoring/meta/argument_specs.yml
+++ b/roles/edpm_instanceha_monitoring/meta/argument_specs.yml
@@ -1,0 +1,32 @@
+---
+argument_specs:
+  # ./roles/edpm_instanceha_monitoring/tasks/main.yml entry point
+  main:
+    short_description: The main entry point for the edpm_instanceha_monitoring role.
+    options:
+      edpm_instanceha_monitoring_heartbeat_enabled:
+        type: bool
+        default: false
+        description: >-
+          Whether to enable the heartbeat sender on compute nodes.
+          When enabled, compute nodes send periodic UDP heartbeat packets
+          to the instanceha pod so it can distinguish host OS failure from
+          nova-compute process crash and avoid unnecessary fencing.
+      edpm_instanceha_monitoring_heartbeat_ip:
+        type: str
+        default: ""
+        description: >-
+          IP address of the instanceha pod on the heartbeat network.
+          Required when heartbeat_enabled is true.
+      edpm_instanceha_monitoring_heartbeat_port:
+        type: int
+        default: 7411
+        description: >-
+          UDP port for heartbeat packets. Must match the instanceha
+          pod's HEARTBEAT_PORT configuration.
+      edpm_instanceha_monitoring_heartbeat_interval:
+        type: int
+        default: 30
+        description: >-
+          Interval in seconds between heartbeat sends. The systemd timer
+          adds jitter of up to 1/3 of this value to prevent thundering herd.

--- a/roles/edpm_instanceha_monitoring/meta/main.yml
+++ b/roles/edpm_instanceha_monitoring/meta/main.yml
@@ -1,0 +1,34 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: OpenStack
+  description: EDPM OpenStack Role -- edpm_instanceha_monitoring
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.9'
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - edpm
+
+
+dependencies: []

--- a/roles/edpm_instanceha_monitoring/molecule/default/converge.yml
+++ b/roles/edpm_instanceha_monitoring/molecule/default/converge.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+  vars:
+    edpm_instanceha_monitoring_heartbeat_enabled: true
+    edpm_instanceha_monitoring_heartbeat_ip: "192.168.122.100"
+  tasks:
+    - name: Deploy instanceha heartbeat
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_instanceha_monitoring

--- a/roles/edpm_instanceha_monitoring/molecule/default/molecule.yml
+++ b/roles/edpm_instanceha_monitoring/molecule/default/molecule.yml
@@ -1,0 +1,22 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+platforms:
+  - name: edpm_instanceha_monitoring
+provisioner:
+  log: true
+  name: ansible
+scenario:
+  test_sequence:
+  - destroy
+  - create
+  - converge
+  - verify
+verifier:
+  name: ansible

--- a/roles/edpm_instanceha_monitoring/molecule/default/verify.yml
+++ b/roles/edpm_instanceha_monitoring/molecule/default/verify.yml
@@ -1,0 +1,101 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Check heartbeat script exists
+      become: true
+      ansible.builtin.stat:
+        path: /usr/local/bin/instanceha-heartbeat.py
+      register: heartbeat_script
+
+    - name: Assert heartbeat script is deployed correctly
+      ansible.builtin.assert:
+        that:
+          - heartbeat_script.stat.exists
+          - heartbeat_script.stat.mode == '0755'
+        fail_msg: "Heartbeat script not deployed or wrong permissions"
+
+    - name: Read heartbeat script content
+      become: true
+      ansible.builtin.slurp:
+        src: /usr/local/bin/instanceha-heartbeat.py
+      register: heartbeat_script_content
+
+    - name: Assert heartbeat script has correct content
+      ansible.builtin.assert:
+        that:
+          - "'struct.pack' in heartbeat_script_content.content | b64decode"
+          - "'!I' in heartbeat_script_content.content | b64decode"
+          - "'192.168.122.100' in heartbeat_script_content.content | b64decode"
+          - "'7411' in heartbeat_script_content.content | b64decode"
+        fail_msg: "Heartbeat script content is incorrect"
+
+    - name: Check heartbeat service unit exists
+      become: true
+      ansible.builtin.stat:
+        path: /etc/systemd/system/instanceha-heartbeat.service
+      register: heartbeat_service
+
+    - name: Assert heartbeat service unit is deployed correctly
+      ansible.builtin.assert:
+        that:
+          - heartbeat_service.stat.exists
+          - heartbeat_service.stat.mode == '0644'
+        fail_msg: "Heartbeat service unit not deployed or wrong permissions"
+
+    - name: Read heartbeat service content
+      become: true
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/instanceha-heartbeat.service
+      register: heartbeat_service_content
+
+    - name: Assert heartbeat service has correct content
+      ansible.builtin.assert:
+        that:
+          - "'Type=oneshot' in heartbeat_service_content.content | b64decode"
+          - "'User=nobody' in heartbeat_service_content.content | b64decode"
+          - "'StandardOutput=null' in heartbeat_service_content.content | b64decode"
+        fail_msg: "Heartbeat service content is incorrect"
+
+    - name: Check heartbeat timer unit exists
+      become: true
+      ansible.builtin.stat:
+        path: /etc/systemd/system/instanceha-heartbeat.timer
+      register: heartbeat_timer
+
+    - name: Assert heartbeat timer unit is deployed correctly
+      ansible.builtin.assert:
+        that:
+          - heartbeat_timer.stat.exists
+          - heartbeat_timer.stat.mode == '0644'
+        fail_msg: "Heartbeat timer unit not deployed or wrong permissions"
+
+    - name: Read heartbeat timer content
+      become: true
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/instanceha-heartbeat.timer
+      register: heartbeat_timer_content
+
+    - name: Assert heartbeat timer has correct content
+      ansible.builtin.assert:
+        that:
+          - "'OnBootSec=10s' in heartbeat_timer_content.content | b64decode"
+          - "'OnUnitActiveSec=30s' in heartbeat_timer_content.content | b64decode"
+          - "'RandomizedDelaySec=10s' in heartbeat_timer_content.content | b64decode"
+        fail_msg: "Heartbeat timer content is incorrect"

--- a/roles/edpm_instanceha_monitoring/tasks/configure.yml
+++ b/roles/edpm_instanceha_monitoring/tasks/configure.yml
@@ -1,0 +1,72 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Validate heartbeat IP is configured
+  ansible.builtin.assert:
+    that:
+      - edpm_instanceha_monitoring_heartbeat_ip | length > 0
+      - edpm_instanceha_monitoring_heartbeat_ip | regex_search('^[0-9a-fA-F.:]+$') is not none
+    fail_msg: >-
+      edpm_instanceha_monitoring_heartbeat_ip must be set to a valid IP address
+      when edpm_instanceha_monitoring_heartbeat_enabled is true.
+      Set it to the instanceha pod IP on the heartbeat network.
+
+- name: Validate heartbeat port is valid
+  ansible.builtin.assert:
+    that:
+      - edpm_instanceha_monitoring_heartbeat_port | int > 0
+      - edpm_instanceha_monitoring_heartbeat_port | int <= 65535
+    fail_msg: >-
+      edpm_instanceha_monitoring_heartbeat_port must be an integer
+      between 1 and 65535.
+
+- name: Validate heartbeat interval is valid
+  ansible.builtin.assert:
+    that:
+      - edpm_instanceha_monitoring_heartbeat_interval | int > 0
+    fail_msg: >-
+      edpm_instanceha_monitoring_heartbeat_interval must be a positive integer.
+
+- name: Deploy instanceha heartbeat script
+  become: true
+  ansible.builtin.template:
+    src: instanceha-heartbeat.py.j2
+    dest: /usr/local/bin/instanceha-heartbeat.py
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Deploy instanceha heartbeat service unit
+  become: true
+  ansible.builtin.template:
+    src: instanceha-heartbeat.service.j2
+    dest: /etc/systemd/system/instanceha-heartbeat.service
+    mode: "0644"
+    owner: root
+    group: root
+  notify:
+    - Reload systemd daemon
+
+- name: Deploy instanceha heartbeat timer unit
+  become: true
+  ansible.builtin.template:
+    src: instanceha-heartbeat.timer.j2
+    dest: /etc/systemd/system/instanceha-heartbeat.timer
+    mode: "0644"
+    owner: root
+    group: root
+  notify:
+    - Reload systemd daemon

--- a/roles/edpm_instanceha_monitoring/tasks/main.yml
+++ b/roles/edpm_instanceha_monitoring/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Configure instanceha heartbeat
+  ansible.builtin.include_tasks: configure.yml
+  when: edpm_instanceha_monitoring_heartbeat_enabled | bool
+
+- name: Flush handlers after configure
+  ansible.builtin.meta: flush_handlers
+
+- name: Run instanceha heartbeat
+  ansible.builtin.include_tasks: run.yml
+  when: edpm_instanceha_monitoring_heartbeat_enabled | bool
+
+- name: Disable instanceha heartbeat
+  become: true
+  ansible.builtin.systemd_service:
+    name: instanceha-heartbeat.timer
+    state: stopped
+    enabled: false
+  when: not (edpm_instanceha_monitoring_heartbeat_enabled | bool)
+  failed_when: false

--- a/roles/edpm_instanceha_monitoring/tasks/run.yml
+++ b/roles/edpm_instanceha_monitoring/tasks/run.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Enable and start instanceha heartbeat timer
+  become: true
+  ansible.builtin.systemd_service:
+    name: instanceha-heartbeat.timer
+    state: started
+    enabled: true

--- a/roles/edpm_instanceha_monitoring/templates/instanceha-heartbeat.py.j2
+++ b/roles/edpm_instanceha_monitoring/templates/instanceha-heartbeat.py.j2
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+# {{ ansible_managed }}
+# Sends a UDP heartbeat packet to the instanceha pod.
+# Packet format: 4-byte magic number (network byte order) + UTF-8 hostname.
+import os
+import socket
+import struct
+
+MAGIC = struct.pack('!I', 0x48425631)
+HOSTNAME = os.uname().nodename.split('.')[0].encode('utf-8')
+TARGET = ('{{ edpm_instanceha_monitoring_heartbeat_ip }}',
+          {{ edpm_instanceha_monitoring_heartbeat_port }})
+
+info = socket.getaddrinfo(TARGET[0], TARGET[1], type=socket.SOCK_DGRAM)[0]
+sock = socket.socket(info[0], info[1])
+try:
+    sock.sendto(MAGIC + HOSTNAME, info[4])
+finally:
+    sock.close()

--- a/roles/edpm_instanceha_monitoring/templates/instanceha-heartbeat.service.j2
+++ b/roles/edpm_instanceha_monitoring/templates/instanceha-heartbeat.service.j2
@@ -1,0 +1,12 @@
+# {{ ansible_managed }}
+[Unit]
+Description=InstanceHA heartbeat sender
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=nobody
+Group=nobody
+ExecStart=/usr/local/bin/instanceha-heartbeat.py
+StandardOutput=null
+StandardError=journal

--- a/roles/edpm_instanceha_monitoring/templates/instanceha-heartbeat.timer.j2
+++ b/roles/edpm_instanceha_monitoring/templates/instanceha-heartbeat.timer.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+[Unit]
+Description=InstanceHA heartbeat timer
+
+[Timer]
+OnBootSec=10s
+OnUnitActiveSec={{ edpm_instanceha_monitoring_heartbeat_interval }}s
+RandomizedDelaySec={{ (edpm_instanceha_monitoring_heartbeat_interval | int // 3) }}s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
New role to deploy a systemd timer on compute nodes that sends periodic UDP heartbeat packets to the instanceha pod. This enables dual-channel failure detection: when Nova marks a host down but heartbeats are still arriving, instanceha knows the host OS is alive and skips fencing (likely just a nova-compute process crash or partial network issue).

The role deploys a Python script, systemd service (oneshot), and systemd timer. Gated behind edpm_instanceha_monitoring_heartbeat_enabled (default: false) for opt-in activation.

The timer uses RandomizedDelaySec to add jitter and prevent thundering herd when many compute nodes boot simultaneously, that should also help spreading heartbeats uniformly across the interval.

Tested with:
~~~
  apiVersion: dataplane.openstack.org/v1beta1
  kind: OpenStackDataPlaneService
  metadata:
    name: instanceha-monitoring
  spec:
    playbook: osp.edpm.instanceha_monitoring
~~~
~~~
  spec:
    nodeTemplate:
      ansible:
        ansibleVars:
          edpm_instanceha_monitoring_heartbeat_enabled: true
          edpm_instanceha_monitoring_heartbeat_ip: "<instanceha-pod-IP>"
          edpm_instanceha_monitoring_heartbeat_port: 7411
          edpm_instanceha_monitoring_heartbeat_interval: 30
~~~

~~~
apiVersion: dataplane.openstack.org/v1beta1
kind: OpenStackDataPlaneDeployment
metadata:
  name: iha-hb
  namespace: openstack
spec:
  ansibleEEEnvConfigMapName: openstack-aee-default-env
  backoffLimit: 6
  deploymentRequeueTime: 15
  nodeSets:
  - openstack-edpm
  preserveJobs: true
  servicesOverride:
    - instanceha-monitoring
~~~

setting edpm_instanceha_monitoring_heartbeat_enabled: false and running the deployment removes the timer.