### PR TITLE
Improve evpn extension configuration

### DIFF
--- a/roles/edpm_neutron_ovn/defaults/main.yml
+++ b/roles/edpm_neutron_ovn/defaults/main.yml
@@ -24,7 +24,9 @@ edpm_neutron_ovn_common_volumes:
   - "{{ edpm_neutron_ovn_agent_lib_dir }}:/var/lib/neutron:shared,z"
   - "{{ edpm_neutron_ovn_agent_lib_dir }}/ovn_agent_haproxy_wrapper:/usr/local/bin/haproxy:ro"
   - "{{ edpm_neutron_ovn_agent_lib_dir }}/kill_scripts:/etc/neutron/kill_scripts:ro"
-  - /run/frr:/run/frr:shared,z
+
+edpm_neutron_ovn_frr_volumes:
+  - "/run/frr:{{ edpm_neutron_ovn_agent_frr_vty_socket }}:shared,z"
 
 # Sidecar containers settings
 edpm_neutron_ovn_agent_sidecar_debug: false
@@ -72,8 +74,10 @@ edpm_neutron_ovn_agent_bgp_peer_bridges: ''
 # Set this variable when the ovn-agent is configured with the ovn-bgp extension.
 edpm_neutron_ovn_agent_bgp_interconnect_bridge: "{{ neutron_physical_bridge_name | default('br-ex') }}"
 
-# ovn-evpn extension options. Set edpm_neutron_ovn_agent_agent_extensions to include
-# 'ovn-evpn' to load the extension and render the [ovn_evpn] section.
+edpm_neutron_ovn_evpn_extension_enabled: >-
+  {{ 'ovn-evpn' in edpm_neutron_ovn_agent_agent_extensions.split(',') | map('trim') | list }}
+
+# ovn-evpn extension options.
 edpm_neutron_ovn_agent_ovn_evpn_bgp_as: ''
 edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: ''
 edpm_neutron_ovn_agent_ovn_evpn_child_vxlan_port: '49152'

--- a/roles/edpm_neutron_ovn/meta/argument_specs.yml
+++ b/roles/edpm_neutron_ovn/meta/argument_specs.yml
@@ -85,9 +85,14 @@ argument_specs:
           - /run/openvswitch:/run/openvswitch:z
           - '{{ edpm_neutron_ovn_agent_config_dir }}:/etc/neutron.conf.d:z'
           - /var/lib/kolla/config_files/ovn_agent.json:/var/lib/kolla/config_files/config.json:ro
-          - /run/frr:/run/frr:shared,z
         description: Volume mounts for Neutron OVN agent
         type: list
+      edpm_neutron_ovn_evpn_extension_enabled:
+        default: false
+        description: >
+          Whether the ovn-evpn extension is enabled. Automatically derived
+          if edpm_neutron_ovn_agent_agent_extensions includes 'ovn-evpn'
+        type: bool
       edpm_neutron_ovn_tls_enabled:
         default: false
         description: >

--- a/roles/edpm_neutron_ovn/molecule/evpn_disabled/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/evpn_disabled/verify.yml
@@ -17,6 +17,20 @@
         that:
           - "'[ovn_evpn]' not in agent_config.content | b64decode"
 
+    - name: Collect ovn_agent bind mounts
+      ansible.builtin.shell: |
+        /usr/bin/podman inspect --format '{{ '{{' }}.HostConfig.Binds{{ '}}' }}' ovn_agent
+      register: _edpm_neutron_ovn_ovn_agent_binds
+      changed_when: false
+
+    - name: Assert /run/frr bind is absent on ovn_agent
+      ansible.builtin.assert:
+        that:
+          - "'/run/frr:' not in _edpm_neutron_ovn_ovn_agent_binds.stdout"
+        fail_msg: >-
+          /run/frr bind unexpectedly found in ovn_agent HostConfig.Binds
+          (binds: {{ _edpm_neutron_ovn_ovn_agent_binds.stdout }})
+
     - name: Check ovn-evpn-local-ip is not set
       ansible.builtin.shell: >
         /usr/bin/ovs-vsctl --if-exists get open_vswitch . external_ids:ovn-evpn-local-ip

--- a/roles/edpm_neutron_ovn/molecule/evpn_enabled/converge.yml
+++ b/roles/edpm_neutron_ovn/molecule/evpn_enabled/converge.yml
@@ -30,3 +30,4 @@
         edpm_neutron_ovn_agent_ovn_evpn_bgp_as: '64999'
         edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: eth0
         edpm_neutron_ovn_agent_ovn_evpn_child_vxlan_port: '49152'
+        edpm_neutron_ovn_agent_frr_vty_socket: '/run/frr/custom'

