### PR TITLE
Add post-quantum SSH key exchange crypto-policy toggle

### DIFF
--- a/roles/edpm_bootstrap/defaults/main.yml
+++ b/roles/edpm_bootstrap/defaults/main.yml
@@ -95,6 +95,10 @@ edpm_bootstrap_fips_fms_status:
   - {exit_code: 1, state: 'inconsistent', message: 'FIPS setup is inconsistent'}
   - {exit_code: 2, state: 'disabled', message: 'FIPS is disabled'}
 
+# Enable sntrup761 post-quantum SSH key exchange via a crypto-policies
+# subpolicy. No-op on FIPS nodes.
+edpm_bootstrap_pq_crypto_policy: false
+
 # Full path name of LVM's default "devicesfile" (see /etc/lvm/lvm.conf)
 edpm_bootstrap_lvm_devices_file: /etc/lvm/devices/system.devices
 

--- a/roles/edpm_bootstrap/handlers/main.yml
+++ b/roles/edpm_bootstrap/handlers/main.yml
@@ -23,3 +23,15 @@
   changed_when: _trust_cmd.rc == 0
   failed_when: _trust_cmd.rc != 0
   listen: "update-ca-trust"
+
+# Reload, not restart, to avoid dropping the Ansible SSH connection.
+- name: Reload sshd to apply crypto-policy
+  become: true
+  ansible.builtin.systemd_service:
+    name: sshd
+    state: reloaded
+  listen: "reload sshd for crypto-policy"
+  when:
+    - ansible_facts.services is defined
+    - "'sshd.service' in ansible_facts.services"
+    - ansible_facts.services['sshd.service'].state == 'running'

--- a/roles/edpm_bootstrap/meta/argument_specs.yml
+++ b/roles/edpm_bootstrap/meta/argument_specs.yml
@@ -113,6 +113,14 @@ argument_specs:
         description: |
           Path of the reboot_required folder used by `edpm_reboot` role
 
+      edpm_bootstrap_pq_crypto_policy:
+        type: bool
+        default: false
+        description: |
+          When true, enable the sntrup761 post-quantum SSH key exchange via a
+          crypto-policies subpolicy composed onto the current base policy.
+          Skipped on FIPS nodes.
+
       edpm_bootstrap_lvm_devices_file:
         type: path
         default: /etc/lvm/devices/system.devices

--- a/roles/edpm_bootstrap/molecule/default/converge.yml
+++ b/roles/edpm_bootstrap/molecule/default/converge.yml
@@ -21,3 +21,4 @@
         edpm_bootstrap_command: |
           touch /tmp/edpm_bootstrap_command
           ls -l /tmp
+        edpm_bootstrap_pq_crypto_policy: true

--- a/roles/edpm_bootstrap/molecule/default/molecule.yml
+++ b/roles/edpm_bootstrap/molecule/default/molecule.yml
@@ -38,6 +38,7 @@ scenario:
   test_sequence:
   - prepare
   - converge
+  - verify
   - check
 verifier:
-  name: testinfra
+  name: ansible

--- a/roles/edpm_bootstrap/molecule/default/verify.yml
+++ b/roles/edpm_bootstrap/molecule/default/verify.yml
@@ -2,6 +2,8 @@
 
 - name: Verify
   hosts: all
+  vars_files:
+    - ../../defaults/main.yml
   tasks:
 
     - name: Verify bootstrap command created expected file
@@ -11,8 +13,10 @@
       failed_when: not bootstrap_stat.stat.exists
 
     - name: Verify the LVM devices file exists
-      stat:
+      become: true
+      ansible.builtin.stat:
         path: "{{ edpm_bootstrap_lvm_devices_file }}"
+        get_checksum: false
       register: lvm_devices_stat
       failed_when: not lvm_devices_stat.stat.exists
 
@@ -22,8 +26,26 @@
       failed_when: rpm_query_result.rc != 0
       changed_when: false
 
