### PR TITLE
[18-stable] Bind telemetry exporters to ctlplane IP instead of host network

### DIFF
--- a/roles/edpm_telemetry/molecule/default/molecule.yml
+++ b/roles/edpm_telemetry/molecule/default/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
         hosts:
           instance:
             canonical_hostname: edpm-0.localdomain
+            ctlplane_ip: 127.0.0.1
 scenario:
   test_sequence:
   - dependency

--- a/roles/edpm_telemetry/templates/container_defs/ceilometer_agent_compute.yaml.j2
+++ b/roles/edpm_telemetry/templates/container_defs/ceilometer_agent_compute.yaml.j2
@@ -3,7 +3,8 @@ user: ceilometer
 restart: always
 command: kolla_start
 security_opt: label:type:ceilometer_polling_t
-net: host
+ports:
+  - "{{ ctlplane_ip }}:9101:9101"
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS
   OS_ENDPOINT_TYPE: internal

--- a/roles/edpm_telemetry/templates/container_defs/node_exporter.yaml.j2
+++ b/roles/edpm_telemetry/templates/container_defs/node_exporter.yaml.j2
@@ -4,7 +4,7 @@ recreate: true
 user: root
 privileged: true
 ports:
-  - "9100:9100"
+  - "{{ ctlplane_ip }}:9100:9100"
 command:
 {% if tls_cert_exists|bool %}
   - --web.config.file=/etc/node_exporter/node_exporter.yaml
@@ -14,7 +14,6 @@ command:
 {% for arg in edpm_telemetry_node_exporter_extra_args %}
   - {{ arg }}
 {% endfor %}
-net: host
 environment:
   OS_ENDPOINT_TYPE: internal
 {% if edpm_telemetry_healthcheck %}

--- a/roles/edpm_telemetry/templates/container_defs/openstack_network_exporter.yaml.j2
+++ b/roles/edpm_telemetry/templates/container_defs/openstack_network_exporter.yaml.j2
@@ -3,9 +3,8 @@ restart: always
 recreate: true
 privileged: true
 ports:
-  - "9105:9105"
+  - "{{ ctlplane_ip }}:9105:9105"
 command: []
-net: host
 environment:
   OS_ENDPOINT_TYPE: internal
   OPENSTACK_NETWORK_EXPORTER_YAML: /etc/openstack_network_exporter/openstack_network_exporter.yaml

--- a/roles/edpm_telemetry/templates/container_defs/podman_exporter.yaml.j2
+++ b/roles/edpm_telemetry/templates/container_defs/podman_exporter.yaml.j2
@@ -4,8 +4,7 @@ recreate: true
 user: root
 privileged: true
 ports:
-  - "9882:9882"
-net: host
+  - "{{ ctlplane_ip }}:9882:9882"
 {% if tls_cert_exists|bool %}
 command:
   - --web.config.file=/etc/podman_exporter/podman_exporter.yaml

--- a/roles/edpm_telemetry_power_monitoring/templates/container_defs/ceilometer_agent_ipmi.yaml.j2
+++ b/roles/edpm_telemetry_power_monitoring/templates/container_defs/ceilometer_agent_ipmi.yaml.j2
@@ -4,7 +4,8 @@ restart: always
 command: kolla_start
 security_opt: label:type:ceilometer_polling_t
 privileged: true
-net: host
+ports:
+  - "{{ ctlplane_ip }}:9102:9102"
 environment:
   KOLLA_CONFIG_STRATEGY: COPY_ALWAYS
   OS_ENDPOINT_TYPE: internal


### PR DESCRIPTION
Replace net: host with explicit port bindings bound to the control plane IP address in all telemetry exporter container definitions:

  - ceilometer_agent_compute: {{ ctlplane_ip }}:9101:9101
  - node_exporter:            {{ ctlplane_ip }}:9100:9100
  - podman_exporter:          {{ ctlplane_ip }}:9882:9882
  - openstack_network_exporter: {{ ctlplane_ip }}:9105:9105
  - ceilometer_agent_ipmi:    {{ ctlplane_ip }}:9102:9102

Using the new port directives ensures the exporters serve metrics only on the control plane network.

Similar to https://github.com/openstack-k8s-operators/edpm-ansible/pull/1239, which couldn't be cherry-picked directly due to the recent quadlet rewrite on main, which isn't planed to be included in 18.

Generated-by: Claude-Code claude-opus-4-6