### PR TITLE
EDPM nmstate tool support

### DIFF
--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -27,9 +27,6 @@
 #   directly to configure networking on hosts. Refer to nmstate.io for configuration snippets.
 edpm_network_config_tool: os-net-config
 
-# Must be set to true to allow usage of nmstate as edpm_network_config_tool
-edpm_network_config_tool_nmstate_override: false
-
 # Packages needed by nmstate (via system-role)
 edpm_network_config_systemrole_nmstate_dependencies:
   - NetworkManager-ovs

--- a/roles/edpm_network_config/molecule/nmstate/converge.yml
+++ b/roles/edpm_network_config/molecule/nmstate/converge.yml
@@ -20,7 +20,6 @@
   vars:
     # edpm_network_config - nmstate
     edpm_network_config_tool: 'nmstate'
-    edpm_network_config_tool_nmstate_override: true
     edpm_network_config_template: |
       ---
       interfaces:

--- a/roles/edpm_network_config/tasks/nmstate_tool.yml
+++ b/roles/edpm_network_config/tasks/nmstate_tool.yml
@@ -17,14 +17,6 @@
 # Network configuration using nmstate as the primary tool (via linux-system-roles)
 # This is for edpm_network_config_tool: 'nmstate' (not os-net-config with nmstate provider)
 
-- name: Fail when edpm_network_config_tool=nmstate unless override is set
-  ansible.builtin.fail:
-    msg: |
-      edpm_network_config_tool=nmstate is experimental and not supported.
-      Set edpm_network_config_tool_nmstate_override=true to continue anyway.
-  when:
-    - not edpm_network_config_tool_nmstate_override|bool
-
 - name: Configure NetworkManager for nmstate
   ansible.builtin.include_tasks: nm_config.yml
   vars:


### PR DESCRIPTION
This change is to provide EDPM deployment based on nmstate tool without providing override variables and avoid failures if nmstate tool is used.