### PR TITLE
Remove kolla dependency from ovn_controller

### DIFF
--- a/roles/edpm_ovn/defaults/main.yml
+++ b/roles/edpm_ovn/defaults/main.yml
@@ -60,7 +60,6 @@ edpm_ovn_controller_common_volumes:
   - /lib/modules:/lib/modules:ro
   - /run:/run
   - /var/lib/openvswitch/ovn:/run/ovn:shared,z
-  - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
 
 edpm_ovn_controller_tls_cacert_bundle_src: "/var/lib/openstack/cacerts/{{ edpm_ovn_service_name }}/tls-ca-bundle.pem"
 edpm_ovn_controller_tls_cacert_bundle_dest: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"

--- a/roles/edpm_ovn/meta/argument_specs.yml
+++ b/roles/edpm_ovn/meta/argument_specs.yml
@@ -81,7 +81,6 @@ argument_specs:
           - /lib/modules:/lib/modules:ro
           - /run:/run
           - /var/lib/openvswitch/ovn:/run/ovn:shared,z
-          - /var/lib/kolla/config_files/ovn_controller.json:/var/lib/kolla/config_files/config.json:ro
         description: List of volumes in a mount point form.
         type: list
       edpm_ovn_controller_tls_volumes:

--- a/roles/edpm_ovn/molecule/default/verify-quadlet.yml
+++ b/roles/edpm_ovn/molecule/default/verify-quadlet.yml
@@ -44,7 +44,9 @@
       - "'ContainerName=ovn_controller' in _quadlet_text"
       - "'Network=host' in _quadlet_text"
       - "'PodmanArgs=--privileged' in _quadlet_text"
-      - "'Environment=KOLLA_CONFIG_STRATEGY=COPY_ALWAYS' in _quadlet_text"
+      - "'Exec=/usr/bin/ovn-controller' in _quadlet_text"
+      - "_quadlet_text is not regex('Exec=.*Volume=')"
+      - "'KOLLA_CONFIG_STRATEGY' not in _quadlet_text"
       - "'[Service]' in _quadlet_text"
       - "'Restart=always' in _quadlet_text"
       - "'[Install]' in _quadlet_text"
@@ -70,17 +72,17 @@
       - _staged_file.stat.exists
     fail_msg: "Staged .container file was not created in rendering directory"
 
-- name: Verify kolla config file deployed
+- name: Verify kolla config file is NOT deployed
   become: true
   ansible.builtin.stat:
     path: /var/lib/kolla/config_files/ovn_controller.json
   register: _kolla_config
 
-- name: Assert kolla config exists
+- name: Assert kolla config does not exist (kolla dependency removed)
   ansible.builtin.assert:
     that:
-      - _kolla_config.stat.exists
-    fail_msg: "Kolla config JSON was not deployed"
+      - not _kolla_config.stat.exists
+    fail_msg: "Kolla config JSON should not be generated after kolla removal"
 
 - name: Verify healthcheck script deployed
   become: true

--- a/roles/edpm_ovn/molecule/resource_providers/verify.yml
+++ b/roles/edpm_ovn/molecule/resource_providers/verify.yml
@@ -27,15 +27,22 @@
           - "'br-storage::' in cms_options_output.stdout"            # Empty config
         fail_msg: "resource_provider_bandwidths configuration not found or format incorrect"
 
+    - name: Gather node fqdn for auto-generated hypervisor assertion
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - "machine"
+
     # Test hypervisor configurations with custom and auto-generated mappings
     - name: Verify resource_provider_hypervisors includes custom and auto-generated providers
       ansible.builtin.assert:
         that:
           - "'resource_provider_hypervisors=' in cms_options_output.stdout"
-          - "'br-ex:custom-compute-01' in cms_options_output.stdout"         # Custom hypervisor name
-          - "'rp_tunnelled:tunnel-host' in cms_options_output.stdout"        # Custom hypervisor name
-          - "'br-ext:edpm-0.localdomain' in cms_options_output.stdout"       # Auto-generated FQDN
-          - "'br-storage:edpm-0.localdomain' in cms_options_output.stdout"   # Auto-generated FQDN
+          - "'br-ex:custom-compute-01' in cms_options_output.stdout"
+          - "'rp_tunnelled:tunnel-host' in cms_options_output.stdout"
+          - "('br-ext:' ~ ansible_facts.fqdn) in cms_options_output.stdout"
+          - "('br-storage:' ~ ansible_facts.fqdn) in cms_options_output.stdout"
         fail_msg: "resource_provider_hypervisors configuration not found or incorrect - should include custom and auto-generated hypervisor mappings"
 
     # Test inventory defaults configuration

--- a/roles/edpm_ovn/tasks/run.yml
+++ b/roles/edpm_ovn/tasks/run.yml
@@ -45,5 +45,3 @@
     edpm_service_name: "{{ edpm_ovn_service_name }}"
     edpm_container_standalone_quadlet_defs:
       ovn_controller: "{{ _edpm_ovn_role_path }}/templates/quadlet/ovn_controller.container.j2"
-    edpm_container_standalone_kolla_config_files:
-      ovn_controller: "{{ lookup('template', 'kolla_config/kolla_ovn_controller.yaml.j2') | from_yaml }}"

--- a/roles/edpm_ovn/templates/kolla_config/kolla_ovn_controller.yaml.j2
+++ b/roles/edpm_ovn/templates/kolla_config/kolla_ovn_controller.yaml.j2
@@ -1,1 +1,0 @@
-command: "/usr/bin/ovn-controller --pidfile unix:/run/openvswitch/db.sock {% if edpm_ovn_tls_enabled | bool %} -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt {% endif %}"

--- a/roles/edpm_ovn/templates/quadlet/ovn_controller.container.j2
+++ b/roles/edpm_ovn/templates/quadlet/ovn_controller.container.j2
@@ -29,7 +29,7 @@ PodmanArgs=--privileged --log-driver=journald
 {% if edpm_ovn_cpu_set | default(false) -%}
 PodmanArgs=--cpuset-cpus={{ edpm_ovn_cpu_set }}
 {% endif -%}
-Environment=KOLLA_CONFIG_STRATEGY=COPY_ALWAYS
+Exec=/usr/bin/ovn-controller --pidfile unix:/run/openvswitch/db.sock{{ ' -p /etc/pki/tls/private/ovndb.key -c /etc/pki/tls/certs/ovndb.crt -C /etc/pki/tls/certs/ovndbca.crt' if edpm_ovn_tls_enabled | bool else '' }}
 {% for vol in edpm_ovn_controller_volumes -%}
 Volume={{ vol }}
 {% endfor -%}


### PR DESCRIPTION
Run ovn-controller directly via the Quadlet Exec= key instead of relying on the kolla_start entrypoint. 

jira: [OSPRH-34415](https://redhat.atlassian.net/browse/OSPRH-34415)