### PR TITLE
Derive sriov pf alias

### DIFF
--- a/plugins/filter/edpm_nmstate_nic_aliases.py
+++ b/plugins/filter/edpm_nmstate_nic_aliases.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Collection filter plugin (plugins/filter/) — same layout as upstream edpm-ansible:
+# https://github.com/openstack-k8s-operators/edpm-ansible/tree/main/plugins/filter
+
+"""Substitute NIC aliases only under nmstate keys that reference interface names."""
+
+
+def _normalize_key(key: str) -> str:
+    if not isinstance(key, str):
+        return ""
+    return key.lower().replace("_", "-")
+
+
+# Keys whose values (string or list of strings) may be Linux interface names or
+# EDPM aliases (nic1, ...) to be resolved. Derived from nmstate YAML usage
+# (interfaces, routes, route-rules, bonds, bridges, vlan/macvlan/vxlan, etc.);
+# see https://www.nmstate.io/devel/yaml_api.html — extend if new schema keys appear.
+_NIC_NAME_KEYS = frozenset(
+    {
+        # Interface identity & attachment
+        "name",
+        "device",
+        "interface",
+        "iface",
+        "interface-name",
+        "parent",
+        "controller",
+        "base-iface",
+        "copy-mac-from",
+        # Bond / bridge / OVS / team ports (also nested under bridge.port, bond.port, …)
+        "peer",
+        "patch",
+        "port",
+        "ports",
+        # Routes & rules (nmstate routes.config / route-rules.config)
+        "next-hop-interface",
+        "next-hop-iface",
+        "vrf-name",
+        "iif",
+    }
+)
+
+
+def _is_nic_name_key(key: str) -> bool:
+    return _normalize_key(key) in _NIC_NAME_KEYS
+
+
+def _subst_value(key: str, value, mapping: dict):
+    if not _is_nic_name_key(key):
+        if isinstance(value, dict):
+            return _walk_dict(value, mapping)
+        if isinstance(value, list):
+            return [_walk_any(item, mapping) for item in value]
+        return value
+    if isinstance(value, str):
+        return mapping.get(value, value)
+    if isinstance(value, list):
+        out = []
+        for item in value:
+            if isinstance(item, str):
+                out.append(mapping.get(item, item))
+            elif isinstance(item, dict):
+                out.append(_walk_dict(item, mapping))
+            elif isinstance(item, list):
+                out.append(_subst_value(key, item, mapping))
+            else:
+                out.append(item)
+        return out
+    if isinstance(value, dict):
+        return _walk_dict(value, mapping)
+    return value
+
+
+def _walk_any(node, mapping: dict):
+    if isinstance(node, dict):
+        return _walk_dict(node, mapping)
+    if isinstance(node, list):
+        return [_walk_any(item, mapping) for item in node]
+    return node
+
+
+def _walk_dict(node: dict, mapping: dict) -> dict:
+    out = {}
+    for k, v in node.items():
+        out[k] = _subst_value(k, v, mapping)
+    return out
+
+
+class FilterModule:
+    def filters(self):
+        return {"edpm_substitute_nic_aliases": self.edpm_substitute_nic_aliases}
+
+    def edpm_substitute_nic_aliases(self, data, mapping):
+        """Replace alias strings only under known nmstate interface-reference keys.
+
+        Keys are listed in _NIC_NAME_KEYS (nmstate YAML API); unknown keys are only
+        recursed, not string-substituted.
+
+        :param data: Parsed nmstate/network_state (dict or list), typically from_yaml.
+        :param mapping: dict mapping alias -> interface name (e.g. nic1 -> eth0).
+        :returns: New structure with substitutions applied; unchanged if mapping empty.
+        """
+        if not mapping:
+            return data
+        if isinstance(data, dict):
+            return _walk_dict(data, mapping)
+        if isinstance(data, list):
+            return [_walk_any(item, mapping) for item in data]
+        return data

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -51,7 +51,21 @@ edpm_network_config_manage_service: true
 # Note: This only applies when edpm_network_config_tool is 'os-net-config'
 edpm_network_config_nmstate: true
 edpm_network_config_purge_provider: ""
