### PR TITLE
Remove unused ceilometer_prom_exporter.yaml from telemetry roles

### DIFF
--- a/roles/edpm_telemetry/files/ceilometer_prom_exporter.yaml
+++ b/roles/edpm_telemetry/files/ceilometer_prom_exporter.yaml
@@ -1,3 +1,0 @@
-tls_server_config:
-    cert_file: /etc/ceilometer/tls/tls.crt
-    key_file: /etc/ceilometer/tls/tls.key

--- a/roles/edpm_telemetry/tasks/configure.yml
+++ b/roles/edpm_telemetry/tasks/configure.yml
@@ -124,7 +124,6 @@
       loop:
         - node_exporter
         - podman_exporter
-        - ceilometer_prom_exporter
       loop_control:
         loop_var: exporter
 

--- a/roles/edpm_telemetry/tasks/update.yml
+++ b/roles/edpm_telemetry/tasks/update.yml
@@ -104,17 +104,11 @@
         ca_bundle_exists: "{{ ca_bundle_stat_res.stat.exists }}"
         tls_cert_exists: "{{ tls_crt_stat.stat.exists and tls_key_stat.stat.exists }}"
 
-- name: Create prometheus exporter configuration
+- name: Remove unused ceilometer_prom_exporter configuration
   become: true
-  block:
-    - name: Create prometheus exporter configuration
-      ansible.builtin.include_tasks:
-        file: exporter_tls.yml
-      vars:
-        exporter: "ceilometer_prom_exporter"
-      when:
-        - tls_crt_stat.stat.exists
-        - tls_key_stat.stat.exists
-      tags:
-        - update
-        - telemetry
+  ansible.builtin.file:
+    path: "{{ edpm_telemetry_config_dest }}/ceilometer_prom_exporter.yaml"
+    state: absent
+  tags:
+    - update
+    - telemetry

--- a/roles/edpm_telemetry/templates/container_defs/ceilometer_agent_compute.yaml.j2
+++ b/roles/edpm_telemetry/templates/container_defs/ceilometer_agent_compute.yaml.j2
@@ -24,7 +24,6 @@ volumes:
   - "{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 {% endif %}
 {% if tls_cert_exists|bool %}
-  - "{{ edpm_telemetry_config_dest }}/ceilometer_prom_exporter.yaml:/etc/ceilometer/ceilometer_prom_exporter.yaml:z"
   - "{{ edpm_telemetry_certs }}:/etc/ceilometer/tls:z"
 {% endif %}
   - /dev/log:/dev/log

--- a/roles/edpm_telemetry_power_monitoring/files/ceilometer_prom_exporter.yaml
+++ b/roles/edpm_telemetry_power_monitoring/files/ceilometer_prom_exporter.yaml
@@ -1,3 +1,0 @@
-tls_server_config:
-    cert_file: /etc/ceilometer/tls/tls.crt
-    key_file: /etc/ceilometer/tls/tls.key

--- a/roles/edpm_telemetry_power_monitoring/tasks/configure.yml
+++ b/roles/edpm_telemetry_power_monitoring/tasks/configure.yml
@@ -110,12 +110,6 @@
   when:
     - tls_crt_stat.stat.exists and tls_key_stat.stat.exists
   block:
-    - name: Copy TLS config for ceilometer_prom_exporter
-      ansible.builtin.copy:
-        src: ceilometer_prom_exporter.yaml
-        dest: "{{ edpm_telemetry_config_dest }}/ceilometer_prom_exporter.yaml"
-        mode: 0644
-
     - name: Change the owner of the crt
       become: true
       ansible.builtin.file:

--- a/roles/edpm_telemetry_power_monitoring/templates/container_defs/ceilometer_agent_ipmi.yaml.j2
+++ b/roles/edpm_telemetry_power_monitoring/templates/container_defs/ceilometer_agent_ipmi.yaml.j2
@@ -24,7 +24,6 @@ volumes:
   - "{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 {% endif %}
 {% if tls_cert_exists|bool %}
-  - "{{ edpm_telemetry_config_dest }}/ceilometer_prom_exporter.yaml:/etc/ceilometer/ceilometer_prom_exporter.yaml:z"
   - "{{ edpm_telemetry_certs }}:/etc/ceilometer/tls:z"
 {% endif %}
   - /dev/log:/dev/log


### PR DESCRIPTION
Ceilometer's built-in Prometheus exporter does not read a web.config.yml-style YAML file. It receives TLS certificate paths programmatically via oslo.config options (prometheus_tls_certfile and prometheus_tls_keyfile in ceilometer.conf). The ceilometer_prom_exporter.yaml file was created by analogy with node_exporter and podman_exporter configs, but was never consumed by ceilometer.

This removes the file from both edpm_telemetry and edpm_telemetry_power_monitoring roles, including the container mount and the copy tasks. The update task is replaced with a cleanup task that removes the file during upgrades from environments where it previously existed. The TLS certificate mounts are preserved as ceilometer still needs them.