-    - name: Verify bootstrap packages pass rpm verification
-      ansible.builtin.command: "rpm -V {{ edpm_bootstrap_packages_bootstrap | join(' ') }}"
-      register: rpm_verify_result
-      failed_when: rpm_verify_result.rc != 0
+    - name: Verify the SNTRUP subpolicy module was deployed
+      ansible.builtin.stat:
+        path: /etc/crypto-policies/policies/modules/SNTRUP.pmod
+      register: pq_pmod_stat
+      failed_when: not pq_pmod_stat.stat.exists
+
+    - name: Get the active crypto-policy
+      ansible.builtin.command: update-crypto-policies --show
+      register: pq_active_policy
+      changed_when: false
+
+    - name: Verify the SNTRUP subpolicy is active
+      ansible.builtin.assert:
+        that:
+          - "'SNTRUP' in (pq_active_policy.stdout | trim).split(':')"
+        fail_msg: "Active crypto-policy '{{ pq_active_policy.stdout | trim }}' does not include the SNTRUP subpolicy"
+
+    - name: Verify sshd back-end offers the sntrup761 PQ key exchange
+      ansible.builtin.command: >-
+        grep -q sntrup761 /etc/crypto-policies/back-ends/opensshserver.config
+      register: pq_sshd_backend
+      failed_when: pq_sshd_backend.rc != 0
       changed_when: false

--- a/roles/edpm_bootstrap/tasks/bootstrap.yml
+++ b/roles/edpm_bootstrap/tasks/bootstrap.yml
@@ -129,5 +129,9 @@
   ansible.builtin.import_tasks: fips.yml
   when: edpm_bootstrap_fips_mode != 'check'
 
+- name: PQ crypto-policy tasks
+  ansible.builtin.import_tasks: pq_crypto_policy.yml
+  when: edpm_bootstrap_pq_crypto_policy | bool
+
 - name: LVM tasks
   ansible.builtin.import_tasks: lvm.yml

--- a/roles/edpm_bootstrap/tasks/pq_crypto_policy.yml
+++ b/roles/edpm_bootstrap/tasks/pq_crypto_policy.yml
@@ -1,0 +1,68 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# sshd_config left untouched: an explicit KexAlgorithms would override the
+# system crypto-policy.
+
+- name: Check whether FIPS mode is enabled
+  become: true
+  ansible.builtin.slurp:
+    src: /proc/sys/crypto/fips_enabled
+  register: _edpm_bootstrap_fips_enabled
+  failed_when: false
+
+- name: Skip PQ crypto-policy on FIPS-enabled nodes
+  ansible.builtin.debug:
+    msg: >-
+      FIPS is enabled; skipping PQ crypto-policy. sntrup761 is not FIPS-approved
+      and switching the base policy would break FIPS compliance.
+  when: >-
+    (_edpm_bootstrap_fips_enabled.content | default('') | b64decode | trim) == '1'
+
+- name: Enable the sntrup761 post-quantum SSH key exchange
+  when: >-
+    (_edpm_bootstrap_fips_enabled.content | default('') | b64decode | trim) != '1'
+  block:
+    - name: Deploy the SNTRUP crypto-policies subpolicy module
+      become: true
+      ansible.builtin.copy:
+        dest: /etc/crypto-policies/policies/modules/SNTRUP.pmod
+        content: "key_exchange = +SNTRUP\n"
+        owner: root
+        group: root
+        mode: "0644"
+      register: _edpm_bootstrap_pq_pmod
+
+    - name: Get the currently active crypto-policy
+      become: true
+      ansible.builtin.command: update-crypto-policies --show
+      register: _edpm_bootstrap_crypto_policy_active
+      changed_when: false
+      check_mode: false
+
+    # Compose onto current policy to keep the base + existing subpolicies;
+    # unique prevents re-appending SNTRUP (DEFAULT:SNTRUP:SNTRUP) on re-run.
+    - name: Activate the SNTRUP subpolicy on the current base policy
+      become: true
+      ansible.builtin.command: >-
+        update-crypto-policies --set
+        {{ ((_edpm_bootstrap_crypto_policy_active.stdout | trim).split(':') + ['SNTRUP']) | unique | join(':') }}
+      register: _edpm_bootstrap_crypto_policy_set
+      changed_when: _edpm_bootstrap_crypto_policy_set.rc == 0
+      when: >-
+        _edpm_bootstrap_pq_pmod is changed or
+        'SNTRUP' not in (_edpm_bootstrap_crypto_policy_active.stdout | trim).split(':')
+      notify: "reload sshd for crypto-policy"


### PR DESCRIPTION
Adds an edpm_bootstrap_pq_crypto_policy toggle (default false) that enables the sntrup761x25519-sha512 hybrid post-quantum SSH key exchange through the system crypto-policy, mitigating harvest-now-decrypt-later attacks.

jira: [OSPRH-29034](https://redhat.atlassian.net/browse/OSPRH-29034)