### PR TITLE
Support per-scope sigstore remap targets

### DIFF
--- a/roles/edpm_podman/defaults/main.yml
+++ b/roles/edpm_podman/defaults/main.yml
@@ -110,4 +110,3 @@ edpm_container_signature_verification: false
 edpm_container_signature_cosign_key_data: ""
 edpm_container_signature_cosign_key_path: "/etc/pki/containers/cosign-redhat.pub"
 edpm_container_signature_registry_mappings: []
-edpm_container_signature_signed_prefix: ""

--- a/roles/edpm_podman/meta/argument_specs.yml
+++ b/roles/edpm_podman/meta/argument_specs.yml
@@ -192,12 +192,7 @@ argument_specs:
           List of source-to-mirror registry mappings for signature
           verification. Each entry is a dict with 'source' (original
           registry prefix, used as policy.json key) and 'mirror' (mirror
-          registry, used for sigstore attachment lookups). Auto-populated
-          by the openstack-operator from IDMS/ICSP and ClusterImagePolicy.
-      edpm_container_signature_signed_prefix:
-        type: str
-        default: ""
-        description: >
-          Optional original registry prefix where images were signed. When set,
-          edpm_podman writes a remapIdentity signedIdentity policy to map mirror
-          registry references back to the original signing identity.
+          registry, used for sigstore attachment lookups). Entries may
+          also include 'signedPrefix' for per-mapping remapIdentity
+          configuration. Auto-populated by the openstack-operator from
+          IDMS/ICSP and ClusterImagePolicy.

--- a/roles/edpm_podman/molecule/install/converge.yml
+++ b/roles/edpm_podman/molecule/install/converge.yml
@@ -31,6 +31,7 @@
         edpm_container_signature_registry_mappings:
           - source: "registry.redhat.io/rhoso"
             mirror: "mirror.example.com:5000/rhoso"
+            signedPrefix: "registry.redhat.io/rhoso"
         edpm_container_signature_cosign_key_data: "{{ test_cosign_key_data }}"
 
     - name: Test podman network ls
@@ -49,7 +50,9 @@
         that:
           - policy.transports.docker["registry.redhat.io/rhoso"][0].type == "sigstoreSigned"
           - policy.transports.docker["registry.redhat.io/rhoso"][0].keyPath == "/etc/pki/containers/cosign-redhat.pub"
-          - "'signedIdentity' not in policy.transports.docker['registry.redhat.io/rhoso'][0]"
+          - policy.transports.docker["registry.redhat.io/rhoso"][0].signedIdentity.type == "remapIdentity"
+          - policy.transports.docker["registry.redhat.io/rhoso"][0].signedIdentity.prefix == "registry.redhat.io/rhoso"
+          - policy.transports.docker["registry.redhat.io/rhoso"][0].signedIdentity.signedPrefix == "registry.redhat.io/rhoso"
           - policy.transports.docker["registry.redhat.io"][0].type == "signedBy"
           - policy.transports.docker["registry.access.redhat.com"][0].type == "signedBy"
       vars:

--- a/roles/edpm_podman/tasks/install.yml
+++ b/roles/edpm_podman/tasks/install.yml
@@ -204,13 +204,13 @@
                       'type': 'sigstoreSigned',
                       'keyPath': edpm_container_signature_cosign_key_path
                     } | combine(
-                      (edpm_container_signature_signed_prefix | length > 0)
+                      ((item.signedPrefix | default('')) | length > 0)
                       | ternary(
                           {
                             'signedIdentity': {
                               'type': 'remapIdentity',
                               'prefix': item.source,
-                              'signedPrefix': edpm_container_signature_signed_prefix
+                              'signedPrefix': item.signedPrefix
                             }
                           },
                           {}


### PR DESCRIPTION
Required as we changed the ansible vars in openstack-operator.

jira: [OSPRH-32484](https://redhat.atlassian.net/browse/OSPRH-32484)
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1972