### PR TITLE
Split frr configuration to bgp and bgp+evpn

### DIFF
--- a/roles/edpm_frr/defaults/main.yml
+++ b/roles/edpm_frr/defaults/main.yml
@@ -19,6 +19,7 @@
 
 # All variables within this role should have a prefix of "edpm_frr"
 
+edpm_enable_evpn: false
 edpm_frr_bfd: true
 # Configures the detection multiplier to determine packet loss.
 # The remote transmission interval will be multiplied by this

--- a/roles/edpm_frr/meta/argument_specs.yml
+++ b/roles/edpm_frr/meta/argument_specs.yml
@@ -146,6 +146,12 @@ argument_specs:
         default: traditional
         description: ''
         type: str
+      edpm_enable_evpn:
+        default: false
+        description: |
+          When true, load the vrf kernel module and always render the l2vpn evpn
+          address-family in frr.conf.j2.
+        type: bool
       edpm_frr_hostname:
         default: '{{ ansible_facts["hostname"] | default("")}}'
         description: Dynamically retrieved from ansible facts.

--- a/roles/edpm_frr/molecule/evpn_mode/collections.yml
+++ b/roles/edpm_frr/molecule/evpn_mode/collections.yml
@@ -1,0 +1,1 @@
+../default/collections.yml

--- a/roles/edpm_frr/molecule/evpn_mode/converge.yml
+++ b/roles/edpm_frr/molecule/evpn_mode/converge.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2026 Red Hat, LLC
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: false
+  vars:
+    edpm_download_cache_podman_auth_file: "" # Override since the file doesn't exist
+    edpm_enable_evpn: true
+    edpm_frr_bgp_peers:
+      - 10.64.0.1
+      - 10.65.0.1
+  pre_tasks:
+    - name: set basic user fact
+      set_fact:
+        ansible_user: "{{ lookup('env', 'USER') }}"
+      when:
+        - ansible_user is undefined
+  tasks:
+    - name: "Download required role packages"
+      ansible.builtin.include_role:
+        name: "osp.edpm.edpm_frr"
+        tasks_from: "download_cache.yml"
+    - ansible.builtin.include_role:
+        name: "osp.edpm.edpm_frr"
+        apply:
+          become: true

--- a/roles/edpm_frr/molecule/evpn_mode/molecule.yml
+++ b/roles/edpm_frr/molecule/evpn_mode/molecule.yml
@@ -1,0 +1,1 @@
+../default/molecule.yml

--- a/roles/edpm_frr/molecule/evpn_mode/prepare.yml
+++ b/roles/edpm_frr/molecule/evpn_mode/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/roles/edpm_frr/molecule/evpn_mode/verify.yml
+++ b/roles/edpm_frr/molecule/evpn_mode/verify.yml
@@ -1,0 +1,48 @@
+---
+# Copyright 2026 Red Hat, LLC
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- import_playbook: ../default/verify.yml
+
+- name: Verify EVPN mode frr.conf
+  gather_facts: false
+  hosts: compute-1
+  vars:
+    frr_conf_path: /var/lib/openstack/frr/etc/frr/frr.conf
+  tasks:
+    - name: Assert frr.conf contains router bgp stanza
+      become: true
+      ansible.builtin.command: grep -Fq 'router bgp' {{ frr_conf_path }}
+      changed_when: false
+
+    - name: Assert frr.conf contains l2vpn evpn address-family
+      become: true
+      ansible.builtin.command: grep -Fq 'address-family l2vpn evpn' {{ frr_conf_path }}
+      changed_when: false
+
+    - name: Assert frr.conf contains advertise-all-vni
+      become: true
+      ansible.builtin.command: grep -Fq 'advertise-all-vni' {{ frr_conf_path }}
+      changed_when: false
+
+    - name: Verify vrf module will be loaded at boot
+      become: true
+      ansible.builtin.command: grep -q 'vrf' /etc/modules-load.d/vrf.conf
+      changed_when: false
+
+    - name: Verify vrf module is loaded
+      become: true
+      ansible.builtin.command: grep -q '^vrf ' /proc/modules
+      changed_when: false

--- a/roles/edpm_frr/tasks/configure.yml
+++ b/roles/edpm_frr/tasks/configure.yml
@@ -14,42 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Identify the real interfaces via os-net-config
-  become: true
-  ansible.builtin.command: os-net-config -i
-  register: os_net_config_result
-  changed_when: os_net_config_result.rc == 0
-  failed_when: os_net_config_result.rc != 0
-
-- name: Os-net-config from json
-  ansible.builtin.set_fact:
-    iface_map: "{{ os_net_config_result.stdout }}"
-
-
-- name: Assert either edpm_frr_bgp_peers or edpm_frr_bgp_uplinks configured
-  ansible.builtin.assert:
-    that:
-      - edpm_frr_bgp_uplinks | length > 0 or edpm_frr_bgp_peers | length > 0
-
-- name: FRR uplink interfaces
-  # if edpm_frr_bgp_peers are defined, edpm_frr_bgp_uplinks are not used to create frr.conf.j2
-  when:
-    - edpm_frr_bgp_uplinks | length > 0
-    - not edpm_frr_bgp_peers | length > 0
-  block:
-    - name: Construct FRR uplink interfaces from os-net-config mappings
-      ansible.builtin.set_fact:
-        edpm_frr_bgp_uplinks_mapped: "{{ edpm_frr_bgp_uplinks | map('extract', iface_map) | list }}"
-      register: check_edpm_frr_bgp_uplinks_mapped
-      ignore_errors: true
-
-    - name: Failed to construct FRR uplink interfaces
-      ansible.builtin.fail:
-        msg: |
-          Failed to map at least one interface from {{ edpm_frr_bgp_uplinks }} to {{ iface_map }}.
-          Please check value of Ansible variable edpm_frr_bgp_uplinks.
-      when: check_edpm_frr_bgp_uplinks_mapped is failed
-
 - name: Gather facts if they don't exist
   when: "'system' not in ansible_facts"
   ansible.builtin.setup:
@@ -58,14 +22,8 @@
       - "!min"
       - "system"
 
-- name: Configure FRR
-  ansible.builtin.template:
-    src: config/frr.conf.j2
-    dest: "{{ edpm_frr_config_basedir }}/etc/frr/frr.conf"
-    mode: '0644'
-    selevel: s0
-    setype: container_file_t
-  register: _frr_config_result
+- name: Configure FRR for BGP underlay
+  ansible.builtin.include_tasks: configure_bgp.yml
 
 - name: Configure FRR daemons
   ansible.builtin.template:

--- a/roles/edpm_frr/tasks/configure_bgp.yml
+++ b/roles/edpm_frr/tasks/configure_bgp.yml
@@ -1,0 +1,60 @@
+---
+# Copyright 2026 Red Hat, LLC
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Identify the real interfaces via os-net-config
+  become: true
+  ansible.builtin.command: os-net-config -i
+  register: os_net_config_result
+  changed_when: os_net_config_result.rc == 0
+  failed_when: os_net_config_result.rc != 0
+
+- name: Os-net-config from json
+  ansible.builtin.set_fact:
+    iface_map: "{{ os_net_config_result.stdout }}"
+
+
+- name: Assert either edpm_frr_bgp_peers or edpm_frr_bgp_uplinks configured
+  ansible.builtin.assert:
+    that:
+      - edpm_frr_bgp_uplinks | length > 0 or edpm_frr_bgp_peers | length > 0
+
+- name: FRR uplink interfaces
+  # if edpm_frr_bgp_peers are defined, edpm_frr_bgp_uplinks are not used to create frr.conf.j2
+  when:
+    - edpm_frr_bgp_uplinks | length > 0
+    - not edpm_frr_bgp_peers | length > 0
+  block:
+    - name: Construct FRR uplink interfaces from os-net-config mappings
+      ansible.builtin.set_fact:
+        edpm_frr_bgp_uplinks_mapped: "{{ edpm_frr_bgp_uplinks | map('extract', iface_map) | list }}"
+      register: check_edpm_frr_bgp_uplinks_mapped
+      ignore_errors: true
+
+    - name: Failed to construct FRR uplink interfaces
+      ansible.builtin.fail:
+        msg: |
+          Failed to map at least one interface from {{ edpm_frr_bgp_uplinks }} to {{ iface_map }}.
+          Please check value of Ansible variable edpm_frr_bgp_uplinks.
+      when: check_edpm_frr_bgp_uplinks_mapped is failed
+
+- name: Configure FRR
+  ansible.builtin.template:
+    src: config/frr.conf.j2
+    dest: "{{ edpm_frr_config_basedir }}/etc/frr/frr.conf"
+    mode: '0644'
+    selevel: s0
+    setype: container_file_t
+  register: _frr_config_result

--- a/roles/edpm_frr/tasks/install.yml
+++ b/roles/edpm_frr/tasks/install.yml
@@ -53,6 +53,14 @@
       - "!min"
       - "selinux"
 
+- name: Load VRF kernel module for EVPN mode
+  when: edpm_enable_evpn | bool
+  ansible.builtin.import_role:
+    name: osp.edpm.edpm_module_load
+  vars:
+    modules:
+      - name: vrf
+
 - name: Create directory {{ edpm_frr_config_basedir }}
   become: true
   ansible.builtin.file:

--- a/roles/edpm_frr/templates/config/frr.conf.j2
+++ b/roles/edpm_frr/templates/config/frr.conf.j2
@@ -148,7 +148,7 @@ router bgp {{ edpm_frr_bgp_asn }}
   exit-address-family
 {% endif %}
 
-{% if edpm_frr_bgp_l2vpn %}
+{% if edpm_frr_bgp_l2vpn or edpm_enable_evpn|bool %}
   address-family l2vpn evpn
 {% if edpm_frr_bgp_l2vpn_uplink_activate|bool %}
     neighbor uplink activate


### PR DESCRIPTION
Neutron is introducing a new frr driver which will configure frr dynamically at runtime.

This patch introduces new variable called `edpm_frr_evpn_mode` which when set will configure frr with minum configuration. Rest will be handled at runtime by the frr driver

JIRA: [OSPRH-29356](https://redhat.atlassian.net/browse/OSPRH-29356)