### PR TITLE
Move molecule tests to run in zuul.

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -33,7 +33,6 @@ jobs:
         - edpm_network_config
         - edpm_neutron_dhcp
         - edpm_neutron_metadata
-        - edpm_neutron_ovn
         - edpm_neutron_sriov
         - edpm_nftables
         - edpm_nodes_validation

--- a/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_custom_interconnect_bridge/verify.yml
@@ -2,6 +2,7 @@
 - name: Verify
   hosts: all
   gather_facts: false
+  become: true
   tasks:
     - name: Verify neutron-bgp-peer-bridges
       ansible.builtin.shell: >

--- a/roles/edpm_neutron_ovn/molecule/bgp_disabled/molecule.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_disabled/molecule.yml
@@ -4,26 +4,25 @@ dependency:
   options:
     role-file: collections.yml
 driver:
-  name: podman
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
 platforms:
-- command: /sbin/init
-  dockerfile: ../../../../molecule/common/Containerfile.j2
-  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
-  name: instance
-  privileged: true
-  registry:
-    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
-  ulimits:
-  - host
+  - name: compute-1
+    groups:
+      - compute
 provisioner:
   log: true
   name: ansible
+  playbooks:
+    cleanup: ../common/cleanup.yml
   inventory:
-    hosts:
-      all:
-        hosts:
-          instance:
-            canonical_hostname: edpm-0.localdomain
+    host_vars:
+      compute-1:
+        ctlplane_ip: "10.0.0.1"
+        canonical_hostname: edpm-0.localdomain
 scenario:
   test_sequence:
   - dependency
@@ -32,6 +31,7 @@ scenario:
   - prepare
   - converge
   - verify
+  - cleanup
   - destroy
 verifier:
   name: ansible

--- a/roles/edpm_neutron_ovn/molecule/bgp_disabled/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_disabled/verify.yml
@@ -2,6 +2,7 @@
 - name: Verify
   hosts: all
   gather_facts: false
+  become: true
   tasks:
     - name: Check neutron-bgp-peer-bridges is not set
       ansible.builtin.shell: >

--- a/roles/edpm_neutron_ovn/molecule/bgp_enabled/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/bgp_enabled/verify.yml
@@ -2,6 +2,7 @@
 - name: Verify
   hosts: all
   gather_facts: false
+  become: true
   tasks:
     - name: Verify neutron-bgp-peer-bridges
       ansible.builtin.shell: >

--- a/roles/edpm_neutron_ovn/molecule/common/cleanup.yml
+++ b/roles/edpm_neutron_ovn/molecule/common/cleanup.yml
@@ -1,0 +1,50 @@
+---
+# Copyright 2026 Red Hat, LLC.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleanup after edpm_neutron_ovn molecule scenario
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Stop ovn_agent systemd service
+      ansible.builtin.systemd:
+        name: edpm_ovn_agent.service
+        state: stopped
+      failed_when: false
+
+    - name: Remove ovn_agent container
+      ansible.builtin.command:
+        cmd: /usr/bin/podman rm -f ovn_agent
+      register: _edpm_neutron_ovn_cleanup_ovn_agent
+      changed_when: _edpm_neutron_ovn_cleanup_ovn_agent.rc == 0
+      failed_when: false
+
+    - name: Remove neutron-haproxy sidecar containers
+      ansible.builtin.shell: |
+        set -o pipefail
+        /usr/bin/podman ps -a --filter name=neutron-haproxy- --format '{{ '{{' }}.ID{{ '}}' }}' |
+          xargs -r /usr/bin/podman rm -f
+      changed_when: false
+      failed_when: false
+
+    - name: Clear BGP and EVPN external IDs from Open_vSwitch
+      ansible.builtin.command:
+        cmd: >-
+          ovs-vsctl --if-exists remove Open_vSwitch . external_ids
+          neutron-bgp-peer-bridges
+          neutron-bgp-interconnect-bridge
+      changed_when: false
+      failed_when: false

--- a/roles/edpm_neutron_ovn/molecule/default/molecule.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/molecule.yml
@@ -4,26 +4,28 @@ dependency:
   options:
     role-file: collections.yml
 driver:
-  name: podman
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
 platforms:
-- command: /sbin/init
-  dockerfile: ../../../../molecule/common/Containerfile.j2
-  image: ${EDPM_ANSIBLE_MOLECULE_IMAGE:-"ubi9/ubi-init"}
-  name: instance
-  privileged: true
-  registry:
-    url: ${EDPM_ANSIBLE_MOLECULE_REGISTRY:-"registry.access.redhat.com"}
-  ulimits:
-  - host
+  - name: compute-1
+    groups:
+      - compute
 provisioner:
   log: true
   name: ansible
