### PR TITLE
Fix virtproxyd config readability on RHEL 10 only

### DIFF
--- a/roles/edpm_libvirt/molecule/default/verify.yml
+++ b/roles/edpm_libvirt/molecule/default/verify.yml
@@ -168,6 +168,38 @@
         that:
           - "'migration@openstack: userPassword' in saslusers.stdout_lines"
 
+    - name: Gather distribution fact
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - "distribution"
+    - name: Expected owner for confined virtproxyd configs
+      ansible.builtin.set_fact:
+        edpm_libvirt_confined_conf_owner: "{{ 'root' if ansible_facts['distribution_major_version'] is version('10', '>=') else 'libvirt' }}"
+    - name: Stat templated libvirt config files
+      become: true
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+      register: libvirt_conf_stat
+      loop:
+        - {"path": "/etc/libvirt/virtproxyd.conf", "owner": "{{ edpm_libvirt_confined_conf_owner }}"}
+        - {"path": "/etc/libvirt/virtnodedevd.conf", "owner": "{{ edpm_libvirt_confined_conf_owner }}"}
+        - {"path": "/etc/libvirt/virtsecretd.conf", "owner": "{{ edpm_libvirt_confined_conf_owner }}"}
+        - {"path": "/etc/sasl2/libvirt.conf", "owner": "{{ edpm_libvirt_confined_conf_owner }}"}
+        - {"path": "/etc/libvirt/virtlogd.conf", "owner": "libvirt"}
+        - {"path": "/etc/libvirt/virtqemud.conf", "owner": "libvirt"}
+        - {"path": "/etc/libvirt/qemu.conf", "owner": "libvirt"}
+        - {"path": "/etc/libvirt/auth.conf", "owner": "libvirt"}
+    - name: Assert libvirt config ownership
+      ansible.builtin.assert:
+        that:
+          - item.stat.pw_name == item.item.owner
+        fail_msg: "{{ item.item.path }} is {{ item.stat.pw_name }}, expected {{ item.item.owner }}"
+      loop: "{{ libvirt_conf_stat.results }}"
+      loop_control:
+        label: "{{ item.item.path }}"
+
     - name: Load /etc/libvirt/virtproxyd.conf
       become: true
       ansible.builtin.slurp:

--- a/roles/edpm_libvirt/tasks/confined_config_owner.yml
+++ b/roles/edpm_libvirt/tasks/confined_config_owner.yml
@@ -1,0 +1,29 @@
+---
+# RHEL 10 virtproxyd_t/virtnodedevd_t/virtsecretd_t are not allowed
+# dac_override, so a root daemon cannot read 0640 files owned by libvirt.
+# virtsecretd.conf is policy-backed (no live A/B). virtlogd_t has
+# dac_override and stays libvirt. RHEL 9 is unchanged.
+- name: Gather distribution fact
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - "!min"
+      - "distribution"
+
+- name: Allow confined libvirt daemons to read their configs on RHEL 10
+  tags:
+    - configure
+    - libvirt
+  become: true
+  when: ansible_facts['distribution_major_version'] is version('10', '>=')
+  ansible.builtin.file:
+    path: "{{ item }}"
+    owner: root
+    group: root
+  loop:
+    - /etc/libvirt/virtproxyd.conf
+    - /etc/libvirt/virtnodedevd.conf
+    - /etc/libvirt/virtsecretd.conf
+    - /etc/sasl2/libvirt.conf
+  notify:
+    - Restart libvirt

--- a/roles/edpm_libvirt/tasks/main.yml
+++ b/roles/edpm_libvirt/tasks/main.yml
@@ -26,6 +26,9 @@
 - name: Configure libvirt
   ansible.builtin.include_tasks: configure.yml
 
+- name: Allow confined virtproxyd to read its configs on RHEL 10
+  ansible.builtin.include_tasks: confined_config_owner.yml
+
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
 


