### PR TITLE
Complete startup config YAML migration

### DIFF
--- a/plugins/modules/container_config_data.py
+++ b/plugins/modules/container_config_data.py
@@ -19,7 +19,6 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule
 
 import glob
-import json
 import os
 import yaml
 
@@ -39,19 +38,19 @@ version_added: '2.8'
 short_description: Generates a dictionary which contains all container configs
 notes: []
 description:
-  - This module reads container configs in JSON files and generate a dictionary
-    which later will be used to manage the containers.
+  - This module reads container configs in JSON or YAML files and generates a
+    dictionary which later will be used to manage the containers.
 options:
   config_path:
     description:
-      - The path of a directory or a file where the JSON files are.
+      - The path of a directory or a file where the container config files are.
         This parameter is required.
     required: True
     type: str
   config_pattern:
     description:
-      - Search pattern to find JSON files.
-    default: '*.json'
+      - Search pattern to find container config files.
+    default: '*.yml'
     required: False
     type: str
   config_overrides:
@@ -76,7 +75,7 @@ EXAMPLES = """
 - name: Generate containers configs data for HAproxy and override image
   container_config_data:
     config_path: /var/lib/edpm-config/container-startup-config/step_1
-    config_pattern: 'haproxy.json'
+    config_pattern: 'haproxy.yml'
     config_overrides:
       haproxy:
         image: my-registry.io/edpm/haproxy:mytag
@@ -113,14 +112,14 @@ class ContainerConfigDataManager(object):
         config_overrides = args['config_overrides']
         self.debug = args['debug']
 
-        # Generate dict from JSON files that match search pattern
+        # Generate dict from config files that match search pattern
         if os.path.exists(config_path):
             matched_configs = glob.glob(os.path.join(config_path,
                                                      config_pattern))
             config_dict = {}
             for mc in matched_configs:
                 name = os.path.splitext(os.path.basename(mc))[0]
-                config = json.loads(self._slurp(mc))
+                config = yaml.safe_load(self._slurp(mc))
                 if self.debug:
                     self.module.debug('Config found for {}: {}'.format(name,
                                                                        config))

--- a/plugins/modules/container_config_hash.py
+++ b/plugins/modules/container_config_hash.py
@@ -99,7 +99,7 @@ class ContainerConfigHashManager:
     the staging directory, computes hashes, and writes them into the
     '# config_hash=' comment placeholder in each file.
 
-    Container_manage path (legacy): scans JSON startup configs and updates
+    Container_manage path (legacy): scans YAML or JSON startup configs and updates
     EDPM_CONFIG_HASH in place.
     """
 
@@ -197,7 +197,7 @@ class ContainerConfigHashManager:
         if os.path.exists(path):
             os.remove(path)
 
-    def _find(self, path, pattern='*.json'):
+    def _find(self, path, pattern='*.yml'):
         """Returns a list of files in a directory.
 
         :param path: string
@@ -233,7 +233,12 @@ class ContainerConfigHashManager:
         :param config: string
         """
         with open(path, 'wb') as f:
-            f.write(json.dumps(config, indent=2).encode('utf-8'))
+            if path.endswith(('.yml', '.yaml')):
+                f.write(yaml.safe_dump(
+                    config, default_flow_style=False
+                ).encode('utf-8'))
+            else:
+                f.write(json.dumps(config, indent=2).encode('utf-8'))
         os.chmod(path, 0o600)
         self.results['changed'] = True
 
@@ -317,7 +322,9 @@ class ContainerConfigHashManager:
     def _update_hashes(self):
         """Update container startup config with new config hashes if needed.
         """
-        configs = self._find(CONTAINER_STARTUP_CONFIG)
+        configs = []
+        for pattern in ('*.yml', '*.yaml', '*.json'):
+            configs.extend(self._find(CONTAINER_STARTUP_CONFIG, pattern))
         for config in configs:
             old_config_hash = ''
             cname = os.path.splitext(os.path.basename(config))[0]
@@ -326,7 +333,7 @@ class ContainerConfigHashManager:
                 # don't exist anymore.
                 self._remove_file(config)
                 continue
