### PR TITLE
edpm_network_config: add nmstate device_map (physical device PCI/driv…

### DIFF
--- a/plugins/tests/test_edpm_nmstate_device_map.py
+++ b/plugins/tests/test_edpm_nmstate_device_map.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright 2026 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT_PATH = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "roles",
+        "edpm_network_config",
+        "files",
+        "edpm_nmstate_device_map.py",
+    )
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("edpm_nmstate_device_map", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestNmstateDeviceMap(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.sys_class_net = os.path.join(self.tmp, "class", "net")
+        self.pci_devices = os.path.join(self.tmp, "bus", "pci", "devices")
+        self.pci_drivers = os.path.join(self.tmp, "bus", "pci", "drivers")
+        os.makedirs(self.sys_class_net)
+        os.makedirs(self.pci_devices)
+        os.makedirs(self.pci_drivers)
+        os.environ["EDPM_TEST_SYS_CLASS_NET"] = self.sys_class_net
+        self.mod = _load_module()
+
+    def tearDown(self):
+        os.environ.pop("EDPM_TEST_SYS_CLASS_NET", None)
+
+    def _mk_physical_netdev(self, name, pci_bdf, driver=None):
+        """A real NIC: netdev/device -> PCI device dir, optionally with a driver symlink."""
+        net_dir = os.path.join(self.sys_class_net, name)
+        os.makedirs(net_dir)
+        pci_path = os.path.join(self.pci_devices, pci_bdf)
+        os.makedirs(pci_path, exist_ok=True)
+        os.symlink(pci_path, os.path.join(net_dir, "device"))
+        if driver:
+            drv_path = os.path.join(self.pci_drivers, driver)
+            os.makedirs(drv_path, exist_ok=True)
+            os.symlink(drv_path, os.path.join(pci_path, "driver"))
+
+    def _mk_virtual_netdev(self, name):
+        """A virtual netdev (bond/bridge/dummy/vlan/loopback): no "device" entry at all."""
+        os.makedirs(os.path.join(self.sys_class_net, name))
+
+    def test_includes_physical_ethernet_device(self):
+        self._mk_physical_netdev("eno1", "0000:01:00.0", driver="ice")
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertIn("eno1", device_map["devices"])
+        self.assertEqual(device_map["devices"]["eno1"]["pci"], "0000:01:00.0")
+        self.assertEqual(device_map["devices"]["eno1"]["driver"], "ice")
+        self.assertIn("updated", device_map)
+
+    def test_includes_sriov_vf_as_physical(self):
+        # VFs are also backed by a real PCI device/driver (e.g. iavf).
+        self._mk_physical_netdev("eno1v0", "0000:01:00.1", driver="iavf")
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertIn("eno1v0", device_map["devices"])
+        self.assertEqual(device_map["devices"]["eno1v0"]["driver"], "iavf")
+
+    def test_excludes_virtual_devices(self):
+        self._mk_physical_netdev("eno1", "0000:01:00.0", driver="ice")
+        for name in ("bond0", "br-ex", "dummy0", "lo", "eno1.100", "veth0"):
+            self._mk_virtual_netdev(name)
+
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertEqual(list(device_map["devices"]), ["eno1"])
+
+    def test_device_without_driver_has_none_driver(self):
+        self._mk_physical_netdev("eno1", "0000:01:00.0")
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertIsNone(device_map["devices"]["eno1"]["driver"])
+
+    def test_empty_sysfs_yields_empty_map(self):
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertEqual(device_map["devices"], {})
+
+    def test_cli_writes_yaml_file(self):
+        self._mk_physical_netdev("eno1", "0000:01:00.0", driver="ice")
+        self._mk_virtual_netdev("dummy0")
+        out_path = os.path.join(self.tmp, "device_map.yaml")
+
+        env = dict(os.environ)
+        subprocess.run(
+            [sys.executable, SCRIPT_PATH, "-o", out_path],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        device_map = self._load_yaml(out_path)
+        self.assertIn("eno1", device_map["devices"])
+        self.assertNotIn("dummy0", device_map["devices"])
+
+    @staticmethod
+    def _load_yaml(path):
+        import yaml
+
+        with open(path, encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -57,6 +57,9 @@ edpm_network_config_purge_provider: ""
 edpm_network_config_os_net_config_mappings: {}
 edpm_network_config_safe_defaults: false
 edpm_network_config_template: ""
+# Path to nmstate device_map.yaml: name -> PCI address/driver for physical
+# network devices (nmstate tool path only). Refreshed after a successful apply.
+edpm_network_config_nmstate_device_map_file: /var/lib/edpm-config/nmstate_device_map.yaml
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"
 edpm_dns_search_domains: []
 edpm_network_config_nonconfigured_cleanup: false

--- a/roles/edpm_network_config/files/edpm_nmstate_device_map.py
+++ b/roles/edpm_network_config/files/edpm_nmstate_device_map.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright 2026 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0
+#
+# Build a simple nmstate device_map.yaml: for every physical network device
+# (i.e. a netdev backed by a real bus device, such as a PCI ethernet NIC or
+# SR-IOV VF) record its name, PCI address and currently bound kernel driver.
+#
+# Virtual netdevs (bond, bridge, dummy, vlan, veth, loopback, ...) have no
+# "device" symlink in sysfs and are skipped.
+#
+# This is intentionally minimal: no filtering/skip policy, no persistence
+# merge logic. It just answers "what physical devices does this host have,
+# and what is their current PCI/driver identity right now?".
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+
+try:
+    import yaml
+except ImportError as exc:
+    raise SystemExit(
+        "PyYAML is required (python3-pyyaml on RHEL-family hosts)."
+    ) from exc
+
+SYS_CLASS_NET = os.environ.get("EDPM_TEST_SYS_CLASS_NET", "/sys/class/net")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _device_dir(sys_class_net: str, name: str) -> str:
+    return os.path.join(sys_class_net, name, "device")
+
+
+def _is_physical_netdev(sys_class_net: str, name: str) -> bool:
+    return os.path.isdir(_device_dir(sys_class_net, name))
+
+
+def _pci_address(sys_class_net: str, name: str) -> Optional[str]:
+    try:
+        return os.path.basename(os.readlink(_device_dir(sys_class_net, name)))
+    except OSError:
+        return None
+
+
+def _driver(sys_class_net: str, name: str) -> Optional[str]:
+    driver_link = os.path.join(_device_dir(sys_class_net, name), "driver")
+    try:
+        return os.path.basename(os.readlink(driver_link))
+    except OSError:
+        return None
+
+
+def build_device_map(sys_class_net: Optional[str] = None) -> dict:
+    base = sys_class_net or SYS_CLASS_NET
+    devices: dict = {}
+
+    if os.path.isdir(base):
+        for name in sorted(os.listdir(base)):
+            if not _is_physical_netdev(base, name):
+                continue
+            devices[name] = {
+                "pci": _pci_address(base, name),
+                "driver": _driver(base, name),
+            }
+
+    return {"devices": devices, "updated": _utc_now()}
+
+
+def _dump_yaml(data: dict) -> str:
+    return yaml.safe_dump(data, default_flow_style=False, allow_unicode=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build nmstate device_map.yaml for physical network devices"
+    )
+    parser.add_argument(
+        "-o", "--output", default="", help="Write device_map YAML here (default: stdout)"
+    )
+    args = parser.parse_args()
+
+    device_map = build_device_map()
+
+    if args.output:
+        os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(_dump_yaml(device_map))
+    else:
+        sys.stdout.write(_dump_yaml(device_map))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -79,6 +79,13 @@ argument_specs:
         type: str
         description: "Which settings template should be rendered."
         default: ""
+      edpm_network_config_nmstate_device_map_file:
+        type: str
+        description: >
+          Path to nmstate device_map.yaml recording, for every physical network device
+          (PCI ethernet NIC, SR-IOV VF, etc.), its current name, PCI address and bound
+          kernel driver. Refreshed after a successful apply (nmstate tool path only).
+        default: /var/lib/edpm-config/nmstate_device_map.yaml
       edpm_bond_interface_ovs_options:
         type: str
         description: "Binding options to be rendered in a template"

--- a/roles/edpm_network_config/tasks/nmstate_device_map.yml
+++ b/roles/edpm_network_config/tasks/nmstate_device_map.yml
@@ -1,0 +1,20 @@
+---
+# Build/refresh a device_map.yaml recording, for every physical network
+# device (PCI ethernet NIC, SR-IOV VF, ...), its current PCI address and
+# bound kernel driver. This is observational only: no filtering or skip
+# decisions are made here.
+
+- name: Ensure /var/lib/edpm-config exists
+  ansible.builtin.file:
+    path: /var/lib/edpm-config
+    state: directory
+    mode: "0755"
+
+- name: Generate nmstate device_map
+  ansible.builtin.command:
+    argv:
+      - python3
+      - "{{ role_path }}/files/edpm_nmstate_device_map.py"
+      - -o
+      - "{{ edpm_network_config_nmstate_device_map_file }}"
+  changed_when: false

--- a/roles/edpm_network_config/tasks/nmstate_tool.yml
+++ b/roles/edpm_network_config/tasks/nmstate_tool.yml
@@ -73,3 +73,6 @@
         content: "0"
         dest: /var/lib/edpm-config/nmstate.returncode
         mode: "0644"
+
+    - name: Refresh nmstate device_map (physical device PCI/driver identity)
+      ansible.builtin.include_tasks: nmstate_device_map.yml


### PR DESCRIPTION
…er map)

Record, for every physical network device (PCI ethernet NIC or SR-IOV VF), its current name, PCI address, and bound kernel driver in a device_map.yaml. Devices are identified by the presence of a "device" symlink in sysfs, which naturally excludes virtual netdevs (bond, bridge, dummy, vlan, veth, loopback). The map is refreshed after every successful nmstate apply via edpm_network_config_nmstate_device_map_file (default /var/lib/edpm-config/nmstate_device_map.yaml).

This is intentionally minimal: no vfio-pci detection, filtering, or skip policy yet. It just establishes the name <-> PCI/driver identity that a later patch can use for SR-IOV passthrough preflight checks.

Assisted-by: Cursor AI