### PR TITLE
Add edpm_leapp_upgrade role for RHEL in-place OS upgrades

### DIFF
--- a/playbooks/leapp_upgrade.yml
+++ b/playbooks/leapp_upgrade.yml
@@ -1,0 +1,21 @@
+---
+- name: Upgrade OS to next Major version (leapp)
+  hosts: "{{ edpm_override_hosts | default('all', true) }}"
+  strategy: linear
+  gather_facts: "{{ gather_facts | default(false) }}"
+  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+  environment: "{{ edpm_playbook_environment | default({}) }}"
+  tasks:
+    - name: Gather ansible_local facts
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - "local"
+
+    - name: Import leapp upgrade role
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_leapp_upgrade
+      tags:
+        - edpm_leapp_upgrade

--- a/roles/edpm_leapp_upgrade/README.md
+++ b/roles/edpm_leapp_upgrade/README.md
@@ -1,0 +1,114 @@
+# edpm_leapp_upgrade role
+
+## Overview
+
+The `edpm_leapp_upgrade` role performs an in-place OS upgrade from RHEL 9 to RHEL 10
+on EDPM nodes using the [Leapp](https://leapp-project.github.io/) framework.
+
+The role is split into three sequential phases, each with a dedicated Ansible tag:
+
+| Phase | Tag | Description |
+|---|---|---|
+| Prepare | `leapp_prepare` | Runs init commands and installs prerequisite packages and the leapp tool |
+| Pre-validation | `leapp_validate` | Checks OS version and network configuration readiness |
+| Run | `leapp_run` | Executes the upgrade and stages a reboot marker |
+
+## Requirements
+
+- RHEL 9 (any minor version)
+- Network connections must be managed by **nmstate/NetworkManager**. Legacy `ifcfg` files must be migrated before the upgrade runs
+
+## Basic Usage
+
+```yaml
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: leapp-upgrade
+spec:
+  backoffLimit: 1
+  deploymentRequeueTime: 15
+  nodeSets:
+  - openstack-edpm
+  preserveJobs: true
+  servicesOverride:
+  - leapp-upgrade
+  env:
+    - name: RUNNER_IDLE_TIMEOUT
+      value: "3600"
+  ansibleLimit: compute-xxxxx-0
+  ansibleExtraVars:
+    edpm_leapp_upgrade_repo_init_command: |
+      dnf copr -y enable @oamg/leapp
+    edpm_leapp_upgrade_init_command: |
+      nmcli conn migrate
+```
+
+```bash
+oc apply -f leapp-upgrade.yml
+```
+
+## Variables
+
+### `defaults/main.yml`
+
+| Variable | Default | Description |
+|---|---|---|
+| `edpm_leapp_upgrade_debug` | `true` | Pass `--debug` to the `leapp upgrade` command |
+| `edpm_leapp_upgrade_packages` | `"leapp-upgrade"` | Leapp package(s) to install |
+| `edpm_leapp_upgrade_repo_init_command` | `""` | Command to run for initialising the leapp upgrade repository (empty = skip) |
+| `edpm_leapp_upgrade_init_command` | `""` | Command to run pre leapp (empty = skip) |
+
+### Required Variables
+
+## Tags
+
+Run only selected phases by passing `--tags`:
+
+```bash
+# Validate only
+ansible-playbook upgrade.yml --tags leapp_validate
+
+# Prepare only (install packages)
+ansible-playbook upgrade.yml --tags leapp_prepare
+
+# Run the upgrade (downloads packages and stages reboot)
+ansible-playbook upgrade.yml --tags leapp_run
+```
+
+## What Each Phase Does
+
+### Prepare (`leapp_prepare`)
+
+Runs any configured init commands, enables the target-OS repositories, and
+installs the prerequisite and `leapp-upgrade` packages. See the
+[Variables](#variables) section for how to customize repos, commands, and
+package pinning.
+
+### Pre-validation (`leapp_validate`)
+
+Confirms the node is actually eligible for the upgrade and fails fast with
+a descriptive error.
+
+### Run (`leapp_run`)
+
+Executes `leapp upgrade` to download the target-OS packages and prepare the initramfs, then stages a
+reboot marker for the orchestration layer.
+
+> **Note:** The role itself does **not** reboot the node. The reboot marker is read by the EDPM orchestration layer, which schedules the reboot at a controlled point in the upgrade workflow.
+
+## Example: Pre-migration Network Check
+
+Before running this role, migrate any `ifcfg` connections to nmstate. You can check for legacy connections with:
+
+```bash
+nmcli -f name,uuid,filename connection show | grep sysconfig
+```
+
+If any connections are listed, migrate them:
+
+```bash
+# Example: migrate a connection named "eth0"
+nmcli connection migrate
+```

--- a/roles/edpm_leapp_upgrade/defaults/main.yml
+++ b/roles/edpm_leapp_upgrade/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of "edpm_leapp_upgrade"
+
+# Enable debug output for leapp upgrade process
+edpm_leapp_upgrade_debug: true
+
+# List of leapp packages to install
+edpm_leapp_upgrade_packages: "leapp-upgrade"
+
+# Command(s) to run for initialising the leapp upgrade repository (empty = skip)
+# Supports multiline strings where each line is executed as a separate command.
+edpm_leapp_upgrade_repo_init_command: ""
+
+# Command(s) to run pre leapp (empty = skip)
+# Supports multiline strings where each line is executed as a separate command.
+edpm_leapp_upgrade_init_command: ""

--- a/roles/edpm_leapp_upgrade/meta/argument_specs.yml
+++ b/roles/edpm_leapp_upgrade/meta/argument_specs.yml
@@ -1,0 +1,52 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+argument_specs:
+  main:
+    short_description: Perform Leapp-based OS upgrade on EDP nodes
+    description:
+      - This role performs an OS upgrade using the Leapp tool on EDP (EDPM) nodes.
+      - It handles the full upgrade lifecycle including preparation, execution,
+        reboot, and post-upgrade tasks.
+    version_added: 0.0.1
+    options:
+      edpm_leapp_upgrade_debug:
+        description:
+          - Enable debug output for leapp upgrade process.
+        type: bool
+        default: true
+      edpm_leapp_upgrade_packages:
+        description:
+          - Space-separated list of leapp packages to install.
+          - When left at the default, the newest available build is always installed.
+          - Set to a specific glob (e.g. "leapp-upgrade-*.pr1565.*") to pin an
+            exact build; pinned builds are installed as-is and not upgraded.
+        type: str
+        default: "leapp-upgrade"
+      edpm_leapp_upgrade_repo_init_command:
+        description:
+          - Command(s) to run for initialising the leapp upgrade repository.
+          - Supports multiline strings where each line is executed as a separate command.
+          - When empty, the init step is skipped.
+        type: str
+        default: ""
+      edpm_leapp_upgrade_init_command:
+        description:
+          - Command(s) to run before the leapp upgrade.
+          - Supports multiline strings where each line is executed as a separate command.
+          - When empty, the init step is skipped.
+        type: str
+        default: ""

--- a/roles/edpm_leapp_upgrade/meta/main.yml
+++ b/roles/edpm_leapp_upgrade/meta/main.yml
@@ -1,0 +1,34 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+galaxy_info:
+  author: "OpenStack"
+  description: "Perform Leapp-based OS upgrade on EDPM nodes"
+  company: "Red Hat"
+  license: "Apache-2.0"
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions:
+        - "9"
+        - "10"
+  galaxy_tags:
+    - edpm
+    - leapp
+    - upgrade
+    - openstack
+
+dependencies: []

--- a/roles/edpm_leapp_upgrade/tasks/main.yml
+++ b/roles/edpm_leapp_upgrade/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# ============================================================================
+# Leapp OS Upgrade - Main Task
+# ============================================================================
+
+- name: Include leapp upgrade prepare tasks
+  ansible.builtin.include_tasks:
+    file: prepare.yml
+    apply:
+      tags:
+        - leapp_prepare
+
+- name: Validate leapp upgrade prerequisites
+  ansible.builtin.include_tasks:
+    file: pre-validate.yml
+    apply:
+      tags:
+        - leapp_validate
+
+- name: Include leapp upgrade run tasks (reboot)
+  ansible.builtin.include_tasks:
+    file: run.yml
+    apply:
+      tags:
+        - leapp_run

--- a/roles/edpm_leapp_upgrade/tasks/pre-validate.yml
+++ b/roles/edpm_leapp_upgrade/tasks/pre-validate.yml
@@ -1,0 +1,63 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# ============================================================================
+# Leapp OS Upgrade - Pre leapp upgrade Validate Phase
+# ============================================================================
+
+- name: Gather distribution fact if needed
+  when:
+    - "'distribution' not in ansible_facts"
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - "!min"
+      - "distribution"
+  tags:
+    - always
+
+- name: Validate leapp upgrade prerequisites
+  ansible.builtin.assert:
+    that:
+      - ansible_facts.distribution == 'RedHat'
+      # TODO: FIXME:
+      #  * we should check for 9.6+
+      #  * validation should check for predictable nic naming
+      #  * validation needs to check if ifcfg was migrated to nmstate
+      #  * validations should go to separate include task
+      - ansible_facts.distribution_major_version is version('9', '==')
+    fail_msg: >
+      Leapp upgrade is only supported on RHEL 9 systems when enabled.
+      Current distribution: {{ ansible_facts.distribution }},
+      Major version: {{ ansible_facts.distribution_major_version }}
+
+- name: Validate ifcfg connections were migrated to nmstate
+  block:
+    - name: Get NetworkManager connection list
+      ansible.builtin.command: nmcli -f name,uuid,filename connection show
+      register: _nmcli_connections
+      changed_when: false
+
+    - name: Debug nmcli connections
+      ansible.builtin.debug:
+        var: _nmcli_connections.stdout_lines
+
+    - name: Assert no sysconfig connections remain
+      ansible.builtin.assert:
+        that:
+          - _nmcli_connections.stdout_lines | select('search', 'sysconfig') | list | length == 0
+        fail_msg: >
+          ifcfg was not migrated to nmstate. Please migrate ifcfg to nmstate before running leapp upgrade.

--- a/roles/edpm_leapp_upgrade/tasks/prepare.yml
+++ b/roles/edpm_leapp_upgrade/tasks/prepare.yml
@@ -1,0 +1,49 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# ============================================================================
+# Leapp OS Upgrade - Prepare Phase
+# ============================================================================
+
+- name: Run leapp repo init commands
+  become: true
+  ansible.builtin.shell:
+    cmd: "{{ item }}"
+  changed_when: true
+  loop: "{{ _leapp_repo_init_command.splitlines() | select() | list }}"
+  when:
+    - _leapp_repo_init_command is string
+    - _leapp_repo_init_command | length > 0
+
+- name: Run leapp init commands
+  become: true
+  ansible.builtin.shell:
+    cmd: "{{ item }}"
+  changed_when: true
+  loop: "{{ _leapp_init_command.splitlines() | select() | list }}"
+  when:
+    - _leapp_init_command is string
+    - _leapp_init_command | length > 0
+
+- name: Debug _leapp_packages
+  ansible.builtin.debug:
+    msg: "{{ _leapp_packages }}"
+
+- name: Install leapp-upgrade 
+  become: true
+  ansible.builtin.dnf:
+    name: "{{ _leapp_packages }}"
+    state: present 

--- a/roles/edpm_leapp_upgrade/tasks/run.yml
+++ b/roles/edpm_leapp_upgrade/tasks/run.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# ============================================================================
+# Leapp OS Upgrade - Run Phase (system_upgrade_run)
+# ============================================================================
+
+- name: Run leapp upgrade (download packages)
+  become: true
+  ansible.builtin.shell: >
+    leapp upgrade
+    {% if _leapp_debug | default(false) %}--debug{% endif %}
+  changed_when: true
+
+- name: Stage reboot marker for leapp upgrade
+  become: true
+  block:
+    - name: Create reboot_required directory
+      ansible.builtin.file:
+        path: /var/lib/openstack/reboot_required/
+        state: directory
+        mode: "0755"
+
+    - name: Create leapp_upgrade marker file
+      ansible.builtin.file:
+        path: /var/lib/openstack/reboot_required/leapp_upgrade
+        state: touch
+        mode: "0600"

--- a/roles/edpm_leapp_upgrade/vars/main.yml
+++ b/roles/edpm_leapp_upgrade/vars/main.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+_leapp_debug: "{{ edpm_leapp_upgrade_debug }}"
+_leapp_repo_init_command: "{{ edpm_leapp_upgrade_repo_init_command }}"
+_leapp_init_command: "{{ edpm_leapp_upgrade_init_command }}"
+_leapp_packages: "{{ edpm_leapp_upgrade_packages }}"


### PR DESCRIPTION
Introduces the edpm_leapp_upgrade role and accompanying playbook to drive leapp-based major-version upgrades of RHEL on EDPM nodes.

The role is structured in three phases:
- pre-validate: asserts RHEL 9, checks that ifcfg connections have been migrated to nmstate before proceeding
- prepare: runs an optional repo-init command, installs prerequisite packages, and installs leapp-upgrade
- run: executes `leapp upgrade` (optional --debug flag) and stages a reboot sentinel file at /var/lib/openstack/reboot_required/leapp_upgrade so the EDPM reboot workflow can detect and complete the upgrade
- Adds playbooks/leapp_upgrade.yml to be able to run leapp-upgrade role