### PR TITLE
Make BGP graceful-shutdown configurable for eBGP support

### DIFF
--- a/roles/edpm_frr/defaults/main.yml
+++ b/roles/edpm_frr/defaults/main.yml
@@ -65,6 +65,7 @@ edpm_frr_watchfrr_options: ''
 edpm_frr_zebra: true
 edpm_frr_zebra_nht_resolve_via_default: true
 edpm_frr_zebra_graceful_restart_time: ''
+edpm_frr_bgp_graceful_shutdown: true
 edpm_frr_conf_custom_globals: ''
 edpm_frr_conf_custom_router_bgp: ''
 edpm_frr_conf_custom_ipv4: ''

--- a/roles/edpm_frr/meta/argument_specs.yml
+++ b/roles/edpm_frr/meta/argument_specs.yml
@@ -213,6 +213,14 @@ argument_specs:
         default: true
         description: ''
         type: bool
+      edpm_frr_bgp_graceful_shutdown:
+        default: true
+        description: >-
+          Enable BGP graceful-shutdown (RFC 8326), adding the
+          GRACEFUL_SHUTDOWN community to advertised routes. Set to
+          false for eBGP nodes where graceful-shutdown should not
+          apply during normal operation.
+        type: bool
       edpm_frr_zebra_graceful_restart_time:
         default: ''
         description: Zebra graceful_restart time (seconds)

--- a/roles/edpm_frr/templates/config/frr.conf.j2
+++ b/roles/edpm_frr/templates/config/frr.conf.j2
@@ -68,7 +68,9 @@ router bgp {{ edpm_frr_bgp_asn }} vrf {{ edpm_frr_ovn_vrf_advertise }}
 router bgp {{ edpm_frr_bgp_asn }}
   bgp router-id {{ hostvars[inventory_hostname][edpm_frr_bgp_ipv4_src_network ~ '_ip'] }}
   bgp log-neighbor-changes
+{% if edpm_frr_bgp_graceful_shutdown | default(true) %}
   bgp graceful-shutdown
+{% endif %}
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
   {{ edpm_frr_conf_custom_router_bgp }}


### PR DESCRIPTION
```
Make BGP graceful-shutdown configurable for eBGP support
BGP graceful-shutdown (RFC 8326) was hardcoded in the FRR config
template. This prevents eBGP deployments from disabling it, where
graceful-shutdown adds the GRACEFUL_SHUTDOWN community to all
advertised routes causing peers to deprioritize them.

Adds edpm_frr_bgp_graceful_shutdown variable (default: true) to
allow eBGP nodes to opt out. Existing deployments are unaffected.

Related: OSPRH-28085
Assisted-By: Claude Code
Signed-off-by: Maor Blaustein <mblue@redhat.com>
```