### PR TITLE
Fix edpm_bootstrap failed_when logic that silently ignores failures

### DIFF
--- a/roles/edpm_bootstrap/molecule/default/verify.yml
+++ b/roles/edpm_bootstrap/molecule/default/verify.yml
@@ -15,3 +15,15 @@
         path: "{{ edpm_bootstrap_lvm_devices_file }}"
       register: lvm_devices_stat
       failed_when: not lvm_devices_stat.stat.exists
+
+    - name: Verify bootstrap packages are installed
+      ansible.builtin.command: "rpm -q {{ edpm_bootstrap_packages_bootstrap | join(' ') }}"
+      register: rpm_query_result
+      failed_when: rpm_query_result.rc != 0
+      changed_when: false
+
+    - name: Verify bootstrap packages pass rpm verification
+      ansible.builtin.command: "rpm -V {{ edpm_bootstrap_packages_bootstrap | join(' ') }}"
+      register: rpm_verify_result
+      failed_when: rpm_verify_result.rc != 0
+      changed_when: false

--- a/roles/edpm_bootstrap/tasks/packages.yml
+++ b/roles/edpm_bootstrap/tasks/packages.yml
@@ -46,9 +46,8 @@
     name: "{{ edpm_bootstrap_packages_bootstrap }}"
     state: present
   failed_when:
-    - (ansible_facts['distribution'] | lower) == 'redhat'
     - not ansible_check_mode | bool
-    - (edpm_bootstrap_packages_bootstrap_result.rc | int) == 1
+    - edpm_bootstrap_packages_bootstrap_result.rc != 0
   register: edpm_bootstrap_packages_bootstrap_result
   until: edpm_bootstrap_packages_bootstrap_result is succeeded
   retries: "{{ edpm_bootstrap_download_retries }}"
@@ -56,9 +55,9 @@
   become: true
 
 - name: Ensure packages are actually well installed
-  ansible.builtin.command: "rpm -V {{ edpm_bootstrap_packages_bootstrap | join(' ') }}"  # noqa: command-instead-of-module
+  ansible.builtin.command: "rpm -V --noconfig {{ edpm_bootstrap_packages_bootstrap | join(' ') }}"  # noqa: command-instead-of-module
   register: rpm_verify_result
   failed_when:
-    - "'%verify' in rpm_verify_result.stderr"
+    - rpm_verify_result.rc != 0
   changed_when: false
   become: true


### PR DESCRIPTION
The install task's failed_when used AND-ed conditions that prevented
failure detection on CentOS Stream 9 and ignored return codes other
than 1. The rpm verify task checked stderr for a string that rpm -V
never outputs. Both bugs allowed EDPM nodes to silently end up in a
broken state during deployment.

Jira: [OSPRH-33601](https://redhat.atlassian.net/browse/OSPRH-33601)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
