### PR TITLE
edpm_telemetry: add node_exporter_extra_args var

### DIFF
--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -75,3 +75,7 @@ edpm_telemetry_openstack_network_exporter_collectors:
 # Supported levels are: debug info notice warning error critical
 # Default: info
 edpm_telemetry_openstack_network_exporter_log_level: info
+# Extra CLI flags passed verbatim to node_exporter (list of strings).
+# Use to disable collectors that generate spurious errors on hardware that
+# does not support them
+edpm_telemetry_node_exporter_extra_args: []

--- a/roles/edpm_telemetry/templates/container_defs/node_exporter.yaml.j2
+++ b/roles/edpm_telemetry/templates/container_defs/node_exporter.yaml.j2
@@ -26,6 +26,9 @@ command:
   - --no-collector.powersupplyclass
   - --no-collector.pressure
   - --no-collector.rapl
+{% for arg in edpm_telemetry_node_exporter_extra_args %}
+  - {{ arg }}
+{% endfor %}
   - --path.rootfs=/rootfs
 net: host
 environment:


### PR DESCRIPTION
Introduce edpm_telemetry_node_exporter_extra_args (default: []) and wire it into the node_exporter container definition template, allowing operators to pass extra flags to node_exporter on a per-nodeset basis.

This may be needed to disable collectors that fail on hardware not fully supported by node_exporter (e.g. on hosts with NVLink CX7 InfiniBand adapters that reject ETHTOOL and IB counter reads with EINVAL).

Resolves: [OSPRH-32325](https://redhat.atlassian.net/browse/OSPRH-32325)
Generated-by: claude-4.6-opus-high