### PR TITLE
Add infra.leapp collection to ansibleee requirements

### DIFF
--- a/openstack_ansibleee/ansibleee-requirements.yaml
+++ b/openstack_ansibleee/ansibleee-requirements.yaml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: fedora.linux_system_roles
+  - name: infra.leapp


### PR DESCRIPTION
infra.leapp collection is a collection for RHEL Upgrade. This patch adds infra.leapp collection instead of writing own role from scratch

Jira: [OSPRH-31558](https://redhat.atlassian.net/browse/OSPRH-31558)

[1] https://github.com/redhat-cop/infra.leapp