### PR TITLE
edpm_network_config: add PCI driver binding via driverctl

### DIFF
--- a/docs/source/roles/role-edpm_network_config.rst
+++ b/docs/source/roles/role-edpm_network_config.rst
@@ -60,3 +60,131 @@ An example of using ``remove_config`` is available in:
 
 .. literalinclude:: ../../../roles/edpm_network_config/molecule/default/converge.yml
    :language: YAML
+nmstate tool
+~~~~~~~~~~~~
+
+When ``edpm_network_config_tool`` is ``nmstate``, the role applies
+``edpm_network_config_template`` as nmstate desired state via the
+``linux_system_roles.network`` role (see ``nmstate_tool.yml``).
+NetworkManager is configured to manage ``/etc/resolv.conf`` on this path.
+
+The nmstate tool is experimental; set
+``edpm_network_config_tool_nmstate_override: true`` to run it.
+Set ``edpm_network_config_update: true`` (or rely on first-run / failed-run
+logic) so the template is applied.
+
+Example playbook (inline template):
+
+.. code-block:: YAML
+
+    - name: Configure host network with nmstate
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_network_config
+      vars:
+        edpm_network_config_tool: nmstate
+        edpm_network_config_tool_nmstate_override: true
+        edpm_network_config_update: true
+        edpm_network_config_template: |
+          ---
+          interfaces:
+            - name: nic1
+              type: ethernet
+              state: up
+              mtu: 1500
+
+Example playbook (template from file; copy
+``roles/edpm_network_config/examples/nmstate_sriov.yaml`` into your playbook
+``files/`` directory):
+
+.. code-block:: YAML
+
+    - name: Configure host network with nmstate (SR-IOV template file)
+      ansible.builtin.include_role:
+        name: osp.edpm.edpm_network_config
+      vars:
+        edpm_network_config_tool: nmstate
+        edpm_network_config_tool_nmstate_override: true
+        edpm_network_config_update: true
+        edpm_network_config_template: >-
+          {{ lookup('file', playbook_dir + '/files/nmstate_sriov.yaml') }}
+
+SR-IOV with the nmstate tool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SR-IOV is configured in ``edpm_network_config_template`` under the PF
+(physical function) ``ethernet.sr-iov`` section. Nmstate creates or updates
+VFs according to ``total-vfs`` and optional per-VF settings (``trust``,
+``spoof-check``, MAC addresses, and so on). See the
+`nmstate YAML API <https://nmstate.io/devel/yaml_api.html>`_ SR-IOV section.
+
+When the ``vfs`` list is present, nmstate expects configuration for every VF
+up to ``total-vfs`` (see nmstate documentation). For OpenStack dataplane NICs,
+``trust: true`` on VFs is commonly required before Neutron SR-IOV agent use.
+
+A full example template ships with this role:
+
+.. literalinclude:: ../../../roles/edpm_network_config/examples/nmstate_sriov.yaml
+   :language: yaml
+
+Minimal SR-IOV (VF count only, default VF parameters):
+
+.. code-block:: yaml
+
+    ---
+    interfaces:
+      - name: nic1
+        type: ethernet
+        state: up
+        ethernet:
+          sr-iov:
+            drivers-autoprobe: true
+            total-vfs: 8
+
+PCI device_map (nmstate tool)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After a successful nmstate apply, the role records the PCI address and
+currently bound kernel driver of every physical network device (PCI
+ethernet NIC or SR-IOV VF) in ``edpm_network_config_nmstate_device_map_file``
+(default ``/var/lib/edpm-config/nmstate_device_map.yaml``). Devices are
+identified by the presence of a ``device`` symlink in sysfs, which naturally
+excludes virtual netdevs (bond, bridge, dummy, vlan, veth, loopback). This is
+observational only; see ``edpm_nmstate_device_map.py``.
+
+PCI driver binding (driverctl)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set ``edpm_network_config_driver_bind`` (nmstate tool path only) to bind a
+kernel driver at a specific PCI address before the main nmstate apply runs,
+e.g. to hand a NIC to ``vfio-pci`` for DPDK/SR-IOV passthrough, or to return
+one to its native driver:
+
+.. code-block:: yaml
+
+    edpm_network_config_driver_bind: |
+      ---
+      interfaces:
+        - name: eno12399np0
+          pci_address: "0000:8a:00.0"
+          driver: vfio-pci
+
+For every entry, the role first confirms that ``name`` really identifies
+``pci_address``:
+
+* If the netdev named ``name`` is present in sysfs, its live PCI address
+  must match the declared ``pci_address``. A mismatch fails the run.
+* If the netdev is not present in sysfs (e.g. it was already unbound from
+  the host network stack), the role falls back to the persisted
+  ``edpm_network_config_nmstate_device_map_file``. If that map has a
+  recorded PCI address for ``name`` which does not match ``pci_address``,
+  the run still fails.
+* If neither sysfs nor the device_map have anything recorded for ``name``,
+  there is nothing to cross-check; the declared ``pci_address`` is trusted
+  and binding proceeds.
+
+Validation runs for every entry before any binding happens, so one bad entry
+does not leave earlier entries half-applied. Once validated, each entry is
+bound with ``driverctl set-override <pci_address> <driver>`` (idempotent:
+if the PCI address is already bound to the requested driver, that entry is
+a no-op). See ``edpm_driver_bind.py``.
+

