### PR TITLE
Use Prometheus web-config for network exporter TLS

### DIFF
--- a/roles/edpm_telemetry/defaults/main.yml
+++ b/roles/edpm_telemetry/defaults/main.yml
@@ -134,6 +134,7 @@ edpm_telemetry_network_exporter_common_volumes:
   - /proc:/host/proc:ro
 edpm_telemetry_network_exporter_tls_volumes:
   - "{{ edpm_telemetry_certs }}:/etc/openstack_network_exporter/tls:z"
+  - "{{ edpm_telemetry_config_dest }}/web_config.yaml:/etc/openstack_network_exporter/web_config.yaml:z"
 edpm_telemetry_network_exporter_ovs_volumes:
   - /var/run/openvswitch:/run/openvswitch:rw,z
   - /var/lib/openvswitch/ovn:/run/ovn:rw,z

--- a/roles/edpm_telemetry/tasks/configure.yml
+++ b/roles/edpm_telemetry/tasks/configure.yml
@@ -107,6 +107,7 @@
   loop:
     - {"src": "config/ceilometer-host-specific.conf.j2", "dest": "ceilometer-host-specific.conf"}
     - {"src": "config/openstack_network_exporter.yaml.j2", "dest": "openstack_network_exporter.yaml"}
+    - {"src": "config/web_config.yaml.j2", "dest": "web_config.yaml"}
   vars:
     ca_bundle_exists: "{{ ca_bundle_stat_res.stat.exists }}"
     tls_cert_exists: "{{ tls_crt_stat.stat.exists and tls_key_stat.stat.exists }}"

--- a/roles/edpm_telemetry/tasks/update.yml
+++ b/roles/edpm_telemetry/tasks/update.yml
@@ -101,9 +101,12 @@
 
     - name: Render openstack_network_exporter config
       ansible.builtin.template:
-        src: "config/openstack_network_exporter.yaml.j2"
-        dest: "{{ edpm_telemetry_config_dest }}/openstack_network_exporter.yaml"
+        src: "{{ item.src }}"
+        dest: "{{ edpm_telemetry_config_dest }}/{{ item.dest }}"
         mode: 0644
+      loop:
+        - {"src": "config/openstack_network_exporter.yaml.j2", "dest": "openstack_network_exporter.yaml"}
+        - {"src": "config/web_config.yaml.j2", "dest": "web_config.yaml"}
       vars:
         ca_bundle_exists: "{{ ca_bundle_stat_res.stat.exists }}"
         tls_cert_exists: "{{ tls_crt_stat.stat.exists and tls_key_stat.stat.exists }}"

--- a/roles/edpm_telemetry/tasks/update.yml
+++ b/roles/edpm_telemetry/tasks/update.yml
@@ -90,8 +90,11 @@
     - update
     - telemetry
 
+# TODO(jwysogla): This section could probably be refactored to reuse a lot
+#                 of the ansible already present for node-exporter and
+#                 prometheus-exporter, since the deployment and configs
+#                 are very similar now.
 - name: Install openstack_network_operator if not present
-  when: not openstack_network_exporter_config_yaml.stat.exists
   become: true
   block:
     - name: Determine if cacert file exists

--- a/roles/edpm_telemetry/templates/config/openstack_network_exporter.yaml.j2
+++ b/roles/edpm_telemetry/templates/config/openstack_network_exporter.yaml.j2
@@ -26,22 +26,14 @@ http-listen: ":9105"
 #
 #http-path: /metrics
 
-# The path to a TLS certificate to enable HTTPS support.
+# Path to a Prometheus exporter-toolkit web configuration file to enable HTTPS
+# support. The referenced file carries the TLS cert/key under tls_server_config.
 #
-# Env: OPENSTACK_NETWORK_EXPORTER_TLS_CERT
+# Env: OPENSTACK_NETWORK_EXPORTER_WEB_CONFIG
 # Default: ""
 #
 {% if tls_cert_exists|bool %}
-tls-cert: "/etc/openstack_network_exporter/tls/tls.crt"
-{% endif %}
-
-# The path to a TLS certificate secret key to enable HTTPS support.
-#
-# Env: OPENSTACK_NETWORK_EXPORTER_TLS_KEY
-# Default: ""
-#
-{% if tls_cert_exists|bool %}
-tls-key: "/etc/openstack_network_exporter/tls/tls.key"
+web-config: "/etc/openstack_network_exporter/web_config.yaml"
 {% endif %}
 
 # Space separated list of valid users and passwords. Leave empty to disable

--- a/roles/edpm_telemetry/templates/config/web_config.yaml.j2
+++ b/roles/edpm_telemetry/templates/config/web_config.yaml.j2
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Prometheus exporter-toolkit web configuration for openstack-network-exporter.
+# Referenced from openstack_network_exporter.yaml via the "web-config" key.
+{% if tls_cert_exists|bool %}
+tls_server_config:
+  cert_file: "/etc/openstack_network_exporter/tls/tls.crt"
+  key_file: "/etc/openstack_network_exporter/tls/tls.key"
+{% endif %}


### PR DESCRIPTION
The edpm openstack-network-exporter config used the fork-specific tls-cert/tls-key keys, but the deployed image is built from upstream openstack-network-exporter, which serves TLS via the Prometheus exporter-toolkit web-config file and ignores unknown keys. As a result the exporter served plain HTTP while scrapers expected HTTPS, so the metrics were never collected.

Emit `web-config: /etc/openstack_network_exporter/web_config.yaml`, render that file with tls_server_config pointing at the mounted tls.crt/tls.key, and mount it alongside the TLS certs.

Similar change was done in ovn-operator [1]

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/632

Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>