+  playbooks:
+    cleanup: ../common/cleanup.yml
   inventory:
-    hosts:
-      all:
-        hosts:
-          instance:
-            canonical_hostname: edpm-0.localdomain
+    host_vars:
+      compute-1:
+        ctlplane_ip: "10.0.0.1"
+        canonical_hostname: edpm-0.localdomain
+        # Containers and config under /var/lib/ are managed as root via
+        # systemd; testinfra must escalate to inspect podman and host files.
+        ansible_become: true
 scenario:
   test_sequence:
   - dependency
@@ -32,6 +34,7 @@ scenario:
   - prepare
   - converge
   - verify
+  - cleanup
   - destroy
 verifier:
   name: testinfra

--- a/roles/edpm_neutron_ovn/molecule/default/prepare.yml
+++ b/roles/edpm_neutron_ovn/molecule/default/prepare.yml
@@ -24,19 +24,42 @@
         - openvswitch
         - iproute
         - podman
+
 - name: Prepare
   hosts: all
   gather_facts: false
+  vars:
+    edpm_download_cache_podman_auth_file: ""
   tasks:
     - ansible.builtin.include_role:
         name: osp.edpm.env_data
 
-    # The openvswitch kernel module needs to be loaded on the host
-    - name: install and modprobe openvswitch
-      shell: |
-        sudo dnf -y install openvswitch
-        sudo modprobe openvswitch
-      delegate_to: localhost
-      run_once: true
+    - name: Install and modprobe openvswitch
+      ansible.builtin.shell: |
+        set -eux
+        dnf -y install openvswitch
+        modprobe openvswitch
+      become: true
+      changed_when: true
 
-  post_tasks: []
+    - name: Force systemd to reread configs
+      ansible.builtin.systemd:
+        daemon_reload: true
+      become: true
+
+    - name: Download required role packages
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_bootstrap
+        tasks_from: download_cache.yml
+
+    - name: Include edpm_bootstrap
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_bootstrap
+        tasks_from: bootstrap.yml
+      become: true
+
+    - name: Download edpm_neutron_ovn container images
+      ansible.builtin.import_role:
+        name: osp.edpm.edpm_neutron_ovn
+        tasks_from: download_cache.yml
+      become: true

--- a/roles/edpm_neutron_ovn/molecule/default/tests/test_neutron_ovn.py
+++ b/roles/edpm_neutron_ovn/molecule/default/tests/test_neutron_ovn.py
@@ -64,7 +64,7 @@ class TestNeutronOvn(unittest.TestCase):
 
     def setUp(self):
         self.host = testinfra.get_host(
-            "ansible://instance?ansible_inventory=%s" %
+            "ansible://compute-1?ansible_inventory=%s" %
             os.environ['MOLECULE_INVENTORY_FILE'])
 
     def tearDown(self):

--- a/scripts/test_roles.py
+++ b/scripts/test_roles.py
@@ -19,6 +19,7 @@ SKIP_LIST = [
     "edpm_frr",
     "edpm_kernel",
     "edpm_ovn_bgp_agent",
+    "edpm_neutron_ovn",
     "test_deps",
 ]
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -97,6 +97,13 @@
     vars:
       TEST_RUN: edpm_ovn_bgp_agent
 - job:
+    name: edpm-ansible-molecule-edpm_neutron_ovn
+    parent: edpm-ansible-molecule-base
+    files:
+     - ^roles/edpm_neutron_ovn/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    vars:
+      TEST_RUN: edpm_neutron_ovn
+- job:
     name: edpm-ansible-molecule-edpm_ovs
     parent: edpm-ansible-molecule-base
     files:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -21,6 +21,7 @@
         - edpm-ansible-molecule-edpm_iscsid
         - edpm-ansible-molecule-edpm_multipathd
         - edpm-ansible-molecule-edpm_ovn_bgp_agent
+        - edpm-ansible-molecule-edpm_neutron_ovn
         - edpm-ansible-molecule-edpm_ovs
         - edpm-ansible-molecule-edpm_tripleo_cleanup
         - edpm-ansible-molecule-edpm_tuned


### PR DESCRIPTION
When working on [PR1189](https://github.com/openstack-k8s-operators/edpm-ansible/pull/1189) I discovered I will need to move molecule tests to run in zuul. This is because the new tests need to install rhel kernel modules and enable frr. 
This PR is strict move of existing tests, no new tests were added. The later PRs will rebase on top of this one. 