+# NIC mapping for BOTH the nmstate and os-net-config paths (not gated by edpm_network_config_tool):
+# merged in nic_mapping.yml and passed to the edpm_os_net_config_mappings module.
+# Legacy role variable: edpm_network_config_os_net_config_mappings. Additional/overriding mapping:
+# edpm_network_config_mappings (wins on duplicate keys, recursive merge).
+# If left empty / no host match: os-net-config falls back to its own built-in default nic1/nic2/...
+# numbering; the nmstate path has no such fallback, so use real interface names in
+# edpm_network_config_template unless a mapping is provided. See meta/argument_specs.yml for details.
 edpm_network_config_os_net_config_mappings: {}
+edpm_network_config_mappings: {}
+
+# edpm_network_config_mapping_file is not a user variable: nmstate_tool.yml and
+# os_net_config_tool.yml set it before nic_mapping.yml runs.
+# Maintainer note: ansible-playbook extra vars (-e) have higher precedence than set_fact and can
+# still override this name; that is unsupported and may break mapping paths. There is no role-level
+# way to forbid extra vars; avoid documenting this key for operators.
 edpm_network_config_safe_defaults: false
 edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"

--- a/roles/edpm_network_config/defaults/main.yml
+++ b/roles/edpm_network_config/defaults/main.yml
@@ -28,8 +28,13 @@
 edpm_network_config_tool: os-net-config
 
 # Packages needed by nmstate (via system-role)
+
+# Packages needed by nmstate (via system-role). python3-pyyaml is required on the
+# node for roles/edpm_network_config/files/edpm_derived_nic_mapping.py (YAML load/save).
+# EDPM targets RHEL-family OS only; no alternate package names for other distros.
 edpm_network_config_systemrole_nmstate_dependencies:
   - NetworkManager-ovs
+  - python3-pyyaml
 
 # seconds between retries for download tasks
 edpm_network_config_download_delay: "{{ edpm_download_delay | default(60) }}"
@@ -66,6 +71,8 @@ edpm_network_config_mappings: {}
 # Maintainer note: ansible-playbook extra vars (-e) have higher precedence than set_fact and can
 # still override this name; that is unsupported and may break mapping paths. There is no role-level
 # way to forbid extra vars; avoid documenting this key for operators.
+# Resolved NIC mapping (mapped_nics); written by files/edpm_derived_nic_mapping.py on nmstate path.
+edpm_network_config_derived_nic_mapping_file: /var/lib/edpm-config/derived_nic_mapping.yaml
 edpm_network_config_safe_defaults: false
 edpm_network_config_template: ""
 edpm_bond_interface_ovs_options: "bond_mode=active-backup"

