### PR TITLE
Make /run/frr volume mount conditional on ovn-evpn extension

### DIFF
--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -24,7 +24,11 @@ edpm_neutron_ovn_common_volumes:
   - "{{ edpm_neutron_ovn_agent_lib_dir }}:/var/lib/neutron:shared,z"
   - "{{ edpm_neutron_ovn_agent_lib_dir }}/ovn_agent_haproxy_wrapper:/usr/local/bin/haproxy:ro"
   - "{{ edpm_neutron_ovn_agent_lib_dir }}/kill_scripts:/etc/neutron/kill_scripts:ro"
-  - /run/frr:/run/frr:shared,z
+
+edpm_neutron_ovn_frr_volumes: >-
+  {{ ['/run/frr:/run/frr:shared,z']
+     if 'ovn-evpn' in edpm_neutron_ovn_agent_agent_extensions.split(',') | map('trim') | list
+     else [] }}
 
 # Sidecar containers settings
 edpm_neutron_ovn_agent_sidecar_debug: false

--- a/roles/edpm_neutron_ovn/meta/argument_specs.yml
+++ b/roles/edpm_neutron_ovn/meta/argument_specs.yml
@@ -85,8 +85,13 @@ argument_specs:
           - /run/openvswitch:/run/openvswitch:z
           - '{{ edpm_neutron_ovn_agent_config_dir }}:/etc/neutron.conf.d:z'
           - /var/lib/kolla/config_files/ovn_agent.json:/var/lib/kolla/config_files/config.json:ro
-          - /run/frr:/run/frr:shared,z
         description: Volume mounts for Neutron OVN agent
+        type: list
+      edpm_neutron_ovn_frr_volumes:
+        default: []
+        description: >
+          FRR volume mounts for the OVN agent container. Automatically populated
+          with /run/frr when the ovn-evpn extension is enabled.
         type: list
       edpm_neutron_ovn_tls_enabled:
         default: false

--- a/roles/edpm_neutron_ovn/molecule/evpn_disabled/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/evpn_disabled/verify.yml
@@ -17,6 +17,20 @@
         that:
           - "'[ovn_evpn]' not in agent_config.content | b64decode"
 
+    - name: Collect ovn_agent bind mounts
+      ansible.builtin.shell: |
+        /usr/bin/podman inspect --format '{{ '{{' }}.HostConfig.Binds{{ '}}' }}' ovn_agent
+      register: _edpm_neutron_ovn_ovn_agent_binds
+      changed_when: false
+
+    - name: Assert /run/frr bind is absent on ovn_agent
+      ansible.builtin.assert:
+        that:
+          - "'/run/frr:/run/frr:' not in _edpm_neutron_ovn_ovn_agent_binds.stdout"
+        fail_msg: >-
+          /run/frr bind unexpectedly found in ovn_agent HostConfig.Binds
+          (binds: {{ _edpm_neutron_ovn_ovn_agent_binds.stdout }})
+
     - name: Check ovn-evpn-local-ip is not set
       ansible.builtin.shell: >
         /usr/bin/ovs-vsctl --if-exists get open_vswitch . external_ids:ovn-evpn-local-ip

--- a/roles/edpm_neutron_ovn/templates/container_defs/ovn_agent.yaml.j2
+++ b/roles/edpm_neutron_ovn/templates/container_defs/ovn_agent.yaml.j2
@@ -12,6 +12,7 @@ volumes:
   {%- set edpm_neutron_ovn_volumes =
           edpm_neutron_ovn_volumes +
           edpm_neutron_ovn_common_volumes +
+          edpm_neutron_ovn_frr_volumes +
           edpm_neutron_ovn_tls_cacert_volumes %}
 {%- if edpm_neutron_ovn_tls_enabled | bool %}
 {%- set edpm_neutron_ovn_volumes =


### PR DESCRIPTION
The /run/frr bind mount was unconditionally added to the ovn_agent container volumes, creating a silent dependency on the edpm_frr role even when the extension is enabled (which is the only extension that requires to access frr from ovn-agent).

Move the /run/frr mount into a new edpm_neutron_ovn_frr_volumes variable that is only populated when the ovn-evpn extension is present in edpm_neutron_ovn_agent_agent_extensions. Add a molecule verification to the evpn_disabled scenario confirming the mount is absent.

Assisted-By: claude-opus-4.6