--- a/roles/edpm_neutron_ovn/molecule/evpn_enabled/verify.yml
+++ b/roles/edpm_neutron_ovn/molecule/evpn_enabled/verify.yml
@@ -19,7 +19,7 @@
           - "'bgp_as = 64999' in agent_config.content | b64decode"
           - "'bgp_local_interface = eth0' in agent_config.content | b64decode"
           - "'child_vxlan_port = 49152' in agent_config.content | b64decode"
-          - "'frr_vty_socket = /run/frr' in agent_config.content | b64decode"
+          - "'frr_vty_socket = /run/frr/custom' in agent_config.content | b64decode"
           - "'extensions = ovn-evpn' in agent_config.content | b64decode"
 
     - name: Collect ovn_agent bind mounts
@@ -28,12 +28,12 @@
       register: _edpm_neutron_ovn_ovn_agent_binds
       changed_when: false
 
-    - name: Assert /run/frr bind is present on ovn_agent
+    - name: Assert /run/frr:/run/frr/custom bind is present on ovn_agent
       ansible.builtin.assert:
         that:
-          - "'/run/frr:/run/frr:' in _edpm_neutron_ovn_ovn_agent_binds.stdout"
+          - "'/run/frr:/run/frr/custom:' in _edpm_neutron_ovn_ovn_agent_binds.stdout"
         fail_msg: >-
-          /run/frr bind not found in ovn_agent HostConfig.Binds
+          /run/frr:/run/frr/custom bind not found in ovn_agent HostConfig.Binds
           (binds: {{ _edpm_neutron_ovn_ovn_agent_binds.stdout }})
 
     - name: Verify vrf module is loaded

--- a/roles/edpm_neutron_ovn/tasks/configure.yml
+++ b/roles/edpm_neutron_ovn/tasks/configure.yml
@@ -70,7 +70,7 @@
       changed_when: true
 
     - name: EVPN extension configuration
-      when: "'ovn-evpn' in edpm_neutron_ovn_agent_agent_extensions.split(',') | map('trim') | list"
+      when: edpm_neutron_ovn_evpn_extension_enabled | bool
       block:
         - name: Gather ansible_local facts
           ansible.builtin.setup:

--- a/roles/edpm_neutron_ovn/templates/config/neutron-ovn-agent.conf.j2
+++ b/roles/edpm_neutron_ovn/templates/config/neutron-ovn-agent.conf.j2
@@ -15,7 +15,7 @@ ovsdb_connection_timeout = {{ edpm_neutron_ovn_agent_ovn_ovsdb_connection_timeou
 ovsdb_probe_interval = {{ edpm_neutron_ovn_agent_ovn_ovsdb_probe_interval }}
 ovn_nb_connection = {{ edpm_neutron_ovn_agent_ovn_ovn_nb_connection }}
 ovn_sb_connection = {{ edpm_neutron_ovn_agent_ovn_ovn_sb_connection }}
-{% if 'ovn-evpn' in edpm_neutron_ovn_agent_agent_extensions.split(',') | map('trim') | list %}
+{% if edpm_neutron_ovn_evpn_extension_enabled | bool %}
 
 [ovn_evpn]
 bgp_as = {{ edpm_neutron_ovn_agent_ovn_evpn_bgp_as }}

--- a/roles/edpm_neutron_ovn/templates/container_defs/ovn_agent.yaml.j2
+++ b/roles/edpm_neutron_ovn/templates/container_defs/ovn_agent.yaml.j2
@@ -13,6 +13,11 @@ volumes:
           edpm_neutron_ovn_volumes +
           edpm_neutron_ovn_common_volumes +
           edpm_neutron_ovn_tls_cacert_volumes %}
+{%- if edpm_neutron_ovn_evpn_extension_enabled | bool %}
+{%- set edpm_neutron_ovn_volumes =
+        edpm_neutron_ovn_volumes +
+        edpm_neutron_ovn_frr_volumes %}
+{%- endif %}
 {%- if edpm_neutron_ovn_tls_enabled | bool %}
 {%- set edpm_neutron_ovn_volumes =
         edpm_neutron_ovn_volumes +


### PR DESCRIPTION
Improve how evpn configuration and volume mount are handled when `ovn-evpn` extension is set. The change partially mimics how `edpm_neutron_ovn_tls_enabled` configures when TLS is enabled.
In this change.

`edpm_neutron_ovn_evpn_extension_enabled` gets set to `True` if the `ovn-evpn` extension is specified in the extensions list. Then:
-  Sets extra volumes in `ovn_agent.yaml.j2`
-  Sets related configuration in `neutron-ovn-agent.conf.j2`