--- a/plugins/tests/test_edpm_driver_bind.py
+++ b/plugins/tests/test_edpm_driver_bind.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright 2026 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0
+
+import importlib.util
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+SCRIPT_PATH = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "roles",
+        "edpm_network_config",
+        "files",
+        "edpm_driver_bind.py",
+    )
+)
+
+FAKE_DRIVERCTL = """#!/usr/bin/env python3
+import os
+import sys
+
+if len(sys.argv) != 4 or sys.argv[1] != "set-override":
+    sys.exit(1)
+
+pci_devices = os.environ["EDPM_TEST_PCI_DEVICES"]
+pci_address, driver = sys.argv[2], sys.argv[3]
+driver_link = os.path.join(pci_devices, pci_address, "driver")
+os.makedirs(os.path.dirname(driver_link), exist_ok=True)
+if os.path.islink(driver_link) or os.path.exists(driver_link):
+    os.remove(driver_link)
+os.symlink(os.path.join("/fake/drivers", driver), driver_link)
+"""
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("edpm_driver_bind", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestEdpmDriverBind(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.sys_class_net = os.path.join(self.tmp, "class", "net")
+        self.pci_devices = os.path.join(self.tmp, "bus", "pci", "devices")
+        os.makedirs(self.sys_class_net)
+        os.makedirs(self.pci_devices)
+
+        self.driverctl_path = os.path.join(self.tmp, "fake-driverctl")
+        with open(self.driverctl_path, "w", encoding="utf-8") as fh:
+            fh.write(FAKE_DRIVERCTL)
+        os.chmod(self.driverctl_path, os.stat(self.driverctl_path).st_mode | stat.S_IEXEC)
+
+        os.environ["EDPM_TEST_SYS_CLASS_NET"] = self.sys_class_net
+        os.environ["EDPM_TEST_PCI_DEVICES"] = self.pci_devices
+        os.environ["EDPM_TEST_DRIVERCTL_BIN"] = self.driverctl_path
+        self.mod = _load_module()
+
+    def tearDown(self):
+        for key in (
+            "EDPM_TEST_SYS_CLASS_NET",
+            "EDPM_TEST_PCI_DEVICES",
+            "EDPM_TEST_DRIVERCTL_BIN",
+        ):
+            os.environ.pop(key, None)
+
+    def _mk_physical_netdev(self, name, pci_bdf, driver=None):
+        net_dir = os.path.join(self.sys_class_net, name)
+        os.makedirs(net_dir)
+        pci_path = os.path.join(self.pci_devices, pci_bdf)
+        os.makedirs(pci_path, exist_ok=True)
+        os.symlink(pci_path, os.path.join(net_dir, "device"))
+        if driver:
+            self._set_pci_driver(pci_bdf, driver)
+
+    def _set_pci_driver(self, pci_bdf, driver):
+        pci_path = os.path.join(self.pci_devices, pci_bdf)
+        os.makedirs(pci_path, exist_ok=True)
+        driver_link = os.path.join(pci_path, "driver")
+        if os.path.islink(driver_link):
+            os.remove(driver_link)
+        os.symlink(os.path.join("/fake/drivers", driver), driver_link)
+
+    def _write_device_map(self, devices):
+        path = os.path.join(self.tmp, "device_map.yaml")
+        with open(path, "w", encoding="utf-8") as fh:
+            yaml.safe_dump({"devices": devices}, fh)
+        return path
+
+    def _write_template(self, interfaces):
+        path = os.path.join(self.tmp, "driver_bind.yaml")
+        with open(path, "w", encoding="utf-8") as fh:
+            yaml.safe_dump({"interfaces": interfaces}, fh)
+        return path
+
+    # -- validation ---------------------------------------------------
+
+    def test_validation_fails_on_sysfs_mismatch(self):
+        self._mk_physical_netdev("eno1", "0000:01:00.0")
+        errors = self.mod.validate_interfaces(
+            [{"name": "eno1", "pci_address": "0000:99:00.0", "driver": "vfio-pci"}],
+            self.sys_class_net,
+            {},
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("eno1", errors[0])
+        self.assertIn("sysfs reports", errors[0])
+
+    def test_validation_fails_on_device_map_mismatch(self):
+        # "eno1" has already disappeared from sysfs (e.g. unbound already).
+        device_map = {"devices": {"eno1": {"pci": "0000:01:00.0"}}}
+        errors = self.mod.validate_interfaces(
+            [{"name": "eno1", "pci_address": "0000:99:00.0", "driver": "vfio-pci"}],
+            self.sys_class_net,
+            device_map,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("device_map.yaml records", errors[0])
+
+    def test_validation_passes_when_absent_from_both(self):
+        errors = self.mod.validate_interfaces(
+            [{"name": "eno1", "pci_address": "0000:99:00.0", "driver": "vfio-pci"}],
+            self.sys_class_net,
+            {},
+        )
+        self.assertEqual(errors, [])
+
+    def test_validation_passes_when_device_map_matches(self):
+        device_map = {"devices": {"eno1": {"pci": "0000:99:00.0"}}}
+        errors = self.mod.validate_interfaces(
+            [{"name": "eno1", "pci_address": "0000:99:00.0", "driver": "vfio-pci"}],
+            self.sys_class_net,
+            device_map,
+        )
+        self.assertEqual(errors, [])
+
+    def test_validation_reports_missing_schema_keys(self):
+        errors = self.mod.validate_interfaces(
+            [{"name": "eno1", "driver": "vfio-pci"}], self.sys_class_net, {}
+        )
+        self.assertTrue(any("pci_address" in e for e in errors))
+
+    # -- binding --------------------------------------------------------
+
+    def test_bind_noop_when_driver_already_set(self):
+        self._set_pci_driver("0000:01:00.0", "vfio-pci")
+        changed = self.mod.bind_driver(
+            self.pci_devices, "0000:01:00.0", "vfio-pci", self.driverctl_path
+        )
+        self.assertFalse(changed)
+
+    def test_bind_invokes_driverctl_when_driver_differs(self):
+        self._set_pci_driver("0000:01:00.0", "ice")
+        changed = self.mod.bind_driver(
+            self.pci_devices, "0000:01:00.0", "vfio-pci", self.driverctl_path
+        )
+        self.assertTrue(changed)
+        self.assertEqual(
+            self.mod._driver_for_pci(self.pci_devices, "0000:01:00.0"), "vfio-pci"
+        )
+
+    # -- CLI end-to-end ---------------------------------------------------
+
+    def test_cli_end_to_end_success(self):
+        self._set_pci_driver("0000:8a:00.0", "ice")
+        template = self._write_template(
+            [{"name": "eno12399np0", "pci_address": "0000:8a:00.0", "driver": "vfio-pci"}]
+        )
+        map_path = self._write_device_map({})
+
+        result = subprocess.run(
+            [sys.executable, SCRIPT_PATH, "-f", template, "-m", map_path],
+            env=dict(os.environ),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("edpm_driver_bind_changed=yes", result.stdout)
+        self.assertEqual(
+            self.mod._driver_for_pci(self.pci_devices, "0000:8a:00.0"), "vfio-pci"
+        )
+
+    def test_cli_end_to_end_validation_failure(self):
+        self._mk_physical_netdev("eno12399np0", "0000:01:00.0")
+        template = self._write_template(
+            [{"name": "eno12399np0", "pci_address": "0000:8a:00.0", "driver": "vfio-pci"}]
+        )
+
+        result = subprocess.run(
+            [sys.executable, SCRIPT_PATH, "-f", template],
+            env=dict(os.environ),
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("validation failed", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/tests/test_edpm_nmstate_device_map.py
+++ b/plugins/tests/test_edpm_nmstate_device_map.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright 2026 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT_PATH = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "roles",
+        "edpm_network_config",
+        "files",
+        "edpm_nmstate_device_map.py",
+    )
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("edpm_nmstate_device_map", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestNmstateDeviceMap(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.sys_class_net = os.path.join(self.tmp, "class", "net")
+        self.pci_devices = os.path.join(self.tmp, "bus", "pci", "devices")
+        self.pci_drivers = os.path.join(self.tmp, "bus", "pci", "drivers")
+        os.makedirs(self.sys_class_net)
+        os.makedirs(self.pci_devices)
+        os.makedirs(self.pci_drivers)
+        os.environ["EDPM_TEST_SYS_CLASS_NET"] = self.sys_class_net
+        self.mod = _load_module()
+
+    def tearDown(self):
+        os.environ.pop("EDPM_TEST_SYS_CLASS_NET", None)
+
+    def _mk_physical_netdev(self, name, pci_bdf, driver=None):
+        """A real NIC: netdev/device -> PCI device dir, optionally with a driver symlink."""
+        net_dir = os.path.join(self.sys_class_net, name)
+        os.makedirs(net_dir)
+        pci_path = os.path.join(self.pci_devices, pci_bdf)
+        os.makedirs(pci_path, exist_ok=True)
+        os.symlink(pci_path, os.path.join(net_dir, "device"))
+        if driver:
+            drv_path = os.path.join(self.pci_drivers, driver)
+            os.makedirs(drv_path, exist_ok=True)
+            os.symlink(drv_path, os.path.join(pci_path, "driver"))
+
+    def _mk_virtual_netdev(self, name):
+        """A virtual netdev (bond/bridge/dummy/vlan/loopback): no "device" entry at all."""
+        os.makedirs(os.path.join(self.sys_class_net, name))
+
+    def test_includes_physical_ethernet_device(self):
+        self._mk_physical_netdev("eno1", "0000:01:00.0", driver="ice")
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertIn("eno1", device_map["devices"])
+        self.assertEqual(device_map["devices"]["eno1"]["pci"], "0000:01:00.0")
+        self.assertEqual(device_map["devices"]["eno1"]["driver"], "ice")
+        self.assertIn("updated", device_map)
+
+    def test_includes_sriov_vf_as_physical(self):
+        # VFs are also backed by a real PCI device/driver (e.g. iavf).
+        self._mk_physical_netdev("eno1v0", "0000:01:00.1", driver="iavf")
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertIn("eno1v0", device_map["devices"])
+        self.assertEqual(device_map["devices"]["eno1v0"]["driver"], "iavf")
+
+    def test_excludes_virtual_devices(self):
+        self._mk_physical_netdev("eno1", "0000:01:00.0", driver="ice")
+        for name in ("bond0", "br-ex", "dummy0", "lo", "eno1.100", "veth0"):
+            self._mk_virtual_netdev(name)
+
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertEqual(list(device_map["devices"]), ["eno1"])
+
+    def test_device_without_driver_has_none_driver(self):
+        self._mk_physical_netdev("eno1", "0000:01:00.0")
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertIsNone(device_map["devices"]["eno1"]["driver"])
+
+    def test_empty_sysfs_yields_empty_map(self):
+        device_map = self.mod.build_device_map(self.sys_class_net)
+        self.assertEqual(device_map["devices"], {})
+
+    def test_cli_writes_yaml_file(self):
+        self._mk_physical_netdev("eno1", "0000:01:00.0", driver="ice")
+        self._mk_virtual_netdev("dummy0")
+        out_path = os.path.join(self.tmp, "device_map.yaml")
+
+        env = dict(os.environ)
+        subprocess.run(
+            [sys.executable, SCRIPT_PATH, "-o", out_path],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        device_map = self._load_yaml(out_path)
+        self.assertIn("eno1", device_map["devices"])
+        self.assertNotIn("dummy0", device_map["devices"])
+
+    @staticmethod
+    def _load_yaml(path):
+        import yaml
+
+        with open(path, encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -57,6 +57,9 @@ edpm_network_config_purge_provider: ""
 edpm_network_config_os_net_config_mappings: {}
 edpm_network_config_safe_defaults: false
 edpm_network_config_template: ""
+# Path to nmstate device_map.yaml: name -> PCI address/driver for physical
+# network devices (nmstate tool path only). Refreshed after a successful apply.
+edpm_network_config_nmstate_device_map_file: /var/lib/edpm-config/nmstate_device_map.yaml
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"
 edpm_dns_search_domains: []
 edpm_network_config_nonconfigured_cleanup: false

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -60,6 +60,11 @@ edpm_network_config_template: ""
 # Path to nmstate device_map.yaml: name -> PCI address/driver for physical
 # network devices (nmstate tool path only). Refreshed after a successful apply.
 edpm_network_config_nmstate_device_map_file: /var/lib/edpm-config/nmstate_device_map.yaml
+# Optional: bind a kernel driver at a specific PCI address before the nmstate
+# apply (e.g. for DPDK/SR-IOV passthrough). YAML string with an "interfaces"
+# list of {name, pci_address, driver} (nmstate tool path only). See
+# roles/edpm_network_config/files/edpm_driver_bind.py for validation rules.
+edpm_network_config_driver_bind: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"
 edpm_dns_search_domains: []
 edpm_network_config_nonconfigured_cleanup: false

--- a/roles/edpm_network_config/files/edpm_driver_bind.py
+++ b/roles/edpm_network_config/files/edpm_driver_bind.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright 2026 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0
+#
+# Validate and apply edpm_network_config_driver_bind entries: for each
+# {name, pci_address, driver} tuple, confirm that "name" really identifies
+# "pci_address" (using live sysfs first, falling back to the persisted
+# nmstate device_map.yaml when the netdev is no longer present, e.g. it was
+# already unbound from the kernel network stack), then bind "driver" at
+# "pci_address" via driverctl.
+#
+# Validation runs for every entry before any binding happens, so a single
+# bad entry does not leave earlier entries half-applied.
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from typing import List, Optional
+
+try:
+    import yaml
+except ImportError as exc:
+    raise SystemExit(
+        "PyYAML is required (python3-pyyaml on RHEL-family hosts)."
+    ) from exc
+
+SYS_CLASS_NET = os.environ.get("EDPM_TEST_SYS_CLASS_NET", "/sys/class/net")
+PCI_DEVICES = os.environ.get("EDPM_TEST_PCI_DEVICES", "/sys/bus/pci/devices")
+DRIVERCTL_BIN = os.environ.get("EDPM_TEST_DRIVERCTL_BIN", "driverctl")
+CHANGED_MARKER = "edpm_driver_bind_changed="
+
+
+def _device_dir(sys_class_net: str, name: str) -> str:
+    return os.path.join(sys_class_net, name, "device")
+
+
+def _is_physical_netdev(sys_class_net: str, name: str) -> bool:
+    return os.path.isdir(_device_dir(sys_class_net, name))
+
+
+def _pci_address(sys_class_net: str, name: str) -> Optional[str]:
+    try:
+        return os.path.basename(os.readlink(_device_dir(sys_class_net, name)))
+    except OSError:
+        return None
+
+
+def _driver_for_pci(pci_devices: str, pci_address: str) -> Optional[str]:
+    driver_link = os.path.join(pci_devices, pci_address, "driver")
+    try:
+        return os.path.basename(os.readlink(driver_link))
+    except OSError:
+        return None
+
+
+def _load_yaml(path: str) -> dict:
+    if not path:
+        return {}
+    with open(path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    return data if isinstance(data, dict) else {}
+
+
+def _validate_schema(interfaces: list) -> List[str]:
+    errors = []
+    for idx, entry in enumerate(interfaces):
+        if not isinstance(entry, dict):
+            errors.append(f"interfaces[{idx}] is not a mapping")
+            continue
+        for key in ("name", "pci_address", "driver"):
+            if not entry.get(key):
+                errors.append(f"interfaces[{idx}] is missing required key '{key}'")
+    return errors
+
+
+def _validate_entry(entry: dict, sys_class_net: str, device_map: dict) -> Optional[str]:
+    name = entry["name"]
+    pci_address = entry["pci_address"]
+
+    if _is_physical_netdev(sys_class_net, name):
+        live_pci = _pci_address(sys_class_net, name)
+        if live_pci and live_pci != pci_address:
+            return (
+                f"{name}: sysfs reports PCI address {live_pci}, but pci_address "
+                f"{pci_address} was declared"
+            )
+        return None
+
+    devices = device_map.get("devices") or {}
+    mapped = devices.get(name)
+    if isinstance(mapped, dict) and mapped.get("pci") and mapped["pci"] != pci_address:
+        return (
+            f"{name}: not present in sysfs, but device_map.yaml records PCI address "
+            f"{mapped['pci']}, which does not match declared pci_address {pci_address}"
+        )
+
+    # Not in sysfs and either absent from device_map, or device_map agrees:
+    # nothing to cross-check against, proceed and trust the declared pci_address.
+    return None
+
+
+def validate_interfaces(interfaces: list, sys_class_net: str, device_map: dict) -> List[str]:
+    errors = _validate_schema(interfaces)
+    if errors:
+        return errors
+
+    for entry in interfaces:
+        error = _validate_entry(entry, sys_class_net, device_map)
+        if error:
+            errors.append(error)
+    return errors
+
+
+def bind_driver(pci_devices: str, pci_address: str, driver: str, driverctl_bin: str) -> bool:
+    if _driver_for_pci(pci_devices, pci_address) == driver:
+        return False
+    subprocess.run(
+        [driverctl_bin, "set-override", pci_address, driver],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate and apply edpm_network_config_driver_bind entries"
+    )
+    parser.add_argument(
+        "-f", "--template", required=True, help="YAML file with an 'interfaces' list"
+    )
+    parser.add_argument(
+        "-m", "--map", default="", help="nmstate device_map.yaml path (optional)"
+    )
+    parser.add_argument(
+        "--driverctl", default=DRIVERCTL_BIN, help="driverctl binary to invoke"
+    )
+    args = parser.parse_args()
+
+    state = _load_yaml(args.template)
+    interfaces = state.get("interfaces") or []
+    device_map = _load_yaml(args.map) if args.map and os.path.isfile(args.map) else {}
+
+    errors = validate_interfaces(interfaces, SYS_CLASS_NET, device_map)
+    if errors:
+        lines = "\n".join(f"  - {error}" for error in errors)
+        raise SystemExit(
+            "edpm_network_config_driver_bind validation failed:\n" + lines
+        )
+
+    changed = False
+    for entry in interfaces:
+        pci_address = entry["pci_address"]
+        driver = entry["driver"]
+        try:
+            if bind_driver(PCI_DEVICES, pci_address, driver, args.driverctl):
+                changed = True
+                print(f"Bound {pci_address} ({entry.get('name')}) to driver {driver}")
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            raise SystemExit(
+                f"driverctl set-override {pci_address} {driver} failed"
+                + (f": {stderr}" if stderr else "")
+            ) from exc
+
+    print(f"{CHANGED_MARKER}{'yes' if changed else 'no'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/roles/edpm_network_config/files/edpm_nmstate_device_map.py
+++ b/roles/edpm_network_config/files/edpm_nmstate_device_map.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright 2026 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0
+#
+# Build a simple nmstate device_map.yaml: for every physical network device
+# (i.e. a netdev backed by a real bus device, such as a PCI ethernet NIC or
+# SR-IOV VF) record its name, PCI address and currently bound kernel driver.
+#
+# Virtual netdevs (bond, bridge, dummy, vlan, veth, loopback, ...) have no
+# "device" symlink in sysfs and are skipped.
+#
+# This is intentionally minimal: no filtering/skip policy, no persistence
+# merge logic. It just answers "what physical devices does this host have,
+# and what is their current PCI/driver identity right now?".
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+
+try:
+    import yaml
+except ImportError as exc:
+    raise SystemExit(
+        "PyYAML is required (python3-pyyaml on RHEL-family hosts)."
+    ) from exc
+
+SYS_CLASS_NET = os.environ.get("EDPM_TEST_SYS_CLASS_NET", "/sys/class/net")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _device_dir(sys_class_net: str, name: str) -> str:
+    return os.path.join(sys_class_net, name, "device")
+
+
+def _is_physical_netdev(sys_class_net: str, name: str) -> bool:
+    return os.path.isdir(_device_dir(sys_class_net, name))
+
+
+def _pci_address(sys_class_net: str, name: str) -> Optional[str]:
+    try:
+        return os.path.basename(os.readlink(_device_dir(sys_class_net, name)))
+    except OSError:
+        return None
+
+
+def _driver(sys_class_net: str, name: str) -> Optional[str]:
+    driver_link = os.path.join(_device_dir(sys_class_net, name), "driver")
+    try:
+        return os.path.basename(os.readlink(driver_link))
+    except OSError:
+        return None
+
+
+def build_device_map(sys_class_net: Optional[str] = None) -> dict:
+    base = sys_class_net or SYS_CLASS_NET
+    devices: dict = {}
+
+    if os.path.isdir(base):
+        for name in sorted(os.listdir(base)):
+            if not _is_physical_netdev(base, name):
+                continue
+            devices[name] = {
+                "pci": _pci_address(base, name),
+                "driver": _driver(base, name),
+            }
+
+    return {"devices": devices, "updated": _utc_now()}
+
+
+def _dump_yaml(data: dict) -> str:
+    return yaml.safe_dump(data, default_flow_style=False, allow_unicode=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build nmstate device_map.yaml for physical network devices"
+    )
+    parser.add_argument(
+        "-o", "--output", default="", help="Write device_map YAML here (default: stdout)"
+    )
+    args = parser.parse_args()
+
+    device_map = build_device_map()
+
+    if args.output:
+        os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(_dump_yaml(device_map))
+    else:
+        sys.stdout.write(_dump_yaml(device_map))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -79,6 +79,13 @@ argument_specs:
         type: str
         description: "Which settings template should be rendered."
         default: ""
+      edpm_network_config_nmstate_device_map_file:
+        type: str
+        description: >
+          Path to nmstate device_map.yaml recording, for every physical network device
+          (PCI ethernet NIC, SR-IOV VF, etc.), its current name, PCI address and bound
+          kernel driver. Refreshed after a successful apply (nmstate tool path only).
+        default: /var/lib/edpm-config/nmstate_device_map.yaml
       edpm_bond_interface_ovs_options:
         type: str
         description: "Binding options to be rendered in a template"

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -86,6 +86,15 @@ argument_specs:
           (PCI ethernet NIC, SR-IOV VF, etc.), its current name, PCI address and bound
           kernel driver. Refreshed after a successful apply (nmstate tool path only).
         default: /var/lib/edpm-config/nmstate_device_map.yaml
+      edpm_network_config_driver_bind:
+        type: str
+        description: >
+          Optional YAML string with an "interfaces" list of {name, pci_address, driver}
+          entries. Before the nmstate apply, each entry's name/pci_address pair is
+          validated against live sysfs (falling back to device_map.yaml when the netdev
+          is no longer present); a mismatch fails the run. Once validated, the given
+          driver is bound at pci_address using driverctl (nmstate tool path only).
+        default: ""
       edpm_bond_interface_ovs_options:
         type: str
         description: "Binding options to be rendered in a template"

--- a/roles/edpm_network_config/tasks/driver_bind.yml
+++ b/roles/edpm_network_config/tasks/driver_bind.yml
@@ -1,0 +1,33 @@
+---
+# Validate and apply edpm_network_config_driver_bind: for each declared
+# {name, pci_address, driver}, confirm "name" really identifies "pci_address"
+# (live sysfs first, falling back to the persisted nmstate device_map.yaml
+# when the netdev is no longer present), then bind "driver" at "pci_address"
+# via driverctl. Runs before the main nmstate apply so devices are already
+# under their target kernel driver (or already detached from the host, e.g.
+# vfio-pci) by the time the network state is configured.
+
+- name: Ensure /var/lib/edpm-config exists
+  ansible.builtin.file:
+    path: /var/lib/edpm-config
+    state: directory
+    mode: "0755"
+
+- name: Write edpm_network_config_driver_bind template
+  ansible.builtin.copy:
+    content: "{{ edpm_network_config_driver_bind }}"
+    dest: /var/lib/edpm-config/.driver_bind_in.yaml
+    mode: "0644"
+
+- name: Validate and bind PCI drivers
+  become: true
+  ansible.builtin.command:
+    argv:
+      - python3
+      - "{{ role_path }}/files/edpm_driver_bind.py"
+      - -f
+      - /var/lib/edpm-config/.driver_bind_in.yaml
+      - -m
+      - "{{ edpm_network_config_nmstate_device_map_file }}"
+  register: edpm_driver_bind_cmd
+  changed_when: "'edpm_driver_bind_changed=yes' in edpm_driver_bind_cmd.stdout"

--- a/roles/edpm_network_config/tasks/nmstate_device_map.yml
+++ b/roles/edpm_network_config/tasks/nmstate_device_map.yml
@@ -1,0 +1,20 @@
+---
+# Build/refresh a device_map.yaml recording, for every physical network
+# device (PCI ethernet NIC, SR-IOV VF, ...), its current PCI address and
+# bound kernel driver. This is observational only: no filtering or skip
+# decisions are made here.
+
+- name: Ensure /var/lib/edpm-config exists
+  ansible.builtin.file:
+    path: /var/lib/edpm-config
+    state: directory
+    mode: "0755"
+
+- name: Generate nmstate device_map
+  ansible.builtin.command:
+    argv:
+      - python3
+      - "{{ role_path }}/files/edpm_nmstate_device_map.py"
+      - -o
+      - "{{ edpm_network_config_nmstate_device_map_file }}"
+  changed_when: false

--- a/roles/edpm_network_config/tasks/nmstate_tool.yml
+++ b/roles/edpm_network_config/tasks/nmstate_tool.yml
@@ -45,6 +45,10 @@
       register: nmstate_returncode_slurp
       when: nmstate_returncode_stat.stat.exists
 
+- name: Validate and bind PCI drivers before applying network state
+  ansible.builtin.include_tasks: driver_bind.yml
+  when: edpm_network_config_driver_bind | trim | length > 0
+
 - name: Configure network with network role from system roles [nmstate]
   become: true
   when:

--- a/roles/edpm_network_config/tasks/nmstate_tool.yml
+++ b/roles/edpm_network_config/tasks/nmstate_tool.yml
@@ -73,3 +73,6 @@
         content: "0"
         dest: /var/lib/edpm-config/nmstate.returncode
         mode: "0644"
+
+    - name: Refresh nmstate device_map (physical device PCI/driver identity)
+      ansible.builtin.include_tasks: nmstate_device_map.yml


### PR DESCRIPTION
Add edpm_network_config_driver_bind (nmstate tool path only): a YAML string with an "interfaces" list of {name, pci_address, driver} entries, applied before the main nmstate apply. This lets a deployer hand a NIC over to a driver such as vfio-pci (e.g. for DPDK/SR-IOV passthrough) as part of the same network configuration run.

For every entry, edpm_driver_bind.py first confirms that "name" really identifies "pci_address": live sysfs is checked first, falling back to the persisted nmstate_device_map.yaml when the netdev is no longer present (e.g. already unbound from the host). A mismatch in either check fails the run; if neither source has a record for "name", the declared pci_address is trusted. All entries are validated up front so one bad entry cannot leave earlier entries half-applied. Validated entries are then bound with "driverctl set-override <pci_address> <driver>", which is a no-op if that PCI address is already on the
requested driver.

Add roles/edpm_network_config/tasks/driver_bind.yml to wire the script into nmstate_tool.yml, new argument_specs/defaults for edpm_network_config_driver_bind, unit tests with a mocked sysfs tree and a fake driverctl stub, and documentation.

Assisted-by: Cursor AI