### PR TITLE
Fix: migrate ovn to quadlet minor update

### DIFF
--- a/roles/edpm_ovn/tasks/update.yml
+++ b/roles/edpm_ovn/tasks/update.yml
@@ -1,0 +1,15 @@
+---
+# Remove old container_manage units from /etc/systemd/system/ so they don't
+# shadow Quadlet-generated units in /run/systemd/generator/ (systemd precedence).
+# No daemon_reload here — quadlet.yml's daemon_reload picks up both changes at once.
+- name: Remove legacy container_manage units that shadow Quadlet
+  tags:
+    - upgrade  # to be removed when upgrade tasks handle this
+    - update
+    - ovn
+  become: true
+  ansible.builtin.file:
+    path: "/etc/systemd/system/edpm_{{ item }}.service"
+    state: absent
+  loop:
+    - ovn_controller

--- a/roles/edpm_update_services/tasks/containers.yml
+++ b/roles/edpm_update_services/tasks/containers.yml
@@ -22,6 +22,17 @@
   # iscsid is part of the "nova" EDPM service
   when: '"nova" in edpm_update_services_running_services'
 
+- name: Apply updates for edpm_ovn role
+  ansible.builtin.include_role:
+    name: osp.edpm.edpm_ovn
+    tasks_from: update.yml
+    apply:
+      become: true
+  tags:
+    - edpm_ovn
+    - edpm_update_services
+  when: '"ovn" in edpm_update_services_running_services'
+
 - name: Updates containers for edpm_ovn role
   ansible.builtin.include_role:
     name: osp.edpm.edpm_ovn


### PR DESCRIPTION
Since we want to merge changes to Quadlet and CI works for the ovn change, but that is still running legacy container/systemd services. It was not caught in the CI because there is no config change for ovn_controller and previous .service unit under /etc/systemd/system/edpm_ovn_controller.service win in precedence over quadlet generated .service file under /run/systemd/generator/edpm_ovn_controller.service and restarted again without any issue.

These changes will make sure the new quadlet container are running and not the legacy container