### PR TITLE
[OSPRH-33254] Require mTLS for prom exporter

### DIFF
--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -124,6 +124,8 @@ edpm_telemetry_node_exporter_tls_volumes:
 # Podman exporter volumes
 edpm_telemetry_podman_exporter_common_volumes:
   - /run/podman/podman.sock:/run/podman/podman.sock:rw,z
+edpm_telemetry_podman_exporter_tls_cacert_volumes:
+  - "{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z"
 edpm_telemetry_podman_exporter_tls_volumes:
   - "{{ edpm_telemetry_config_dest }}/podman_exporter.yaml:/etc/podman_exporter/podman_exporter.yaml:z"
   - "{{ edpm_telemetry_certs }}:/etc/podman_exporter/tls:z"

--- a/roles/edpm_telemetry/files/podman_exporter.yaml
+++ b/roles/edpm_telemetry/files/podman_exporter.yaml
@@ -1,3 +1,5 @@
 tls_server_config:
     cert_file: /etc/podman_exporter/tls/tls.crt
     key_file: /etc/podman_exporter/tls/tls.key
+    client_ca_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+    client_auth_type: RequireAndVerifyClientCert

--- a/roles/edpm_telemetry/meta/argument_specs.yml
+++ b/roles/edpm_telemetry/meta/argument_specs.yml
@@ -164,6 +164,10 @@ argument_specs:
         default:
           - /run/podman/podman.sock:/run/podman/podman.sock:rw,z
         description: "List of always-present volume mounts for podman_exporter"
+      edpm_telemetry_podman_exporter_tls_cacert_volumes:
+        type: list
+        required: false
+        description: "List of CA bundle volume mounts for podman_exporter, added when CA bundle exists"
       edpm_telemetry_podman_exporter_tls_volumes:
         type: list
         required: false

--- a/roles/edpm_telemetry/molecule/default/prepare.yml
+++ b/roles/edpm_telemetry/molecule/default/prepare.yml
@@ -130,6 +130,12 @@
         state: directory
         mode: "0775"
 
+    - name: Create cacerts directory
+      ansible.builtin.file:
+        path: "{{ edpm_telemetry_cacerts }}"
+        state: directory
+        mode: "0775"
+
     - name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
       community.crypto.openssl_privatekey:
         path: "{{ edpm_telemetry_certs }}/tls.key"
@@ -143,5 +149,14 @@
         privatekey_path: "{{ edpm_telemetry_certs }}/tls.key"
         provider: selfsigned
         mode: "0600"
+        owner: root
+        group: root
+
+    - name: Copy self-signed certificate as CA bundle
+      ansible.builtin.copy:
+        src: "{{ edpm_telemetry_certs }}/tls.crt"
+        dest: "{{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem"
+        remote_src: true
+        mode: "0644"
         owner: root
         group: root

--- a/roles/edpm_telemetry/molecule/default/verify.yml
+++ b/roles/edpm_telemetry/molecule/default/verify.yml
@@ -90,16 +90,11 @@
           - "'Volume=/etc/pki/ca-trust/source/anchors:/etc/pki/ca-trust/source/anchors:ro' in _container_content"
           - "'Volume=/dev/log:/dev/log' in _container_content"
           - "'Volume={{ edpm_telemetry_certs }}:/etc/ceilometer/tls:z' in _container_content"
+          - "'Volume={{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z' in _container_content"
           - "'Volume=/var/lib/openstack/healthchecks/ceilometer_agent_compute:/openstack:ro,z' in _container_content"
         fail_msg: "Missing volume in ceilometer .container file"
       vars:
         _container_content: "{{ _ceilometer_container.content | b64decode }}"
-
-    - name: Verify CA bundle volume is absent when CA bundle does not exist
-      ansible.builtin.assert:
-        that:
-          - "'tls-ca-bundle.pem' not in _ceilometer_container.content | b64decode"
-        fail_msg: "CA bundle volume should not be present when CA bundle file does not exist"
 
     - name: Read rendered node_exporter .container file
       become: true
@@ -131,6 +126,7 @@
           - "'Volume=/run/podman/podman.sock:/run/podman/podman.sock:rw,z' in _container_content"
           - "'Volume={{ edpm_telemetry_config_dest }}/podman_exporter.yaml:/etc/podman_exporter/podman_exporter.yaml:z' in _container_content"
           - "'Volume={{ edpm_telemetry_certs }}:/etc/podman_exporter/tls:z' in _container_content"
+          - "'Volume={{ edpm_telemetry_cacerts }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z' in _container_content"
           - "'Volume=/var/lib/openstack/healthchecks/podman_exporter:/openstack:ro,z' in _container_content"
         fail_msg: "Missing volume in podman_exporter .container file"
       vars:

--- a/roles/edpm_telemetry/tasks/exporter.yml
+++ b/roles/edpm_telemetry/tasks/exporter.yml
@@ -15,6 +15,19 @@
     ca_bundle_exists: "{{ ca_bundle_stat_res.stat.exists }}"
     tls_cert_exists: "{{ tls_crt_stat.stat.exists and tls_key_stat.stat.exists }}"
 
+# NOTE(jwysogla): This shouldn't fail, we should always have the CA certs
+# available when we have the server TLS certs. But check it just in case of
+# some unexpected failure and fail early rather than the containers failing
+# to start later.
+- name: Fail when TLS certs exist without CA bundle
+  ansible.builtin.fail:
+    msg: >-
+      TLS certificates were found but the CA bundle is missing.
+      mTLS requires the CA bundle to verify client certificates.
+  when:
+    - tls_cert_exists | bool
+    - not (ca_bundle_exists | bool)
+
 - name: Build quadlet defs dict for exporter
   ansible.builtin.set_fact:
     _exporter_quadlet_defs: "{{ {exporter: _edpm_telemetry_role_path ~ '/templates/quadlet/' ~ exporter ~ '.container.j2'} }}"

--- a/roles/edpm_telemetry/templates/quadlet/podman_exporter.container.j2
+++ b/roles/edpm_telemetry/templates/quadlet/podman_exporter.container.j2
@@ -6,6 +6,10 @@
 {%- set _podman_exporter_volumes = _podman_exporter_volumes +
         edpm_telemetry_podman_exporter_tls_volumes -%}
 {%- endif %}
+{%- if ca_bundle_exists | bool -%}
+{%- set _podman_exporter_volumes = _podman_exporter_volumes +
+        edpm_telemetry_podman_exporter_tls_cacert_volumes -%}
+{%- endif %}
 
 # DO NOT REMOVE - used by container_config_hash module
 # config_hash=


### PR DESCRIPTION
This configures prometheus-podman-exporter to require client certificates for scraping and to verify the certificates against the openstack CA.

Assisted-By: Claude-Code claude-opus-4-6