--- a/roles/edpm_network_config/files/edpm_derived_nic_mapping.py
+++ b/roles/edpm_network_config/files/edpm_derived_nic_mapping.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# Copyright 2026 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0
+#
+# EDPM-only NIC alias -> Linux interface name resolution. No dependency on
+# os-net-config: mapping logic lives entirely in this module.
+#
+# Reads and writes /var/lib/edpm-config/derived_nic_mapping.yaml by default
+# (same as role var edpm_network_config_derived_nic_mapping_file; override with -f).
+# YAML shape:
+#   interface_mapping:
+#     nic1: <MAC or interface name>
+#     nic2: ...
+#
+# After a run, values are resolved to Linux interface names; unmapped active
+# interfaces get nic1, nic2, ... per embedded-first then natural sort ordering.
+# Kernel dummy interfaces (dummy0, …) are included for Molecule/lab; they have no
+# PCI device/ in sysfs — see _is_available_nic.
+
+import argparse
+import glob
+import logging
+import os
+import re
+import sys
+from typing import Dict, List, Optional
+
+LOG = logging.getLogger(__name__)
+
+DEFAULT_PATH = "/var/lib/edpm-config/derived_nic_mapping.yaml"
+SYS_CLASS_NET = "/sys/class/net"
+
+
+def _natural_sort_key(s):
+    nsre = re.compile(r"([0-9]+)")
+    return [int(text) if text.isdigit() else text for text in re.split(nsre, s)]
+
+
+def _normalize_mac(s: str) -> Optional[str]:
+    """Canonical aa:bb:cc:dd:ee:ff (lowercase) or None if not 12 hex digits."""
+    if not s:
+        return None
+    hex_only = re.sub(r"[^0-9A-Fa-f]", "", s.strip())
+    if len(hex_only) != 12:
+        return None
+    return ":".join(hex_only[i : i + 2].lower() for i in range(0, 12, 2))
+
+
+def _is_embedded_nic(nic: str) -> bool:
+    return nic.startswith(("em", "eno", "eth"))
+
+
+def _is_kernel_dummy(interface_name: str) -> bool:
+    """True for Linux dummy devices (ip link add … type dummy), e.g. dummy0."""
+    return bool(interface_name) and interface_name.startswith("dummy")
+
+
+def _has_link_layer_address(interface_name: str) -> bool:
+    """True if sysfs reports a non-empty address (MAC) for the interface."""
+    addr_path = os.path.join(SYS_CLASS_NET, interface_name, "address")
+    try:
+        with open(addr_path, encoding="utf-8") as f:
+            return bool(f.read().rstrip())
+    except OSError:
+        return False
+
+
+def _read_mac(ifname: str) -> Optional[str]:
+    """MAC for bonding slave (perm_hwaddr) or interface address file."""
+    bond_path = os.path.join(SYS_CLASS_NET, ifname, "bonding_slave", "perm_hwaddr")
+    try:
+        with open(bond_path, encoding="utf-8") as f:
+            return f.read().rstrip()
+    except OSError:
+        pass
+    addr_path = os.path.join(SYS_CLASS_NET, ifname, "address")
+    try:
+        with open(addr_path, encoding="utf-8") as f:
+            return f.read().rstrip()
+    except OSError:
+        return None
+
+
+def _is_real_nic(interface_name: str) -> bool:
+    if interface_name == "lo":
+        return True
+    device_dir = os.path.join(SYS_CLASS_NET, interface_name, "device")
+    if not os.path.isdir(device_dir):
+        return False
+    addr_path = os.path.join(SYS_CLASS_NET, interface_name, "address")
+    try:
+        with open(addr_path, encoding="utf-8") as f:
+            addr = f.read().rstrip()
+    except OSError:
+        return False
+    return bool(addr)
+
+
+def _is_vf_by_name(interface_name: str) -> bool:
+    physfn = os.path.join(SYS_CLASS_NET, interface_name, "physfn")
+    return os.path.isdir(physfn)
+
+
+def _is_available_nic(interface_name: str, check_active: bool) -> bool:
+    if interface_name == "lo":
+        return False
+    # Dummies have no PCI device/ in sysfs; still mappable by MAC/name (Molecule, etc.)
+    if _is_kernel_dummy(interface_name):
+        if not _has_link_layer_address(interface_name):
+            return False
+    elif not _is_real_nic(interface_name):
+        return False
+    if check_active:
+        try:
+            with open(
+                os.path.join(SYS_CLASS_NET, interface_name, "operstate"),
+                encoding="utf-8",
+            ) as f:
+                operstate = f.read().rstrip().lower()
+        except OSError:
+            return False
+        if operstate != "up":
+            return False
+    if _is_vf_by_name(interface_name):
+        return False
+    return True
+
+
+def _ordered_nics(check_active: bool) -> List[str]:
+    embedded_nics: List[str] = []
+    nics: List[str] = []
+    for name in glob.iglob(SYS_CLASS_NET + "/*"):
+        nic = name[len(SYS_CLASS_NET) + 1 :]
+        if _is_available_nic(nic, check_active):
+            if _is_embedded_nic(nic):
+                embedded_nics.append(nic)
+            else:
+                nics.append(nic)
+    active_nics = sorted(embedded_nics, key=_natural_sort_key) + sorted(
+        nics, key=_natural_sort_key
+    )
+    return active_nics
+
+
+def derive_nic_mapping(nic_mapping: Optional[dict]) -> Dict[str, str]:
+    """Resolve user interface_mapping to Linux names; assign nicN for leftovers."""
+    mapping = dict(nic_mapping or {})
+    mapped: Dict[str, str] = {}
+
+    if mapping:
+        available_nics = _ordered_nics(check_active=False)
+        for nic_alias, nic_mapped in mapping.items():
+            nm = nic_mapped
+            nm_mac = _normalize_mac(str(nm))
+            if nm_mac:
+                found = False
+                for nic in available_nics:
+                    mac = _read_mac(nic)
+                    mac_norm = _normalize_mac(mac) if mac else None
+                    if mac_norm and nm_mac == mac_norm:
+                        nm = nic
+                        found = True
+                        break
+                if not found:
+                    LOG.error(
+                        "mac %s not found in available nics %s",
+                        nic_mapped,
+                        ", ".join(available_nics),
+                    )
+                    continue
+            elif nm not in available_nics:
+                LOG.error(
+                    "nic %s not found in available nics %s",
+                    nic_mapped,
+                    ", ".join(available_nics),
+                )
+                continue
+
+            if nm in mapped.values():
+                raise ValueError(
+                    "interface %s already mapped, check mapping file for duplicates"
+                    % nm
+                )
+            if _is_available_nic(nic_alias, check_active=True):
+                raise ValueError(
+                    "cannot map %s to alias %s, alias overlaps with active NIC."
+                    % (nm, nic_alias)
+                )
+            if _is_real_nic(nic_alias) or _is_kernel_dummy(nic_alias):
+                LOG.warning(
+                    "Mapped nic %s overlaps with name of inactive NIC.", nic_alias
+                )
+
+            mapped[nic_alias] = nm
+            LOG.info("%s => %s", nic_alias, nm)
+
+    active_nics = _ordered_nics(check_active=True)
+    for nic_mapped in set(active_nics).difference(set(mapped.values())):
+        nic_alias = "nic%i" % (active_nics.index(nic_mapped) + 1)
+        if nic_alias in mapped:
+            LOG.warning(
+                "no mapping for interface %s because %s is mapped to %s",
+                nic_mapped,
+                nic_alias,
+                mapped[nic_alias],
+            )
+        else:
+            mapped[nic_alias] = nic_mapped
+            LOG.info("%s => %s", nic_alias, nic_mapped)
+
+    if not mapped:
+        LOG.warning("No active nics found.")
+    return mapped
+
+
+def load_yaml(path: str) -> Dict[str, str]:
+    if not os.path.isfile(path):
+        return {}
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError(
+            "PyYAML is required: on RHEL-like hosts install package python3-pyyaml "
+            "(see edpm_network_config_systemrole_nmstate_dependencies)."
+        ) from exc
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not data:
+        return {}
+    if "interface_mapping" in data:
+        return dict(data["interface_mapping"])
+    if "mapped_nics" in data:
+        return dict(data["mapped_nics"])
+    return {}
+
+
+def save_yaml(path: str, mapped: Dict[str, str]) -> bool:
+    """Write derived mapping YAML. Returns True if the file was created or updated."""
+    import yaml
+
+    payload = {"interface_mapping": mapped}
+    if os.path.isfile(path):
+        try:
+            with open(path, encoding="utf-8") as f:
+                existing = yaml.safe_load(f) or {}
+            if existing.get("interface_mapping") == mapped:
+                return False
+        except OSError:
+            pass
+
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(payload, f, default_flow_style=False, allow_unicode=True)
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Derive NIC alias to interface name mapping for EDPM (standalone)."
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        default=DEFAULT_PATH,
+        help=f"Read/write derived mapping YAML (default: {DEFAULT_PATH})",
+    )
+    parser.add_argument(
+        "-n", "--dry-run", action="store_true", help="Do not write the output file."
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    nic_mapping = load_yaml(args.file)
+    result = derive_nic_mapping(nic_mapping)
+
+    LOG.debug("derived mapping: %r", result)
+    if not args.dry_run:
+        wrote = save_yaml(args.file, result)
+        if wrote:
+            LOG.info("Wrote %s", args.file)
+        else:
+            LOG.info("Derived mapping unchanged for %s", args.file)
+        # One line for Ansible changed_when (stdout; logging uses stderr).
+        print(
+            "edpm_derived_nic_mapping_changed=yes"
+            if wrote
+            else "edpm_derived_nic_mapping_changed=no"
+        )
+    else:
+        print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (RuntimeError, ValueError) as e:
+        LOG.error("%s", e)
+        sys.exit(1)

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -8,7 +8,10 @@ argument_specs:
         type: list
         default:
           - NetworkManager-ovs
-        description: Packages needed by nmstate (via system-role)
+          - python3-pyyaml
+        description: >
+          Packages needed by nmstate (via system-role) on RHEL-family hosts, including
+          python3-pyyaml for edpm_derived_nic_mapping.py on the managed host.
       edpm_network_config_download_delay:
         type: int
         default: 5

--- a/roles/edpm_network_config/meta/argument_specs.yml
+++ b/roles/edpm_network_config/meta/argument_specs.yml
@@ -55,7 +55,32 @@ argument_specs:
         default: true
       edpm_network_config_os_net_config_mappings:
         type: dict
-        description: "Per node and/or per node group configuration map. Used by the edpm_os_net_config_mappings module."
+        description: >
+          Legacy role variable: per-node / node-group NIC mapping. Applies to BOTH
+          edpm_network_config_tool values (nmstate and os-net-config) — it is not gated by that
+          variable and is merged with edpm_network_config_mappings in nic_mapping.yml (the latter
+          wins on duplicate keys). The merged dict is passed to the edpm_os_net_config_mappings
+          Ansible module as net_config_data_lookup, which resolves nic1/nic2/... to real interfaces
+          by MAC address or dmiString+id match and writes the result to
+          /etc/os-net-config/mapping.yaml (os-net-config path) or
+          /var/lib/edpm-config/template_nic_mapping.yaml (nmstate path).
+          If this and edpm_network_config_mappings are both left at their default ({}), or neither
+          matches this host, no mapping file is written. In that case the os-net-config path falls
+          back to os-net-config's own built-in default nic1/nic2/... numbering (embedded interfaces
+          such as em/eth/eno first, then other active NICs, both ordered alphanumerically); the
+          nmstate path has no equivalent built-in fallback, so nic aliases in
+          edpm_network_config_template are only resolved when a mapping is supplied here (or via
+          edpm_network_config_mappings) — otherwise use real interface names in the template.
+        default: {}
+      edpm_network_config_mappings:
+        type: dict
+        description: >
+          Optional additional or overriding NIC mapping for the nmstate and os-net-config paths
+          (merged in nic_mapping.yml). Merged with edpm_network_config_os_net_config_mappings; this
+          variable wins on duplicate keys. See edpm_network_config_os_net_config_mappings above for
+          how the merged mapping is used and what happens when no mapping is provided/matched.
+          Must be a YAML mapping (dict). Do not use a block literal (|) after the key — that
+          produces a string and role validation will fail.
         default: {}
       edpm_network_config_purge_provider:
         type: str

