### PR TITLE
Add RHEL restriction for kernel pinning feature

### DIFF
--- a/roles/edpm_accel_drivers/molecule/kernel_pin/converge.yml
+++ b/roles/edpm_accel_drivers/molecule/kernel_pin/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge - Test kernel pinning on supported OS
   hosts: all
   pre_tasks:
     - name: Read kernel version saved by prepare
@@ -17,3 +17,35 @@
           kernel_pin:
             enabled: true
             version: "{{ test_kernel_version }}"
+
+- name: Converge - Test RHEL restriction
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Override distribution fact to simulate RHEL
+      ansible.builtin.set_fact:
+        ansible_facts:
+          distribution: "RedHat"
+
+    - name: Attempt kernel pinning on RHEL (should fail)
+      block:
+        - name: Run edpm_accel_drivers with kernel_pin enabled
+          ansible.builtin.include_role:
+            name: edpm_accel_drivers
+          vars:
+            edpm_accel_drivers:
+              kernel_pin:
+                enabled: true
+                version: "5.14.0-570.26.1.el9_6"
+
+        - name: Fail if kernel pinning was allowed on RHEL
+          ansible.builtin.fail:
+            msg: "Kernel pinning should have failed on RHEL systems but did not!"
+
+      rescue:
+        - name: Verify failure message contains expected text
+          ansible.builtin.assert:
+            that:
+              - "'Kernel pinning is not supported on RHEL production systems' in ansible_failed_result.msg"
+            fail_msg: "Expected failure message not found. Got: {{ ansible_failed_result.msg }}"
+            success_msg: "Kernel pinning correctly blocked on RHEL systems"

--- a/roles/edpm_accel_drivers/tasks/kernel_pin.yml
+++ b/roles/edpm_accel_drivers/tasks/kernel_pin.yml
@@ -1,4 +1,14 @@
 ---
+- name: Assert kernel pinning is not used on RHEL systems
+  ansible.builtin.assert:
+    that:
+      - not (ansible_facts['distribution'] | lower == 'redhat')
+    fail_msg: >-
+      Kernel pinning is not supported on RHEL production systems.
+      Pinning kernels prevents security updates and CVE fixes during RHOSO upgrades.
+      This feature is only for CI/development environments (CentOS/Fedora).
+    success_msg: "Kernel pinning is UNSUPPORTED on production systems and may result in missed security updates."
+
 - name: Validate kernel version format
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
## Summary

This follow-up PR adds production safety guards to prevent kernel pinning on RHEL systems, addressing lifecycle and support concerns raised by @bogdando in #1204.

## Changes

- **kernel_pin.yml**: Add assertion at start to fail on RHEL systems
- **kernel_pin/converge.yml**: Add second test play to verify RHEL restriction works
- Align with existing DKMS restrictions pattern in dkms_restrictions.yml

## Rationale

Kernel pinning on RHEL production systems creates support risks:
- Blocks security updates and CVE fixes during RHOSO upgrades
- Makes kernel "out of tree" and unsupported  
- Can result in customers claiming missed CVE patches

This feature is intended **only for CI/development** (CentOS/Fedora) where kernel version must match specific NVIDIA GRID driver versions.

## Testing

The molecule test `kernel_pin` now includes two test plays:
1. **Successful path**: Tests kernel pinning on supported OS (CentOS/Fedora)
2. **RHEL restriction**: Simulates RHEL and verifies kernel pinning is blocked with proper error message

## Addresses

Follow-up to: #1204
