### PR TITLE
Add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "github>openstack-k8s-operators/renovate-config:default.json5"
+  ],
+  "baseBranchPatterns": [
+    "main"
+  ],
+  "enabledManagers": ["github-actions"]
+}


### PR DESCRIPTION
Enable Renovate to manage GitHub Actions dependencies. Only the github-actions manager is enabled.