--- a/roles/edpm_network_config/tasks/nic_mapping.yml
+++ b/roles/edpm_network_config/tasks/nic_mapping.yml
@@ -1,0 +1,86 @@
+---
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# nmstate / os-net-config: build interface_mapping (nic1 -> MAC or interface name, etc.)
+# and write edpm_network_config_mapping_file (set by nmstate_tool.yml or os_net_config_tool.yml).
+# Not an inventory variable; -e edpm_network_config_mapping_file=... overrides set_fact (unsupported).
+# Input: merged edpm_network_config_os_net_config_mappings (legacy) + edpm_network_config_mappings.
+# The edpm_os_net_config_mappings name refers to the Ansible module (plugins/modules/), not a role variable.
+
+- name: Merge NIC mapping lookups (edpm_network_config_os_net_config_mappings + edpm_network_config_mappings)
+  ansible.builtin.set_fact:
+    edpm_network_config_merged_mappings: >-
+      {{
+        edpm_network_config_os_net_config_mappings | default({})
+        | combine(edpm_network_config_mappings | default({}), recursive=True)
+      }}
+
+- name: Create directory for EDPM NIC mapping file
+  ansible.builtin.file:
+    path: "{{ edpm_network_config_mapping_file | dirname }}"
+    state: directory
+    mode: "0755"
+
+# edpm_os_net_config_mappings is read-only (reads /sys/class/net/*/address and shells out to
+# dmidecode; never writes anything), so force it to run even under --check with check_mode: false.
+# The module declares supports_check_mode=False, which would otherwise make Ansible skip it in
+# check mode; skipping it would make edpm_os_net_config_mappings_result.mapping Undefined (not
+# None) whenever mapping data is configured, which would make the "Fail when NIC mappings were
+# provided but no host match" task below fail on every --check run regardless of whether the host
+# actually matches.
+- name: Create NIC mappings from lookup data
+  edpm_os_net_config_mappings:
+    net_config_data_lookup:
+      "{{ edpm_network_config_merged_mappings }}"
+  check_mode: false
+  register: edpm_os_net_config_mappings_result
+
+# Defensive: keep mapping in a variable that is always defined (a real mapping dict, or None for
+# "ran and found no host match"), so downstream "is none"/"is not none" checks and filters never
+# operate on an Undefined value.
+- name: Normalize NIC mapping result to a defined variable (None when no match)
+  ansible.builtin.set_fact:
+    edpm_os_net_config_mapping: "{{ edpm_os_net_config_mappings_result.mapping | default(None) }}"
+
+- name: Fail when NIC mappings were provided but no host match
+  ansible.builtin.fail:
+    msg: |
+      The edpm_os_net_config_mappings module did not match this host, so
+      {{ edpm_network_config_mapping_file }} was not written.
+      Set edpm_network_config_os_net_config_mappings and/or edpm_network_config_mappings so a MAC
+      matches an address under /sys/class/net/*/address (see plugins/modules/edpm_os_net_config_mappings.py),
+      or use dmiString + id. inventory_hostname for this run is {{ inventory_hostname }}.
+  when:
+    - edpm_network_config_merged_mappings | length > 0
+    - edpm_os_net_config_mapping is none
+
+- name: Write EDPM NIC mapping file
+  ansible.builtin.copy:
+    content: "{{ edpm_os_net_config_mapping | to_nice_yaml }}"
+    dest: "{{ edpm_network_config_mapping_file }}"
+    mode: "0644"
+  when: edpm_os_net_config_mapping is not none
+
+# Not gated on ansible_check_mode: the file/copy modules below already simulate correctly under
+# --check (no real write/delete happens), and since the discovery task above always runs for real
+# (check_mode: false), edpm_os_net_config_mapping reflects the true match state even in check mode.
+# edpm_network_config_mapping_file is the only mapping output this role manages, so this is the
+# only place it can go stale.
+- name: Remove stale NIC mapping file when nothing matched/configured this run
+  ansible.builtin.file:
+    path: "{{ edpm_network_config_mapping_file }}"
+    state: absent
+  when: edpm_os_net_config_mapping is none

--- a/roles/edpm_network_config/tasks/nmstate_tool.yml
+++ b/roles/edpm_network_config/tasks/nmstate_tool.yml
@@ -27,6 +27,73 @@
   ansible.builtin.set_fact:
     edpm_network_config_mapping_file: /var/lib/edpm-config/template_nic_mapping.yaml
 
+- name: Ensure /var/lib/edpm-config exists
+  become: true
+  ansible.builtin.file:
+    path: /var/lib/edpm-config
+    state: directory
+    mode: "0755"
+
+- name: Create EDPM NIC mapping file (nmstate path)
+  become: true
+  ansible.builtin.import_tasks: nic_mapping.yml
+
+# Check mode: derived NIC mapping is not produced here, and the derived-file slurp is skipped later for the same reason.
+- name: Copy user NIC mapping to derived input and run mapped_nics
+  become: true
+  when: not ansible_check_mode | bool
+
+  block:
+    - name: Stat user NIC mapping file
+      ansible.builtin.stat:
+        path: "{{ edpm_network_config_mapping_file }}"
+      register: edpm_user_nic_mapping_stat
+
+    - name: Copy user_nic_mapping.yaml to derived_nic_mapping.yaml
+      ansible.builtin.copy:
+        src: "{{ edpm_network_config_mapping_file }}"
+        dest: "{{ edpm_network_config_derived_nic_mapping_file }}"
+        remote_src: true
+        force: true
+        mode: "0644"
+      when: edpm_user_nic_mapping_stat.stat.exists | default(false)
+
+    - name: Remove stale derived NIC mapping when template mapping file is absent
+      ansible.builtin.file:
+        path: "{{ edpm_network_config_derived_nic_mapping_file }}"
+        state: absent
+      when: not (edpm_user_nic_mapping_stat.stat.exists | default(false))
+
+    - name: Check that Python3 can import yaml (requires python3-pyyaml on the node)
+      ansible.builtin.command:
+        argv:
+          - python3
+          - -c
+          - "import yaml"
+      register: edpm_derived_nic_mapping_pyyaml_check
+      changed_when: false
+      failed_when: false
+
+    - name: Fail when PyYAML is not available for derived NIC mapping
+      ansible.builtin.fail:
+        msg: >-
+          edpm_derived_nic_mapping.py needs PyYAML. Install the OS package that provides
+          it (on RHEL-like systems: python3-pyyaml), e.g. ensure
+          edpm_network_config_systemrole_nmstate_dependencies includes python3-pyyaml
+          and package installation ran (see role tasks/package_management.yml).
+      when: edpm_derived_nic_mapping_pyyaml_check.rc | int != 0
+
+    - name: Run derived NIC mapping (edpm_derived_nic_mapping.py)
+      ansible.builtin.command:
+        argv:
+          - python3
+          - "{{ role_path }}/files/edpm_derived_nic_mapping.py"
+          - "-f"
+          - "{{ edpm_network_config_derived_nic_mapping_file }}"
+      register: edpm_derived_nic_mapping_result
+      changed_when: >-
+        'edpm_derived_nic_mapping_changed=yes' in (edpm_derived_nic_mapping_result.stdout | default(''))
+
 - name: Check nmstate return code for conditional logic
   become: true
   block:
@@ -43,6 +110,11 @@
 
 - name: Configure network with network role from system roles [nmstate]
   become: true
+  # The conditions here are when we want to apply the NetworkConfig:
+  # - If edpm_network_config_update is True
+  # - Or the previous run of NetworkConfig failed
+  # - Or it has never run
+  # This matches the prior behavior of when a Heat SoftwareDeployment was used
   when:
     - (edpm_network_config_update) or
       (nmstate_returncode_stat.stat.exists and
@@ -52,23 +124,45 @@
     - name: Create EDPM NIC mapping file (nmstate path)
       ansible.builtin.import_tasks: nic_mapping.yml
 
-    - name: Render network_state variable
+    - name: Stat derived NIC mapping file for nmstate template substitution
+      ansible.builtin.stat:
+        path: "{{ edpm_network_config_derived_nic_mapping_file }}"
+      register: edpm_derived_nic_mapping_file_stat
+
+    - name: Read derived NIC mapping for nmstate template substitution
+      ansible.builtin.slurp:
+        path: "{{ edpm_network_config_derived_nic_mapping_file }}"
+      register: edpm_derived_nic_mapping_for_template
+      when:
+        - not ansible_check_mode | bool
+        - edpm_derived_nic_mapping_file_stat.stat.exists | default(false)
+
+    - name: Build interface_mapping dict from derived file
       ansible.builtin.set_fact:
-        network_state: "{{ edpm_network_config_template | from_yaml }}"
+        edpm_derived_interface_mapping: >-
+          {{
+            (edpm_derived_nic_mapping_for_template.content | b64decode | from_yaml | default({})).get('interface_mapping', {})
+            if edpm_derived_nic_mapping_for_template is defined
+            and edpm_derived_nic_mapping_for_template.content is defined
+            else {}
+          }}
+
+    - name: Render network_state variable (NIC aliases only under nmstate iface keys)
+      ansible.builtin.set_fact:
+        network_state: >-
+          {{
+            edpm_network_config_template
+            | from_yaml
+            | edpm_substitute_nic_aliases(edpm_derived_interface_mapping | default({}))
+          }}
 
     - name: Load system-roles.network tasks [nmstate]
       ansible.builtin.include_role:
         name: "{{ lookup('ansible.builtin.env', 'EDPM_SYSTEMROLES', default='fedora.linux_system_roles') + '.network' }}"
       register: nmstate_result
 
-    - name: Ensure /var/lib/edpm-config exists
-      ansible.builtin.file:
-        path: /var/lib/edpm-config
-        state: directory
-        mode: "0755"
-
     - name: Write rc of nmstate run
       ansible.builtin.copy:
-        content: "0"
+        content: "{{ '1' if (nmstate_result.failed | default(false)) else '0' }}"
         dest: /var/lib/edpm-config/nmstate.returncode
         mode: "0644"

--- a/roles/edpm_network_config/tasks/nmstate_tool.yml
+++ b/roles/edpm_network_config/tasks/nmstate_tool.yml
@@ -23,6 +23,10 @@
     # For nmstate, always enable NetworkManager DNS management
     edpm_bootstrap_network_resolvconf_update: true
 
+- name: Set NIC mapping file path for nmstate path (internal, not user-overridable)
+  ansible.builtin.set_fact:
+    edpm_network_config_mapping_file: /var/lib/edpm-config/template_nic_mapping.yaml
+
 - name: Check nmstate return code for conditional logic
   become: true
   block:
@@ -45,6 +49,9 @@
       ((nmstate_returncode_slurp.content | b64decode | int) != 0)) or
       (not nmstate_returncode_stat.stat.exists)
   block:
+    - name: Create EDPM NIC mapping file (nmstate path)
+      ansible.builtin.import_tasks: nic_mapping.yml
+
     - name: Render network_state variable
       ansible.builtin.set_fact:
         network_state: "{{ edpm_network_config_template | from_yaml }}"

--- a/roles/edpm_network_config/tasks/os_net_config_tool.yml
+++ b/roles/edpm_network_config/tasks/os_net_config_tool.yml
@@ -53,25 +53,11 @@
       ((os_net_config_returncode_slurp.content | b64decode | int) != 0)) or
       (not os_net_config_returncode_stat.stat.exists)
   block:
-    - name: Create /etc/os-net-config directory
-      ansible.builtin.file:
-        path: /etc/os-net-config
-        state: directory
-        mode: "0755"
-
-    - name: Create os-net-config mappings from lookup data
-      edpm_os_net_config_mappings:
-        net_config_data_lookup:
-          "{{ edpm_network_config_os_net_config_mappings }}"
-      when: not ansible_check_mode | bool
-      register: os_net_config_mappings_result
-
-    - name: Write os-net-config mappings file /etc/os-net-config/mapping.yaml
-      ansible.builtin.copy:
-        content: "{{ os_net_config_mappings_result.mapping | to_nice_yaml }}"
-        dest: /etc/os-net-config/mapping.yaml
-        mode: "0644"
-      when: os_net_config_mappings_result.changed | bool  # noqa: no-handler
+    - name: Create EDPM NIC mapping file (os-net-config path)
+      vars:
+        # Internal path for nic_mapping output; not exposed in role defaults.
+        edpm_network_config_mapping_file: /etc/os-net-config/mapping.yaml
+      ansible.builtin.import_tasks: nic_mapping.yml
 
     - name: Manage NetworkConfig with edpm_os_net_config module
       block:


### PR DESCRIPTION
edpm_substitute_nic_aliases only ever looked up a nmstate interface-name string verbatim in the alias mapping. nmstate's SR-IOV VF pseudo interface name, "sriov:<pf_name>:<vf_id>" (e.g. used as a bond port referring to a specific VF), never matched as a whole and was left unresolved, causing:
    
      NmstateValueError: Failed to find SR-IOV VF interface name for bond-sriov0
    
Recognize this syntax and substitute the alias inside the <pf_name> segment instead, falling back to the original name when the PF alias isn't in the mapping.