### PR TITLE
Bind ceilometer_ipmi to ctlplane IP instead of host network

### DIFF
--- a/roles/edpm_telemetry_power_monitoring/molecule/default/molecule.yml
+++ b/roles/edpm_telemetry_power_monitoring/molecule/default/molecule.yml
@@ -36,7 +36,7 @@ provisioner:
       all:
         hosts:
           compute-1:
-            ctlplane_ip: 10.0.0.3
+            ctlplane_ip: 127.0.0.1
             canonical_hostname: edpm-0.localdomain
 scenario:
   test_sequence:

--- a/roles/edpm_telemetry_power_monitoring/templates/quadlet/ceilometer_agent_ipmi.container.j2
+++ b/roles/edpm_telemetry_power_monitoring/templates/quadlet/ceilometer_agent_ipmi.container.j2
@@ -20,7 +20,7 @@ Description=Ceilometer Agent IPMI container (EDPM)
 [Container]
 ContainerName=ceilometer_agent_ipmi
 Image={{ edpm_telemetry_ceilometer_ipmi_image }}
-Network=host
+PublishPort={{ ctlplane_ip }}:9102:9102
 User=ceilometer
 PodmanArgs=--privileged --security-opt label=type:ceilometer_polling_t --log-driver=journald
 {% if edpm_telemetry_power_monitoring_healthcheck -%}


### PR DESCRIPTION
Replace Network=host with explicit PublishPort directive bound to the control plane IP for ceilometer ipmi agent.

Using the new PublishPort directive ensures the exporter serves metrics only on the control plane network.

The molecule test inventory is updated to supply a ctlplane_ip on localhost so that the quadlet template renders correctly and we have an IP that actually works with the PublishPort in CI.