### PR TITLE
Safely expand ansible-runner settings defaults

### DIFF
--- a/openstack_ansibleee/edpm_entrypoint.sh
+++ b/openstack_ansibleee/edpm_entrypoint.sh
@@ -1,8 +1,28 @@
 #!/usr/bin/env bash
 
 # Adding edpm ansible-runner specific scripts here
+# Set defaults before expanding the settings template.
+: "${RUNNER_IDLE_TIMEOUT:=600}"
+: "${RUNNER_JOB_TIMEOUT:=3600}"
+: "${RUNNER_PEXPECT_TIMEOUT:=10}"
+: "${RUNNER_PEXPECT_USE_POLL:=True}"
+: "${RUNNER_SUPPRESS_OUTPUT_FILE:=False}"
+: "${RUNNER_SUPPRESS_ANSIBLE_OUTPUT:=False}"
+: "${RUNNER_FACT_CACHE:=fact_cache}"
+: "${RUNNER_FACT_CACHE_TYPE:=jsonfile}"
+
+export \
+    RUNNER_IDLE_TIMEOUT \
+    RUNNER_JOB_TIMEOUT \
+    RUNNER_PEXPECT_TIMEOUT \
+    RUNNER_PEXPECT_USE_POLL \
+    RUNNER_SUPPRESS_OUTPUT_FILE \
+    RUNNER_SUPPRESS_ANSIBLE_OUTPUT \
+    RUNNER_FACT_CACHE \
+    RUNNER_FACT_CACHE_TYPE
+
 # Expand the variables
-eval "echo \"$(cat /runner/env/settings)\"" > /runner/env/settings
+envsubst < /runner/env/settings > /runner/env/settings.tmp && mv /runner/env/settings.tmp /runner/env/settings
 
 if [ -n "$RUNNER_INVENTORY" ]; then
     echo "---" > /runner/inventory/inventory.yaml

--- a/openstack_ansibleee/settings
+++ b/openstack_ansibleee/settings
@@ -1,26 +1,26 @@
 # If no output is detected from ansible in this number of seconds the execution will
 # be terminated.
-idle_timeout: ${RUNNER_IDLE_TIMEOUT:-600}
+idle_timeout: ${RUNNER_IDLE_TIMEOUT}
 # The maximum amount of time to allow the job to run for, exceeding this and the
 # execution will be terminated.
-job_timeout: ${RUNNER_JOB_TIMEOUT:-3600}
+job_timeout: ${RUNNER_JOB_TIMEOUT}
 
 # Number of seconds for the internal pexpect command to wait to block on
 # input before continuing.
-pexpect_timeout: ${RUNNER_PEXPECT_TIMEOUT:-10}
+pexpect_timeout: ${RUNNER_PEXPECT_TIMEOUT}
 # Use poll() function for communication with child processes instead of select().
 # select() is used when the value is set to False. select() has a known limitation of
 # using only up to 1024 file descriptors.
-pexpect_use_poll: ${RUNNER_PEXPECT_USE_POLL:-True}
+pexpect_use_poll: ${RUNNER_PEXPECT_USE_POLL}
 
 # Allow output from ansible to not be streamed to the stdout or stderr files inside
 # of the artifacts directory.
-suppress_output_file: ${RUNNER_SUPPRESS_OUTPUT_FILE:-False}
+suppress_output_file: ${RUNNER_SUPPRESS_OUTPUT_FILE}
 # Allow output from ansible to not be printed to the screen.
-suppress_ansible_output: ${RUNNER_SUPPRESS_ANSIBLE_OUTPUT:-False}
+suppress_ansible_output: ${RUNNER_SUPPRESS_ANSIBLE_OUTPUT}
 
 # The directory relative to artifacts where jsonfile fact caching will be stored.
 # Defaults to fact_cache. This is ignored if fact_cache_type is different than jsonfile.
-fact_cache: ${RUNNER_FACT_CACHE:-'fact_cache'}
+fact_cache: ${RUNNER_FACT_CACHE}
 # The type of fact cache to use. Defaults to jsonfile.
-fact_cache_type: ${RUNNER_FACT_CACHE_TYPE:-'jsonfile'}
+fact_cache_type: ${RUNNER_FACT_CACHE_TYPE}

--- a/openstack_ansibleee/setup.sh
+++ b/openstack_ansibleee/setup.sh
@@ -4,6 +4,7 @@ set -eux pipefail
 microdnf -y makecache
 microdnf install -y \
     gcc \
+    gettext \
     libssh-devel \
     iputils \
     bind-utils \


### PR DESCRIPTION
Set the runner defaults in the entrypoint before running envsubst so settings expansion avoids eval while preserving the existing fallback values.

jira: [OSPRH-32790](https://redhat.atlassian.net/browse/OSPRH-32790)

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4061