### PR TITLE
Report AEE run termination in pod logs for non-successful runs

### DIFF
--- a/openstack_ansibleee/edpm_run_and_summarize.sh
+++ b/openstack_ansibleee/edpm_run_and_summarize.sh
@@ -48,7 +48,7 @@ write_runner_summary() {
     fi
 
     if [ -f "${summary_helper}" ] && [ "${#runner_cmd[@]}" -gt 0 ] && [ -x "${runner_cmd[0]}" ]; then
-        "${runner_cmd[@]}" "${summary_helper}" >/dev/null 2>&1 || true
+        "${runner_cmd[@]}" "${summary_helper}" || true
     fi
 }
 

--- a/openstack_ansibleee/write_runner_summary.py
+++ b/openstack_ansibleee/write_runner_summary.py
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""Summarize ansible-runner artifacts for pod termination logs."""
+"""Summarize ansible-runner artifacts for the pod termination log and stdout."""
 
 from __future__ import annotations
 
@@ -35,9 +35,13 @@ def _latest_run_dir(artifacts_root: Path) -> Path | None:
     return max(candidates, key=lambda path: path.stat().st_mtime)
 
 
-def _load_json(path: Path) -> dict[str, Any]:
+def _load_json(path: Path) -> Any:
     with path.open(encoding="utf-8") as handle:
         return json.load(handle)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
 
 
 def _latest_stats_event(job_events_dir: Path) -> dict[str, Any]:
@@ -46,15 +50,55 @@ def _latest_stats_event(job_events_dir: Path) -> dict[str, Any]:
 
     for event_file in job_events_dir.glob("*.json"):
         try:
-            event_data = _load_json(event_file)
-            if event_data.get("event") != "playbook_on_stats":
-                continue
-
-            return event_data
-        except (json.JSONDecodeError, OSError, TypeError):
+            event = _load_json(event_file)
+        except (json.JSONDecodeError, OSError, TypeError, UnicodeDecodeError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("event") != "playbook_on_stats":
             continue
 
+        return event
+
     return {}
+
+
+def _load_status(run_dir: Path) -> dict[str, Any]:
+    """Read the run verdict from ansible-runner artifacts.
+
+    ansible-runner writes ``status`` (e.g. ``successful``, ``failed``,
+    ``timeout``) and ``rc`` as plain-text files.
+    """
+    try:
+        status = (run_dir / "status").read_text(encoding="utf-8").strip() or None
+    except (OSError, UnicodeDecodeError):
+        status = None
+
+    try:
+        rc = int((run_dir / "rc").read_text(encoding="utf-8").strip())
+    except (OSError, ValueError, UnicodeDecodeError):
+        rc = None
+
+    return {"status": status, "rc": rc}
+
+
+def _last_event(job_events_dir: Path) -> dict[str, Any]:
+    last: dict[str, Any] = {}
+    if not job_events_dir.exists():
+        return last
+    for event_file in job_events_dir.glob("*.json"):
+        try:
+            event = _load_json(event_file)
+        except (OSError, json.JSONDecodeError, TypeError, UnicodeDecodeError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        counter = event.get("counter", 0)
+        if isinstance(counter, bool) or not isinstance(counter, (int, float)):
+            continue
+        if counter >= last.get("counter", 0):
+            last = event
+    return last
 
 
 def _host_keys(stats_dict: Any) -> set[str]:
@@ -66,7 +110,7 @@ def _host_keys(stats_dict: Any) -> set[str]:
 
 def build_summary(run_dir: Path) -> dict[str, Any]:
     stats_event = _latest_stats_event(run_dir / "job_events")
-    event_data = stats_event.get("event_data", {})
+    event_data = _as_dict(stats_event.get("event_data"))
 
     total_hosts = _host_keys(event_data.get("processed"))
     failure_hosts = _host_keys(event_data.get("failures"))
@@ -113,6 +157,24 @@ def main() -> int:
 
     summary = build_summary(run_dir)
     _write_summary(summary, output_path)
+
+    status = _load_status(run_dir)
+    if status.get("status") == "successful":
+        return 0
+
+    event_data = _as_dict(_last_event(run_dir / "job_events").get("event_data"))
+    task = event_data.get("task")
+    rc = status.get("rc")
+    print(
+        "EDPM AEE SUMMARY: "
+        f"status={status.get('status') or '-'} "
+        f"rc={rc if rc is not None else '-'} "
+        f"total_hosts={summary['totalHosts']} "
+        f"failed_hosts={summary['failedHosts']} "
+        f"unreachable_hosts={summary['unreachableHosts']} "
+        f"last_task={task.get('name') if isinstance(task, dict) else '-'} "
+        f"last_host={event_data.get('host') or '-'}"
+    )
     return 0
 
 

--- a/tests/test_write_runner_summary.py
+++ b/tests/test_write_runner_summary.py
@@ -187,3 +187,135 @@ def test_main_returns_zero_when_no_artifacts_exist(tmp_path, monkeypatch):
 
     assert write_runner_summary.main() == 0
     assert not output_path.exists()
+
+
+def _create_malformed_run_dir(tmp_path):
+    run_dir = tmp_path / "artifacts" / "run-one"
+    events_dir = run_dir / "job_events"
+    events_dir.mkdir(parents=True)
+    (run_dir / "status").write_text("", encoding="utf-8")
+    (events_dir / "1-list.json").write_text(
+        json.dumps([1, 2]), encoding="utf-8"
+    )
+    (events_dir / "2-string-counter.json").write_text(
+        json.dumps({"counter": "high", "event": "task_start"}),
+        encoding="utf-8",
+    )
+    (events_dir / "3-bool-counter.json").write_text(
+        json.dumps({"counter": True, "event": "task_start"}),
+        encoding="utf-8",
+    )
+    (events_dir / "4-non-mapping-event-data.json").write_text(
+        json.dumps(
+            {"counter": 4, "event": "task_start", "event_data": "unexpected"}
+        ),
+        encoding="utf-8",
+    )
+    (events_dir / "5-binary.json").write_bytes(b"\xff\xfe\x00not-utf8")
+    return run_dir
+
+
+def test_main_prints_summary_with_malformed_artifacts(
+    tmp_path, monkeypatch, capsys
+):
+    _create_malformed_run_dir(tmp_path)
+    output_path = tmp_path / "termination.log"
+
+    monkeypatch.setenv("EDPM_AEE_ARTIFACTS_ROOT", str(tmp_path / "artifacts"))
+    monkeypatch.setenv("EDPM_AEE_TERMINATION_LOG", str(output_path))
+
+    assert write_runner_summary.main() == 0
+
+    captured = capsys.readouterr()
+    assert "EDPM AEE SUMMARY:" in captured.out
+    assert "status=-" in captured.out
+    assert "rc=-" in captured.out
+    assert "last_task=-" in captured.out
+    assert "last_host=-" in captured.out
+
+
+def test_main_stays_silent_on_successful_run(tmp_path, monkeypatch, capsys):
+    _create_run_dir(
+        tmp_path,
+        "run-one",
+        5,
+        {"host-a": 1},
+        {},
+        {},
+    )
+    run_dir = tmp_path / "artifacts" / "run-one"
+    (run_dir / "status").write_text("successful", encoding="utf-8")
+    (run_dir / "rc").write_text("0", encoding="utf-8")
+    output_path = tmp_path / "termination.log"
+
+    monkeypatch.setenv("EDPM_AEE_ARTIFACTS_ROOT", str(tmp_path / "artifacts"))
+    monkeypatch.setenv("EDPM_AEE_TERMINATION_LOG", str(output_path))
+
+    assert write_runner_summary.main() == 0
+
+    assert capsys.readouterr().out == ""
+    written_summary = json.loads(output_path.read_text(encoding="utf-8"))
+    assert written_summary["totalHosts"] == 1
+
+
+def test_main_prints_plain_text_status_and_rc(tmp_path, monkeypatch, capsys):
+    _create_run_dir(
+        tmp_path,
+        "run-one",
+        3,
+        {"host-a": 1, "host-b": 1},
+        {"host-b": 1},
+        {},
+    )
+    run_dir = tmp_path / "artifacts" / "run-one"
+    (run_dir / "status").write_text("failed", encoding="utf-8")
+    (run_dir / "rc").write_text("2", encoding="utf-8")
+    events_dir = run_dir / "job_events"
+    (events_dir / "4-task-start.json").write_text(
+        json.dumps(
+            {
+                "counter": 4,
+                "event": "task_start",
+                "event_data": {
+                    "task": {"name": "Install packages"},
+                    "host": "host-b",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "termination.log"
+
+    monkeypatch.setenv("EDPM_AEE_ARTIFACTS_ROOT", str(tmp_path / "artifacts"))
+    monkeypatch.setenv("EDPM_AEE_TERMINATION_LOG", str(output_path))
+
+    assert write_runner_summary.main() == 0
+
+    captured = capsys.readouterr()
+    assert "EDPM AEE SUMMARY:" in captured.out
+    assert "status=failed" in captured.out
+    assert "rc=2" in captured.out
+    assert "last_task=Install packages" in captured.out
+    assert "last_host=host-b" in captured.out
+
+
+def test_build_summary_handles_non_mapping_event_data(tmp_path):
+    run_dir = tmp_path / "artifacts" / "run-one"
+    events_dir = run_dir / "job_events"
+    events_dir.mkdir(parents=True)
+    (events_dir / "1-stats.json").write_text(
+        json.dumps(
+            {
+                "counter": 1,
+                "event": "playbook_on_stats",
+                "event_data": ["unexpected"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = write_runner_summary.build_summary(run_dir)
+
+    assert summary["totalHosts"] == 0
+    assert summary["failedHostList"] == []
+    assert summary["unreachableHostList"] == []


### PR DESCRIPTION
The termination log carries only host failure counts, not the run verdict - on timeout it reads all zeros while status and rc=254 are only recoverable from pod exitCode plus runner internals. Print the AEE summary to pod stdout for non-successful runs; successful runs stay silent and the termination-log payload is unchanged.

Related jira: [OSPRH-35300](https://redhat.atlassian.net/browse/OSPRH-35300)