-            startup_config_json = json.loads(self._slurp(config))
+            startup_config_json = yaml.safe_load(self._slurp(config))
             config_volumes = self._match_config_volumes(startup_config_json)
             if config_volumes:
                 old_config_hash = startup_config_json['environment'].get(

--- a/plugins/modules/edpm_container_manage.py
+++ b/plugins/modules/edpm_container_manage.py
@@ -41,10 +41,10 @@ module: edpm_container_manage
 author:
   - "Alex Schultz (@mwhahaha)"
 version_added: '2.9'
-short_description: Create containers from a set of json configurations
+short_description: Create containers from a set of JSON or YAML configurations
 notes: []
 description:
-  - Create containers from a set of json configurations
+  - Create containers from a set of JSON or YAML configurations
 requirements:
   - None
 options:
@@ -55,14 +55,14 @@ options:
     required: True
   config_dir:
     description:
-      - Path to the json container definitions
+      - Path to the container definitions
     type: str
     required: True
   config_patterns:
     description:
       - Glob for configuration files
     type: str
-    default: "*.json"
+    default: "*.yml"
   config_overrides:
     description:
       - Allows to override any container configuration which will take
@@ -169,7 +169,7 @@ class EdpmContainerManage:
                     self.module.debug(f'Skipping {name} - not in containers list')
                 continue
             with open(match, 'r') as data:
-                config = json.loads(data.read())
+                config = yaml.safe_load(data.read())
             if self.debug:
                 self.module.debug(f'Config found for {name}: {config}')
             configs.update({name: config})

--- a/roles/edpm_cleanup/meta/argument_specs.yml
+++ b/roles/edpm_cleanup/meta/argument_specs.yml
@@ -40,7 +40,7 @@ argument_specs:
         description: |
           Remove container startup config directories during cleanup.
           Deletes /var/lib/edpm-config/container-startup-config/<service>/
-          including all *.json container definition files within it.
+          including any legacy *.json and current *.yml container definition files within it.
         type: bool
       edpm_cleanup_orphaned_containers:
         default: false

--- a/roles/edpm_cleanup/molecule/default/verify.yml
+++ b/roles/edpm_cleanup/molecule/default/verify.yml
@@ -109,7 +109,7 @@
 
     - name: Check if startup config for container_b exists
       ansible.builtin.stat:
-        path: /var/lib/edpm-config/container-startup-config/test_service3/test_service3_container_b.json
+        path: /var/lib/edpm-config/container-startup-config/test_service3/test_service3_container_b.yml
       register: _container_b_startup_config
 
     - name: Verify startup config for container_b does not exist

--- a/roles/edpm_cleanup/tasks/cleanup_services.yml
+++ b/roles/edpm_cleanup/tasks/cleanup_services.yml
@@ -139,7 +139,9 @@
     - name: Find startup config files for orphaned containers
       ansible.builtin.find:
         paths: "{{ edpm_container_startup_config_dir }}"
-        patterns: "{{ item }}.json"
+        patterns:
+          - "{{ item }}.yml"
+          - "{{ item }}.json"
         recurse: true
       loop: "{{ _edpm_orphaned_containers }}"
       register: _edpm_orphaned_startup_configs

--- a/roles/edpm_cleanup/tasks/cleanup_single_service.yml
+++ b/roles/edpm_cleanup/tasks/cleanup_single_service.yml
@@ -37,13 +37,13 @@
     - item['Config']['Labels']['managed_by'] is defined
     - item['Config']['Labels']['managed_by'] == 'edpm_ansible'
 
-- name: Remove container startup config directory and all JSON files
+- name: Remove container startup config directory and all startup files
   ansible.builtin.file:
     path: "{{ edpm_container_startup_config_dir }}/{{ _edpm_cleanup_service_name }}"
     state: absent
   when: edpm_cleanup_remove_config_dirs | bool
   # This removes /var/lib/edpm-config/container-startup-config/<service>/
-  # including all *.json container definition files within it
+  # including any legacy *.json and current *.yml container definition files within it
 
 - name: Remove container-scoped startup config directories
   ansible.builtin.file:

--- a/roles/edpm_container_manage/defaults/main.yml
+++ b/roles/edpm_container_manage/defaults/main.yml
@@ -29,7 +29,7 @@ edpm_container_manage_concurrency: 1
 edpm_container_manage_config: "/var/lib/edpm-config/"
 edpm_container_manage_config_id: edpm
 edpm_container_manage_config_overrides: {}
-edpm_container_manage_config_patterns: '*.json'
+edpm_container_manage_config_patterns: '*.yml'
 edpm_container_manage_containers: []  # If set, only manage these specific containers
 edpm_container_manage_healthcheck_disabled: false
 edpm_container_manage_log_path: '/var/log/containers/stdouts'  # DEPRECATED: ignored, services log to journald

--- a/roles/edpm_container_manage/meta/argument_specs.yml
+++ b/roles/edpm_container_manage/meta/argument_specs.yml
@@ -34,7 +34,7 @@ argument_specs:
         default: {}
       edpm_container_manage_config_patterns:
         type: str
-        default: '*.json'
+        default: '*.yml'
       edpm_container_manage_containers:
         type: list
         elements: str

--- a/roles/edpm_container_manage/molecule/default/converge.yml
+++ b/roles/edpm_container_manage/molecule/default/converge.yml
@@ -20,7 +20,7 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_config_patterns: '*.json'
+    edpm_container_manage_config_patterns: '*.yml'
   tasks:
     - include_role:
         name: osp.edpm.edpm_container_manage
@@ -85,7 +85,7 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_config_patterns: '*.json'
+    edpm_container_manage_config_patterns: '*.yml'
   tasks:
     - name: Gather facts about centos container before new run
       containers.podman.podman_container_info:
@@ -117,7 +117,7 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_config_patterns: '*.json'
+    edpm_container_manage_config_patterns: '*.yml'
   tasks:
     - name: Stop systemd service for edpm_centos in a manual stop
       systemd:
@@ -148,7 +148,7 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_config_patterns: 'centos.json'
+    edpm_container_manage_config_patterns: 'centos.yml'
     edpm_container_manage_clean_orphans: false
     edpm_container_manage_config_overrides:
       centos:
@@ -193,7 +193,7 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_config_patterns: 'centos.json'
+    edpm_container_manage_config_patterns: 'centos.yml'
     edpm_container_manage_clean_orphans: false
   tasks:
     - include_role:
@@ -229,11 +229,11 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_config_patterns: 'centos_*.json'
+    edpm_container_manage_config_patterns: 'centos_*.yml'
   tasks:
     - name: Remove centos container config
       file:
-        path: '/tmp/container-configs/centos.json'
+        path: '/tmp/container-configs/centos.yml'
         state: absent
     - include_role:
         name: osp.edpm.edpm_container_manage
@@ -261,17 +261,15 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_config_patterns: 'centos_*.json'
+    edpm_container_manage_config_patterns: 'centos_*.yml'
   tasks:
     - name: Modify the centos_bis container config
       copy:
         content: |
-          {
-            "image": "quay.io/centos/centos:stream9",
-            "net": "host",
-            "command": "sleep 10"
-          }
-        dest: '/tmp/container-configs/centos_bis.json'
+          image: quay.io/centos/centos:stream9
+          net: host
+          command: sleep 10
+        dest: '/tmp/container-configs/centos_bis.yml'
     - include_role:
         name: osp.edpm.edpm_container_manage
   post_tasks:
@@ -302,7 +300,7 @@
   gather_facts: false
   vars:
     edpm_container_manage_config: '/tmp/container-configs'
-    edpm_container_manage_config_patterns: 'centos_*.json'
+    edpm_container_manage_config_patterns: 'centos_*.yml'
     edpm_container_manage_config_overrides:
       centos_bis:
         image: centos:stream9

--- a/roles/edpm_container_manage/molecule/default/prepare.yml
+++ b/roles/edpm_container_manage/molecule/default/prepare.yml
@@ -35,32 +35,26 @@
       # ipc mode added as WA for podman 4.1.x
       copy:
         content: |
-          {
-            "image": "quay.io/centos/centos:stream9",
-            "net": "host",
-            "ipc": "shareable",
-            "command": "sleep 3600",
-            "restart": "always",
-            "check_interval": "500s"
-          }
-        dest: '/tmp/container-configs/centos.json'
+          image: quay.io/centos/centos:stream9
+          net: host
+          ipc: shareable
+          command: sleep 3600
+          restart: always
+          check_interval: 500s
+        dest: '/tmp/container-configs/centos.yml'
     - name: Create a secondary configuration file for a centos container
       copy:
         content: |
-          {
-            "image": "quay.io/centos/centos:stream9",
-            "net": "host",
-            "ipc": "shareable",
-            "command": "sleep 5"
-          }
-        dest: '/tmp/container-configs/centos_bis.json'
+          image: quay.io/centos/centos:stream9
+          net: host
+          ipc: shareable
+          command: sleep 5
+        dest: '/tmp/container-configs/centos_bis.yml'
     - name: Create a third configuration file for a centos container
       copy:
         content: |
-          {
-            "image": "quay.io/centos/centos:stream9",
-            "net": "host",
-            "ipc": "shareable",
-            "command": "sleep 5"
-          }
-        dest: '/tmp/container-configs/centos_three.json'
+          image: quay.io/centos/centos:stream9
+          net: host
+          ipc: shareable
+          command: sleep 5
+        dest: '/tmp/container-configs/centos_three.yml'

--- a/roles/edpm_container_standalone/tasks/main.yml
+++ b/roles/edpm_container_standalone/tasks/main.yml
@@ -60,8 +60,8 @@
 
     - name: "Render container definitions: [{{ edpm_container_standalone_service }} ]"
       ansible.builtin.copy:
-        content: "{{ item.value | to_nice_json }}"
-        dest: "{{ edpm_container_startup_config_dir }}/{{ edpm_container_standalone_service }}/{{ item.key }}.json"
+        content: "{{ item.value | to_nice_yaml }}"
+        dest: "{{ edpm_container_startup_config_dir }}/{{ edpm_container_standalone_service }}/{{ item.key }}.yml"
         mode: "0644"
       # NOTE(tkajinam): Some containers can contain secrets in their environments. Hide the output to avoid dumping these to output.
       no_log: true
@@ -72,7 +72,7 @@
         name: edpm_container_manage
       vars:
         edpm_container_manage_config: "{{ edpm_container_startup_config_dir }}/{{ edpm_container_standalone_service }}"
-        edpm_container_manage_config_patterns: "*.json"
+        edpm_container_manage_config_patterns: "*.yml"
         edpm_container_manage_config_id: "{{ edpm_container_standalone_service }}"
         edpm_container_manage_containers: "{{ edpm_container_standalone_container_defs.keys() | list }}"
         # Disable deprecated orphan cleanup - use edpm_cleanup role instead

--- a/roles/edpm_telemetry/tasks/update.yml
+++ b/roles/edpm_telemetry/tasks/update.yml
@@ -69,8 +69,8 @@
 
 - name: Check for openstack_network_exporter config
   ansible.builtin.stat:
-    path: "{{ edpm_telemetry_config_dest }}/openstack_network_exporter.json"
-  register: openstack_network_exporter_config_json
+    path: "{{ edpm_telemetry_config_dest }}/openstack_network_exporter.yaml"
+  register: openstack_network_exporter_config_yaml
 
 - name: Check that tls.crt exists
   become: true
@@ -91,7 +91,7 @@
     - telemetry
 
 - name: Install openstack_network_operator if not present
-  when: not openstack_network_exporter_config_json.stat.exists
+  when: not openstack_network_exporter_config_yaml.stat.exists
   become: true
   block:
     - name: Determine if cacert file exists


### PR DESCRIPTION
Switch startup config generation, discovery, and verification from JSON filenames to YAML so migrated services use a consistent on-disk format. Update the container config readers to accept YAML while keeping intentional Kolla JSON handling unchanged.

jira: [OSPRH-33727](https://redhat.atlassian.net/browse/OSPRH-33727)