### PR TITLE
Switch container build from EL9 to EL10

### DIFF
--- a/molecule/common/Containerfile.j2
+++ b/molecule/common/Containerfile.j2
@@ -5,7 +5,7 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos9-master/current/delorean.repo && \
+RUN curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos10-master/current/delorean.repo && \
     dnf upgrade -y && \
     dnf -y install sudo python3-libselinux selinux-policy git python3-pip {{ item.pkg_extras | default('') }} && \
     git clone https://github.com/openstack-k8s-operators/repo-setup && \

--- a/openstack_ansibleee/Containerfile
+++ b/openstack_ansibleee/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as builder
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest as builder
 ARG PYV=3.12
 ARG REMOTE_SOURCE=.
 ARG REMOTE_SOURCE_DIR=/var/tmp/edpm-ansible
@@ -13,7 +13,7 @@ RUN cd $REMOTE_SOURCE_DIR/openstack_ansibleee && \
     ansible-galaxy collection install -U $REMOTE_SOURCE_DIR --collections-path "/usr/share/ansible/collections"
 
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as runner
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest as runner
 
 ARG PYV=3.12
 ARG REMOTE_SOURCE=.


### PR DESCRIPTION
Update base images to UBI10, default image tag to latest-el10, and molecule delorean repo to centos10-master as prerequisite to RHOSO19