### PR DESCRIPTION
RHEL 10 [`virtproxyd_t`](https://github.com/fedora-selinux/selinux-policy/blob/rawhide/policy/modules/contrib/virt.te) cannot read a `0640` libvirt-owned config (`dac_override` AVC). The daemon never starts, so TCP 16514 is closed and Nova live block migration fails with connection refused. SASL TLS also fails if [`/etc/sasl2/libvirt.conf`](https://github.com/openstack-k8s-operators/edpm-ansible/blob/main/roles/edpm_libvirt/templates/sasl_libvirt.conf) stays libvirt-owned.

The template task in [`configure.yml`](https://github.com/openstack-k8s-operators/edpm-ansible/blob/main/roles/edpm_libvirt/tasks/configure.yml) is unchanged. After templating, and only when `distribution_major_version >= 10`, [`confined_config_owner.yml`](https://github.com/openstack-k8s-operators/edpm-ansible/blob/fix-libvirt-conf-root-ownership/roles/edpm_libvirt/tasks/confined_config_owner.yml) chowns `root:root` on:

- [`/etc/libvirt/virtproxyd.conf`](https://github.com/openstack-k8s-operators/edpm-ansible/blob/main/roles/edpm_libvirt/templates/virtproxyd.conf)
- [`/etc/libvirt/virtnodedevd.conf`](https://github.com/openstack-k8s-operators/edpm-ansible/blob/main/roles/edpm_libvirt/templates/virtnodedevd.conf)
- [`/etc/libvirt/virtsecretd.conf`](https://github.com/openstack-k8s-operators/edpm-ansible/blob/main/roles/edpm_libvirt/templates/virtsecretd.conf)
- [`/etc/sasl2/libvirt.conf`](https://github.com/openstack-k8s-operators/edpm-ansible/blob/main/roles/edpm_libvirt/templates/sasl_libvirt.conf)

`virtsecretd.conf` is **policy-backed, not live A/B**. fedora [`virt.te`](https://github.com/fedora-selinux/selinux-policy/blob/rawhide/policy/modules/contrib/virt.te) grants no `dac_override` to `virtsecretd_t` (same DAC shape as virtproxyd/nodedevd). There was no leftover-env restart test for virtsecretd; the computes were reimaged. `virtlogd.conf` stays `libvirt` (`virtlogd_t` has `dac_override`). The existing [`Restart libvirt`](https://github.com/openstack-k8s-operators/edpm-ansible/blob/main/roles/edpm_libvirt/handlers/main.yml) handler already includes `virtsecretd`.

Jira: [OSPNW-1740](https://redhat.atlassian.net/browse/OSPNW-1740) (epic [ANVIL-31](https://redhat.atlassian.net/browse/ANVIL-31)).

The original failure was [`uni01alpha-rhel10-rhoso19.0`](https://gitlab.cee.redhat.com/ci-framework/ci-framework-testproject/-/merge_requests/2601) ([build `278830c4`](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/logs/278/components-integration/278830c4dbba4ed7a23712c6748967ad/), [buildset](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/buildset/cb2887adb3aa4167a3eaa6bb47a73a56)). On that leftover env, a **manual chown** equivalent of the virtproxyd/nodedevd/sasl split (not this playbook in Zuul) was checked: Enforcing A/B, `virsh qemu+tls`, and a cirros live block-migration succeeded.

## Test plan
- [x] Manual chown equivalent on live RHEL 10 computes (Enforcing): virtproxyd/nodedevd fail with `libvirt:libvirt`, start with `root:root`
- [x] Manual: `/etc/sasl2/libvirt.conf` as `libvirt` → virsh TLS SASL fails; as `root` → `virsh -c qemu+tls://<peer>/system hostname` works
- [x] Manual: Nova live block-migration of cirros with that ownership split
- [x] [Molecule `edpm_libvirt`](https://gateway-cloud-softwarefactory.apps.ocp.cloud.ci.centos.org/logs/3bf/rdoproject.org/3bf1c26b405d43d299108555c1e3cb77/) on CS9: new task skipped, ownership stayed `libvirt` (pre-virtsecretd-loop SHA)
- [ ] This playbook run by `edpm_libvirt` on RHEL 10 (molecule / a real job)
- [ ] virtsecretd start under Enforcing with `640 libvirt:libvirt` vs `root:root` (policy-backed; no live A/B)
