### PR TITLE
Bind telemetry exporters to ctlplane IP instead of host network

### DIFF
--- a/roles/edpm_telemetry/molecule/default/molecule.yml
+++ b/roles/edpm_telemetry/molecule/default/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
         hosts:
           instance:
             canonical_hostname: edpm-0.localdomain
+            ctlplane_ip: 127.0.0.1
 scenario:
   test_sequence:
   - dependency

--- a/roles/edpm_telemetry/templates/quadlet/ceilometer_agent_compute.container.j2
+++ b/roles/edpm_telemetry/templates/quadlet/ceilometer_agent_compute.container.j2
@@ -20,7 +20,7 @@ Description=Ceilometer Agent Compute container (EDPM)
 [Container]
 ContainerName=ceilometer_agent_compute
 Image={{ edpm_telemetry_ceilometer_compute_image }}
-Network=host
+PublishPort={{ ctlplane_ip }}:9101:9101
 User=ceilometer
 PodmanArgs=--security-opt label=type:ceilometer_polling_t --log-driver=journald
 {% if edpm_telemetry_healthcheck -%}

--- a/roles/edpm_telemetry/templates/quadlet/node_exporter.container.j2
+++ b/roles/edpm_telemetry/templates/quadlet/node_exporter.container.j2
@@ -16,7 +16,7 @@ Description=Node Exporter container (EDPM)
 [Container]
 ContainerName=node_exporter
 Image={{ edpm_telemetry_node_exporter_image }}
-Network=host
+PublishPort={{ ctlplane_ip }}:9100:9100
 User=root
 PodmanArgs=--privileged --log-driver=journald
 {% if edpm_telemetry_healthcheck -%}

--- a/roles/edpm_telemetry/templates/quadlet/openstack_network_exporter.container.j2
+++ b/roles/edpm_telemetry/templates/quadlet/openstack_network_exporter.container.j2
@@ -20,7 +20,7 @@ Description=OpenStack Network Exporter container (EDPM)
 [Container]
 ContainerName=openstack_network_exporter
 Image={{ edpm_telemetry_openstack_network_exporter_image }}
-Network=host
+PublishPort={{ ctlplane_ip }}:9105:9105
 PodmanArgs=--privileged --log-driver=journald
 {% if edpm_telemetry_healthcheck -%}
 PodmanArgs=--health-cmd="/openstack/healthcheck openstack-netwo"

--- a/roles/edpm_telemetry/templates/quadlet/podman_exporter.container.j2
+++ b/roles/edpm_telemetry/templates/quadlet/podman_exporter.container.j2
@@ -16,7 +16,7 @@ Description=Podman Exporter container (EDPM)
 [Container]
 ContainerName=podman_exporter
 Image={{ edpm_telemetry_podman_exporter_image }}
-Network=host
+PublishPort={{ ctlplane_ip }}:9882:9882
 User=root
 PodmanArgs=--privileged --log-driver=journald
 {% if edpm_telemetry_healthcheck -%}


### PR DESCRIPTION
Replace Network=host with explicit PublishPort directives bound to the control plane IP address in all telemetry exporter quadlets:

  - ceilometer_agent_compute: {{ ctlplane_ip }}:9101:9101
  - node_exporter:            {{ ctlplane_ip }}:9100:9100
  - podman_exporter:          {{ ctlplane_ip }}:9882:9882
  - openstack_network_exporter: {{ ctlplane_ip }}:9105:9105

Using the new PublishPort directives ensures the exporters serve metrics only on the control plane network.

The molecule test inventory is updated to supply a ctlplane_ip value so the quadlet templates render correctly during CI.

Generated-by: Claude-Code claude-opus-4-6